### PR TITLE
Only strip Sentry framework from Xcode projects

### DIFF
--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -228,7 +228,7 @@ export class Cordova extends BaseIntegration {
         shellScript:
           '# SENTRY_FRAMEWORK_PATCH \\n' +
           'APP_PATH="${TARGET_BUILD_DIR}/${WRAPPER_NAME}"\\n' +
-          'find "$APP_PATH" -name \'*.framework\' -type d | while read -r FRAMEWORK\\n' +
+          'find "$APP_PATH" -name \'Sentry*.framework\' -type d | while read -r FRAMEWORK\\n' +
           'do\\n' +
           'FRAMEWORK_EXECUTABLE_NAME=$(defaults read "$FRAMEWORK/Info.plist" CFBundleExecutable)\\n' +
           'FRAMEWORK_EXECUTABLE_PATH="$FRAMEWORK/$FRAMEWORK_EXECUTABLE_NAME"\\n' +


### PR DESCRIPTION
Searching for `*.framework` causes the script to strip archs that don't exist in other frameworks. This patch ensures only Sentry frameworks are stripped.

<details>
 <summary>Example error from trying to strip other frameworks</summary>

```
Executable is /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/Protobuf.framework/Protobuf
Extracting arm64 from Protobuf
fatal error: lipo: input file (/Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/Protobuf.framework/Protobuf) must be a fat file when the -extract option is specified
Merging extracted architectures: arm64
fatal error: lipo: can't open input file: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/Protobuf.framework/Protobuf-arm64 (No such file or directory)
rm: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/Protobuf.framework/Protobuf-arm64: No such file or directory
Replacing original executable with thinned version
mv: rename /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/Protobuf.framework/Protobuf-merged to /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/Protobuf.framework/Protobuf: No such file or directory
Executable is /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKLoginKit.framework/FBSDKLoginKit
Extracting arm64 from FBSDKLoginKit
fatal error: lipo: input file (/Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKLoginKit.framework/FBSDKLoginKit) must be a fat file when the -extract option is specified
Merging extracted architectures: arm64
fatal error: lipo: can't open input file: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKLoginKit.framework/FBSDKLoginKit-arm64 (No such file or directory)
rm: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKLoginKit.framework/FBSDKLoginKit-arm64: No such file or directory
Replacing original executable with thinned version
mv: rename /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKLoginKit.framework/FBSDKLoginKit-merged to /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKLoginKit.framework/FBSDKLoginKit: No such file or directory
Executable is /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKShareKit.framework/FBSDKShareKit
Extracting arm64 from FBSDKShareKit
fatal error: lipo: input file (/Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKShareKit.framework/FBSDKShareKit) must be a fat file when the -extract option is specified
Merging extracted architectures: arm64
fatal error: lipo: can't open input file: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKShareKit.framework/FBSDKShareKit-arm64 (No such file or directory)
rm: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKShareKit.framework/FBSDKShareKit-arm64: No such file or directory
Replacing original executable with thinned version
mv: rename /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKShareKit.framework/FBSDKShareKit-merged to /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKShareKit.framework/FBSDKShareKit: No such file or directory
Executable is /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/GoogleToolboxForMac.framework/GoogleToolboxForMac
Extracting arm64 from GoogleToolboxForMac
fatal error: lipo: input file (/Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/GoogleToolboxForMac.framework/GoogleToolboxForMac) must be a fat file when the -extract option is specified
Merging extracted architectures: arm64
fatal error: lipo: can't open input file: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/GoogleToolboxForMac.framework/GoogleToolboxForMac-arm64 (No such file or directory)
rm: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/GoogleToolboxForMac.framework/GoogleToolboxForMac-arm64: No such file or directory
Replacing original executable with thinned version
mv: rename /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/GoogleToolboxForMac.framework/GoogleToolboxForMac-merged to /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/GoogleToolboxForMac.framework/GoogleToolboxForMac: No such file or directory
Executable is /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/nanopb.framework/nanopb
Extracting arm64 from nanopb
fatal error: lipo: input file (/Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/nanopb.framework/nanopb) must be a fat file when the -extract option is specified
Merging extracted architectures: arm64
fatal error: lipo: can't open input file: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/nanopb.framework/nanopb-arm64 (No such file or directory)
rm: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/nanopb.framework/nanopb-arm64: No such file or directory
Replacing original executable with thinned version
mv: rename /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/nanopb.framework/nanopb-merged to /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/nanopb.framework/nanopb: No such file or directory
Executable is /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKCoreKit.framework/FBSDKCoreKit
Extracting arm64 from FBSDKCoreKit
fatal error: lipo: input file (/Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKCoreKit.framework/FBSDKCoreKit) must be a fat file when the -extract option is specified
Merging extracted architectures: arm64
fatal error: lipo: can't open input file: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKCoreKit.framework/FBSDKCoreKit-arm64 (No such file or directory)
rm: /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKCoreKit.framework/FBSDKCoreKit-arm64: No such file or directory
Replacing original executable with thinned version
mv: rename /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKCoreKit.framework/FBSDKCoreKit-merged to /Users/johnmick/Library/Developer/Xcode/DerivedData/ThreeSixtyPlayer-fwqwnmeuamftpugdfgrgzthnieiz/Build/Products/Debug-iphoneos/ThreeSixtyPlayer.app/Frameworks/FBSDKCoreKit.framework/FBSDKCoreKit: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```
</details>