### PR TITLE
ref(nextjs): Move most config to SDK

### DIFF
--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -3,75 +3,22 @@
 // https://nextjs.org/docs/api-reference/next.config.js/introduction
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-const SentryWebpackPlugin = require('@sentry/webpack-plugin');
-const fs = require('fs');
+const { withSentryConfig } = require('@sentry/nextjs');
 
-const {
-  VERCEL_GITHUB_COMMIT_SHA,
-  VERCEL_GITLAB_COMMIT_SHA,
-  VERCEL_BITBUCKET_COMMIT_SHA,
-  SENTRY_URL,
-  SENTRY_ORG,
-  SENTRY_PROJECT,
-  SENTRY_AUTH_TOKEN,
-  SENTRY_RELEASE,
-} = process.env;
-
-function getSentryRelease() {
-  return (
-    SENTRY_RELEASE ||
-    VERCEL_GITHUB_COMMIT_SHA ||
-    VERCEL_GITLAB_COMMIT_SHA ||
-    VERCEL_BITBUCKET_COMMIT_SHA
-  );
-}
-
-// Next.js requires a plugin's version to match the Next.js version, so we fake
-// it here by rewriting our plugin's package.json
-function syncSentryPluginVersion() {
-  const packageJson = require('./package.json');
-  if (
-    packageJson &&
-    packageJson.dependencies &&
-    packageJson.dependencies.next
-  ) {
-    const packagePluginPath = `./node_modules/@sentry/next-plugin-sentry/package.json`;
-    const packagePlugin = require(packagePluginPath);
-    packagePlugin.version = packageJson.dependencies.next;
-    fs.writeFileSync(packagePluginPath, JSON.stringify(packagePlugin));
-  } else {
-    console.error(`Can't find 'next' dependency`);
-  }
-}
-syncSentryPluginVersion();
-
-module.exports = {
-  experimental: { plugins: true },
-  plugins: ['@sentry/next-plugin-sentry'],
-  productionBrowserSourceMaps: true,
-  webpack: (config, { dev }) => {
-    if (!dev) {
-      // Enable high-quality source-maps for non-dev builds. See
-      // https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md
-      config.devtool = 'source-map';
-    }
-    config.plugins.push(
-      new SentryWebpackPlugin({
-        release: getSentryRelease(),
-        url: SENTRY_URL,
-        org: SENTRY_ORG,
-        project: SENTRY_PROJECT,
-        authToken: SENTRY_AUTH_TOKEN,
-        configFile: 'sentry.properties',
-        stripPrefix: ['webpack://_N_E/'],
-        urlPrefix: `~/_next`,
-        include: '.next/',
-        ignore: ['node_modules', 'webpack.config.js'],
-        dryRun: dev,
-        // for all available options, see
-        // https://github.com/getsentry/sentry-webpack-plugin#options
-      }),
-    );
-    return config;
-  },
+const moduleExports = {
+  // your existing module.exports
 };
+
+const SentryWebpackPluginOptions = {
+  // Additional config options for the Sentry Webpack plugin. Keep in mind that
+  // the following options are set automatically, and overriding them is not
+  // recommended:
+  //   release, url, org, project, authToken, configFile, stripPrefix,
+  //   urlPrefix, include, ignore
+  // For all available options, see:
+  // https://github.com/getsentry/sentry-webpack-plugin#options.
+};
+
+// Make sure adding Sentry options is the last code to run before exporting, to
+// ensure that your source maps include changes from all other Webpack plugins
+module.exports = withSentryConfig(moduleExports);

--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -6,7 +6,7 @@
 const { withSentryConfig } = require('@sentry/nextjs');
 
 const moduleExports = {
-  // your existing module.exports
+  // Your existing module.exports
 };
 
 const SentryWebpackPluginOptions = {
@@ -21,4 +21,4 @@ const SentryWebpackPluginOptions = {
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(moduleExports);
+module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);


### PR DESCRIPTION
See detailed explanation in https://github.com/getsentry/sentry-javascript/pull/3418. TL;DR, this (together with that PR) pulls as much of the boilerplate config as possible out of `next.config.js` and into the `nextjs` SDK.

See also the [docs change](https://github.com/getsentry/sentry-docs/pull/3319/commits/06ac0bed2982b1b31a1715e4bbecf285fae2d118) corresponding to these PRs.