### PR TITLE
ref(nextjs): Update minimum required `next` version

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -8,7 +8,7 @@ import { debug, green, l, nl, red } from '../../Helper/Logging';
 import { SentryCli } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
 
-const MIN_NEXTJS_VERSION = '10.0.0';
+const MIN_NEXTJS_VERSION = '10.0.8';
 const PROPERTIES_FILENAME = 'sentry.properties';
 const CONFIG_DIR = 'configs/';
 const MERGEABLE_CONFIG_PREFIX = '_';


### PR DESCRIPTION
The minimum version the Next.js SDK supports was updated in the docs, but not in the Wizard.