### PR TITLE
ref(nextjs): Don't hardcode package name

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -167,7 +167,7 @@ export class NextJs extends BaseIntegration {
       isNaN(devDepVersion)
     ) {
       red(
-        "✗ `latest` version for NextJS isn't supported. Please specify a version number for `next` in your `package.json`.",
+        `✗ \`latest\` version for \`${packageName}\` isn't supported. Please specify a version number for \`${packageName}\` in your \`package.json\`.`,
       );
       nl();
       return false;


### PR DESCRIPTION
The package name was hardcoded, instead of using the local variable with the appropriate package name. This PR fixes this, using that variable instead.