### PR TITLE
fix(nextjs): Get release from environment

### DIFF
--- a/scripts/NextJs/configs/sentry.client.config.js
+++ b/scripts/NextJs/configs/sentry.client.config.js
@@ -8,4 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
+  // note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
 });

--- a/scripts/NextJs/configs/sentry.client.config.js
+++ b/scripts/NextJs/configs/sentry.client.config.js
@@ -8,7 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
-  // note: if you want to override the automatic release value, do not set a
+  // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
 });

--- a/scripts/NextJs/configs/sentry.server.config.js
+++ b/scripts/NextJs/configs/sentry.server.config.js
@@ -8,4 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
+  // note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
 });

--- a/scripts/NextJs/configs/sentry.server.config.js
+++ b/scripts/NextJs/configs/sentry.server.config.js
@@ -8,7 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
-  // note: if you want to override the automatic release value, do not set a
+  // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
 });


### PR DESCRIPTION
A few small last-minute changes before we release the next.js SDK:

- Pull release value from the standard `SENTRY_RELEASE` env variable
- Add note to initialization files not to set the release there but rather to use the env var, so it will get attached to source maps
- Rename method to make it clear it's a Sentry method (since all of our `next.config.js` code is going to get mixed in with whatever other `next.config.js` code the user has)

We may still want to pull much of this logic out into the SDK itself, but that's out of the scope of this PR.