### PR TITLE
fix: Fix iOS uninstall script for React Native

### DIFF
--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -409,7 +409,10 @@ export class ReactNative extends MobileProject {
     }
   }
 
-  private _unpatchXcodeProj(filename: string): Promise<string> {
+  private _unpatchXcodeProj(
+    _contents: string,
+    filename: string,
+  ): Promise<string> {
     const proj = xcode.project(filename);
     return new Promise((resolve, reject) => {
       proj.parse((err: any) => {


### PR DESCRIPTION
Fixes a regression where we removed the first argument for the Xcode unpatch method and caused the file contents to be passed instead of the filename.

Fixes #106 