### PR TITLE
Only upload sentry symbols for prod builds

### DIFF
--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -260,8 +260,10 @@ export class ReactNative extends MobileProject {
       {
         shellPath: '/bin/sh',
         shellScript:
-          'export SENTRY_PROPERTIES=sentry.properties\\n' +
-          '../node_modules/@sentry/cli/bin/sentry-cli upload-dsym',
+          'if [ "$CONFIGURATION" != "Debug" ]; then\\n' +
+          '  export SENTRY_PROPERTIES=sentry.properties\\n' +
+          '  ../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\\n' +
+          'fi\\n',
       },
     );
   }


### PR DESCRIPTION
Current code makes it so Sentry symbols are uploaded on each build, even debug ones.
Sentry symbols uploading only makes sense in prod build so in addition to fixing this in my app, here's a PR so other people can enjoy faster debug builds