### PR TITLE
chore(nextjs): Clarify messages, ignore `coverage` when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,14 @@ module.exports = {
     ecmaVersion: 2018,
   },
   extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'assets/**', 'scripts/**'],
+  ignorePatterns: [
+    'build/**',
+    'dist/**',
+    'esm/**',
+    'assets/**',
+    'scripts/**',
+    'coverage/**',
+  ],
   overrides: [
     {
       files: ['*.ts', '*.tsx', '*.d.ts'],

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -167,7 +167,7 @@ export class NextJs extends BaseIntegration {
       isNaN(devDepVersion)
     ) {
       red(
-        "✗ `latest` version for NextJS isn't supported, replace it with the actual version number.",
+        "✗ `latest` version for NextJS isn't supported. Please specify a version number for `next` in your `package.json`.",
       );
       nl();
       return false;
@@ -177,7 +177,7 @@ export class NextJs extends BaseIntegration {
       devDepVersion < parsedVersion
     ) {
       red(
-        `✗ Your installed version of ${packageName} is not supported, >${MIN_NEXTJS_VERSION} needed`,
+        `✗ Your installed version of \`${packageName}\` is not supported, >${MIN_NEXTJS_VERSION} needed`,
       );
       return false;
     } else {

--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -21,7 +21,8 @@ const COMMIT_SHA =
 const SentryWebpackPlugin = require('@sentry/webpack-plugin');
 const fs = require('fs');
 
-// We require this to fake that our plugin matches the next version
+// Next.js requires a plugin's version to match the next.js version, so we fake
+// it here by rewriting our plugin's package.json
 function replaceVersion() {
   const packageJson = require('./package.json');
   if (
@@ -57,12 +58,13 @@ module.exports = {
         project: SENTRY_PROJECT,
         authToken: SENTRY_AUTH_TOKEN,
         configFile: 'sentry.properties',
-        // Webpack specific configuration
         stripPrefix: ['webpack://_N_E/'],
         urlPrefix: `~/_next`,
         include: '.next/',
         ignore: ['node_modules', 'webpack.config.js'],
         dryRun: dev,
+        // for all available options, see
+        // https://github.com/getsentry/sentry-webpack-plugin#options
       }),
     );
     return config;


### PR DESCRIPTION
A handful of small changes:

- Clarify that it's the user's `package.json` version of `next` which can't be set to `latest`.
- Clarify why we have to change the version number on our plugin
- Add a link to other sentry-webpack-plugin options
- Ignore `coverage` when linting