### PR TITLE
fix(file-patching): Check new contents before overwriting a file

### DIFF
--- a/lib/Helper/File.ts
+++ b/lib/Helper/File.ts
@@ -21,7 +21,7 @@ export function patchMatchingFile(
       .then(newContents => {
         if (
           newContents !== null &&
-          contents !== undefined &&
+          newContents !== undefined &&
           contents !== newContents
         ) {
           fs.writeFileSync(match, newContents);


### PR DESCRIPTION
fixed writes of undefined contents when patching files.

I did not test but it seems to be a really obvious typo

Fixes #112 