### PR TITLE
ref(nextjs): Make webpack silent by default

### DIFF
--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -15,6 +15,8 @@ const SentryWebpackPluginOptions = {
   // recommended:
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
+
+  silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
 };


### PR DESCRIPTION
The [Sentry Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) outputs logs that may be annoying for some users, especially when running in `dryRun` mode. Adding `silent` suppresses all logs, decreasing noise to users. Docs have already been updated, in https://github.com/getsentry/sentry-docs/pull/3612.