### PR TITLE
ref(electron): Update Electron integration code

### DIFF
--- a/scripts/Electron/symbols.js
+++ b/scripts/Electron/symbols.js
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
-const SentryCli = require('@sentry/cli');
-const download = require('electron-download');
+try {
+  const SentryCli = require('@sentry/cli');
+  const download = require('electron-download');
+} catch (e) {
+  console.error('ERROR: Missing required packages, please run:');
+  console.error('npm install --save-dev @sentry/cli electron-download');
+  process.exit(1);
+}
 
 const VERSION = /\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\b/i;
 const SYMBOL_CACHE_FOLDER = '.electron-symbols';


### PR DESCRIPTION
Updated integration code example due to https://github.com/getsentry/sentry-electron/pull/53:

- [x] Update code example with new syntax
- [x] Use public DSN instead of private one
- [x] Do not require `electron-download`
- [x] Update link to docs (moved to `/clients/electron`)

![screen shot 2018-04-09 at 09 17 22](https://user-images.githubusercontent.com/1433023/38484434-e24fc89a-3bd6-11e8-8927-9b8dcf23895e.png)
