### PR TITLE
fix(project selector): Use `slug` rather than `name` to identify projects

### DIFF
--- a/lib/Steps/SentryProjectSelector.ts
+++ b/lib/Steps/SentryProjectSelector.ts
@@ -12,7 +12,10 @@ export class SentryProjectSelector extends BaseStep {
       return {};
     }
 
-    if (_.has(answers, 'wizard.projects') && answers.wizard.projects.length === 0) {
+    if (
+      _.has(answers, 'wizard.projects') &&
+      answers.wizard.projects.length === 0
+    ) {
       throw new Error('no projects');
     }
 
@@ -24,7 +27,7 @@ export class SentryProjectSelector extends BaseStep {
         {
           choices: answers.wizard.projects.map((project: any) => {
             return {
-              name: `${project.organization.name} / ${project.name}`,
+              name: `${project.organization.name} / ${project.slug}`,
               value: project,
             };
           }),
@@ -41,11 +44,23 @@ export class SentryProjectSelector extends BaseStep {
           token: _.get(answers, 'wizard.apiKeys.token', null),
         },
         dsn: {
-          public: _.get(selectedProject, 'selectedProject.keys.0.dsn.public', null),
-          secret: _.get(selectedProject, 'selectedProject.keys.0.dsn.secret', null),
+          public: _.get(
+            selectedProject,
+            'selectedProject.keys.0.dsn.public',
+            null,
+          ),
+          secret: _.get(
+            selectedProject,
+            'selectedProject.keys.0.dsn.secret',
+            null,
+          ),
         },
         organization: {
-          slug: _.get(selectedProject, 'selectedProject.organization.slug', null),
+          slug: _.get(
+            selectedProject,
+            'selectedProject.organization.slug',
+            null,
+          ),
         },
         project: {
           slug: _.get(selectedProject, 'selectedProject.slug', null),


### PR DESCRIPTION
The UI for a project's `name` was pulled from project settings almost a year ago, in this PR: https://github.com/getsentry/sentry/pull/11986.

However, we still fill in the field at project creation time, with an title-kebab-cased version of the platform if no other name is specified (as can be seen [here](https://github.com/getsentry/sentry/blob/f3490bc05bea24451d4e3c2218cdbf17b65c0c77/src/sentry/static/sentry/app/components/createProject.jsx#L48), [here](https://github.com/getsentry/sentry/blob/f3490bc05bea24451d4e3c2218cdbf17b65c0c77/src/sentry/static/sentry/app/components/createProject.jsx#L111-L114), [here](https://github.com/getsentry/sentry/blob/f3490bc05bea24451d4e3c2218cdbf17b65c0c77/src/sentry/static/sentry/app/components/createProject.jsx#L71-L76), and [here](https://github.com/getsentry/sentry/blob/9400ce6551730e0371aa74f463adb5948f726ef6/src/sentry/api/endpoints/team_projects.py#L138-L143)), and the name in turn generates the slug (see [here](https://github.com/getsentry/sentry/blob/fbe1eda4aa3d57e1ae1bc5c6fd4dbe2c4c0f722f/src/sentry/models/project.py#L130-L135)). So, for new projects, `name` and `slug` match (save possible case differences).

The problem comes when someone changes a project's slug in the UI (which many folks do, since initially many projects have only the platform as the slug, which is too generic). Because `name` used to be separately controllable from the UI, it made sense to not touch it when updating the slug. But now what that means is that unless you specify a name at project creation time, it will forever be equal to the platform. And since the wizard's project selector currently looks at `name` instead of `slug`, people get confused, especially if they have more than one project with the same platform-as-name `name` value.

So, long story long, this changes the project selector to use `slug` instead, which isn't deprecated, matches the UI, and is [guaranteed to be unique](https://github.com/getsentry/sentry/blob/fbe1eda4aa3d57e1ae1bc5c6fd4dbe2c4c0f722f/src/sentry/models/project.py#L115) within the org.

NB: This is only not a one-liner because prettier had opinions about how things were formatted and changed a bunch of stuff. The only relevant change is in the second red -> green block.