### PR TITLE
ref(nextjs): Remove serializable configs from `next.config.js`

### DIFF
--- a/scripts/NextJs/next.config.js
+++ b/scripts/NextJs/next.config.js
@@ -48,19 +48,6 @@ module.exports = {
     NEXT_PUBLIC_COMMIT_SHA: COMMIT_SHA,
   },
   plugins: ['@sentry/next-plugin-sentry'],
-  // Sentry.init config for server-side code. Can accept any available config option.
-  serverRuntimeConfig: {
-    sentry: {
-      // debug: true,
-    },
-  },
-  // Sentry.init config for client-side code (and fallback for server-side)
-  // can accept only serializeable values. For more granular control see below.
-  publicRuntimeConfig: {
-    sentry: {
-      // debug: true,
-    },
-  },
   productionBrowserSourceMaps: true,
   webpack: (config, { dev }) => {
     config.devtool = 'source-map';


### PR DESCRIPTION
To customize the Next.js SDK initialization, serializable values were placed in the `next.config.js`. However, to make this SDK's initialization as similar as possible to other SDKs, this changed in https://github.com/getsentry/sentry-javascript/pull/3301/commits/15e4baa8f1337ec85b6fd8c3bb481007eb380937 (there are now two config files, `sentry.client.config.js` and `sentry.server.config.js`, where the usual `Sentry.init` is placed).