### PR TITLE
fix: Only override `config.devtool` in non-production environments

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -162,7 +162,12 @@ export class NextJs extends BaseIntegration {
       red(`✗ ${packageName} isn't in your dependencies`);
       red(`  please install it with yarn/npm`);
       return false;
-    } else if (appPackage['dependencies'][packageName] === 'latest') {
+    } else if (
+      // When the Next.js dependency is `latest` the int parsing will output
+      // in a NaN. Don't support this.
+      isNaN(depVersion) ||
+      isNaN(devDepVersion)
+    ) {
       red(
         "✗ `latest` version for NextJS isn't supported, replace it with the actual version number.",
       );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/wizard",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "homepage": "https://github.com/getsentry/sentry-wizard",
   "repository": "https://github.com/getsentry/sentry-wizard",
   "description": "Sentry wizard helping you to configure your project",

--- a/scripts/NextJs/next.config.js
+++ b/scripts/NextJs/next.config.js
@@ -49,14 +49,14 @@ module.exports = {
   },
   plugins: ['@sentry/next-plugin-sentry'],
   // Sentry.init config for server-side code, serializable values only.
-  // See more in [DOCS PAGE].
+  // See more in https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/custom-init/
   serverRuntimeConfig: {
     sentry: {
       // debug: true,
     },
   },
   // Sentry.init config for client-side code (and fallback for server-side),
-  // serializeable values only. See more in [DOCS PAGE].
+  // serializeable values only. See more in https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/custom-init/
   publicRuntimeConfig: {
     sentry: {
       // debug: true,

--- a/scripts/NextJs/next.config.js
+++ b/scripts/NextJs/next.config.js
@@ -48,14 +48,15 @@ module.exports = {
     NEXT_PUBLIC_COMMIT_SHA: COMMIT_SHA,
   },
   plugins: ['@sentry/next-plugin-sentry'],
-  // Sentry.init config for server-side code. Can accept any available config option.
+  // Sentry.init config for server-side code, serializable values only.
+  // See more in [DOCS PAGE].
   serverRuntimeConfig: {
     sentry: {
       // debug: true,
     },
   },
-  // Sentry.init config for client-side code (and fallback for server-side)
-  // can accept only serializeable values. For more granular control see below.
+  // Sentry.init config for client-side code (and fallback for server-side),
+  // serializeable values only. See more in [DOCS PAGE].
   publicRuntimeConfig: {
     sentry: {
       // debug: true,
@@ -63,7 +64,9 @@ module.exports = {
   },
   productionBrowserSourceMaps: true,
   webpack: (config, { dev }) => {
-    config.devtool = 'source-map';
+    if (!dev) {
+      config.devtool = 'source-map';
+    }
     config.plugins.push(
       new SentryWebpackPlugin({
         // Sentry project config

--- a/scripts/NextJs/next.config.js
+++ b/scripts/NextJs/next.config.js
@@ -65,6 +65,8 @@ module.exports = {
   productionBrowserSourceMaps: true,
   webpack: (config, { dev }) => {
     if (!dev) {
+      // Enable high-quality source-maps for non-dev builds. See
+      // https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md
       config.devtool = 'source-map';
     }
     config.plugins.push(

--- a/scripts/NextJs/next.config.js
+++ b/scripts/NextJs/next.config.js
@@ -49,14 +49,14 @@ module.exports = {
   },
   plugins: ['@sentry/next-plugin-sentry'],
   // Sentry.init config for server-side code, serializable values only.
-  // See more in https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/custom-init/
+  // See more in [LINK TO DOCS]
   serverRuntimeConfig: {
     sentry: {
       // debug: true,
     },
   },
   // Sentry.init config for client-side code (and fallback for server-side),
-  // serializeable values only. See more in https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/custom-init/
+  // serializeable values only. See more in [LINK TO DOCS]
   publicRuntimeConfig: {
     sentry: {
       // debug: true,

--- a/scripts/NextJs/next.config.js
+++ b/scripts/NextJs/next.config.js
@@ -48,20 +48,6 @@ module.exports = {
     NEXT_PUBLIC_COMMIT_SHA: COMMIT_SHA,
   },
   plugins: ['@sentry/next-plugin-sentry'],
-  // Sentry.init config for server-side code, serializable values only.
-  // See more in [LINK TO DOCS]
-  serverRuntimeConfig: {
-    sentry: {
-      // debug: true,
-    },
-  },
-  // Sentry.init config for client-side code (and fallback for server-side),
-  // serializeable values only. See more in [LINK TO DOCS]
-  publicRuntimeConfig: {
-    sentry: {
-      // debug: true,
-    },
-  },
   productionBrowserSourceMaps: true,
   webpack: (config, { dev }) => {
     if (!dev) {


### PR DESCRIPTION
Changing `config.devtool` in non-production environments is not recommended and [may cause regressions](https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md). It's overridden by Next.js in development environments and a warning is logged in console; so to avoid this warning, `config.devtool` is only changed in non-development environments.

Links to docs (WIP) of customizing the Next.js SDK initialization have also been added.