### PR TITLE
fix(nextjs): Remove unused function in the integration

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import * as path from 'path';
 
 import { Args } from '../../Constants';
-import { debug, dim, green, l, nl, red } from '../../Helper/Logging';
+import { debug, green, l, nl, red } from '../../Helper/Logging';
 import { SentryCli } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
 

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -15,16 +15,6 @@ const MERGEABLE_CONFIG_PREFIX = '_';
 
 let appPackage: any = {};
 
-function printExample(example: string, title: string = ''): void {
-  if (title) {
-    l(title);
-  }
-
-  nl();
-  dim(example.replace(/^/gm, '    '));
-  nl();
-}
-
 try {
   appPackage = require(path.join(process.cwd(), 'package.json'));
 } catch {


### PR DESCRIPTION
https://github.com/getsentry/sentry-wizard/pull/94 performs some changes that leave a function unused. This PR removes that function (and an import that the function was using).