### PR TITLE
fix: Fix React Native JS patching throwing errors due to incorrect argument

### DIFF
--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -160,6 +160,7 @@ export class ReactNative extends MobileProject {
 
   private _patchJs(
     contents: string,
+    _filename: string,
     answers: Answers,
     platform?: string,
   ): Promise<string | null> {


### PR DESCRIPTION
Fix missing `filename` second argument to `ReactNative._patchJS` that was causing the JS patching functionality to not work. This method is called here: https://github.com/getsentry/sentry-wizard/blob/61fdd1d26541c23dc78e20df36c40d4327dd1fb6/lib/Helper/File.ts#L20 where `match` is the filename, which should be the second parameter before the rest of the args.

Fixes https://github.com/getsentry/sentry-react-native/issues/1386#issuecomment-836311751

Reverts a change made in #72