### PR TITLE
feat(nextjs): Add performance monitoring support to scripts

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -101,6 +101,11 @@ export class NextJs extends BaseIntegration {
     for (const template of templates) {
       this._setTemplate(configDirectory, template, dsn);
     }
+    red(
+      '⚠ Performance monitoring is enabled capturing 100% of transactions.\n' +
+        '  Learn more in https://docs.sentry.io/product/performance/',
+    );
+    nl();
   }
 
   private _setTemplate(

--- a/scripts/NextJs/configs/sentry.client.config.js
+++ b/scripts/NextJs/configs/sentry.client.config.js
@@ -8,8 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
+  // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
   // ...
   // Note: if you want to override the automatic release value, do not set a

--- a/scripts/NextJs/configs/sentry.client.config.js
+++ b/scripts/NextJs/configs/sentry.client.config.js
@@ -8,6 +8,10 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+  // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps

--- a/scripts/NextJs/configs/sentry.server.config.js
+++ b/scripts/NextJs/configs/sentry.server.config.js
@@ -8,8 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
+  // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
   // ...
   // Note: if you want to override the automatic release value, do not set a

--- a/scripts/NextJs/configs/sentry.server.config.js
+++ b/scripts/NextJs/configs/sentry.server.config.js
@@ -8,6 +8,10 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN || '___DSN___',
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+  // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps


### PR DESCRIPTION
Setting `tracesSampleRate` is key for performance monitoring. This PR adds it to the two files (`sentry.client.config.js` and `sentry.server.config.js`) initializing the Next.js SDK.