### PR TITLE
fix: support for React-Native >0.46

### DIFF
--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -369,7 +369,7 @@ export class ReactNative extends MobileProject {
             (match: any, m1: string) => {
               const rv = m1.trim();
               if (rv === '') {
-                return '../node_modules/react-native/packager/react-native-xcode.sh';
+                return '../node_modules/react-native/scripts/react-native-xcode.sh';
               } else {
                 return rv;
               }


### PR DESCRIPTION
This update provides support for react native version >= 0.46.X.

Ref: https://github.com/facebook/react-native/issues/14935