### PR TITLE
fix: Fix platform selection issues and repeated prompts

### DIFF
--- a/lib/Steps/Integrations/BaseIntegration.ts
+++ b/lib/Steps/Integrations/BaseIntegration.ts
@@ -23,7 +23,7 @@ export abstract class BaseIntegration extends BaseStep {
    * if we should configure iOS/Android.
    * Basically this will be merged into answers so it can be check by a later step.
    */
-  public async shouldConfigure(_answers?: Answers): Promise<Answers> {
+  public async shouldConfigure(_answers: Answers): Promise<Answers> {
     if (this._shouldConfigure) {
       return this._shouldConfigure;
     }

--- a/lib/Steps/Integrations/BaseIntegration.ts
+++ b/lib/Steps/Integrations/BaseIntegration.ts
@@ -34,7 +34,7 @@ export abstract class BaseIntegration extends BaseStep {
   public async shouldEmit(_answers: Answers): Promise<boolean> {
     return (
       _.keys(
-        _.pickBy(await this.shouldConfigure(), (active: boolean) => active),
+        _.pickBy(await this.shouldConfigure(_answers), (active: boolean) => active),
       ).length > 0
     );
   }


### PR DESCRIPTION
Fixes issues that have been reported by users about getting stuck in the platform step, or getting spammed with the same repeated platform question with then their platform selection not actually being used.

<img width="517" alt="Screen Shot 2021-04-28 at 11 06 42 PM" src="https://user-images.githubusercontent.com/30991498/116436297-78217d00-a876-11eb-96a6-fde18d33e507.png">


Fixes https://github.com/getsentry/sentry-wizard/issues/93,  https://github.com/getsentry/sentry-react-native/issues/1386.

Fixed by passing `_answers` to `this.shouldConfigure` in `this.shouldEmit`. Also requires `_answers` to be defined as a parameter in `shouldConfigure`.

Tested by running on a React Native sample app and a Cordova sample app.