### PR TITLE
fix(nextjs): Don't expose auth token in `sentry.properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.12
+
+* Don't expose auth token in `sentry.properties` (#128)
+
 ## 1.2.11
 
 * Parse Next.js version as a string, instead of int (#122)


### PR DESCRIPTION
The Wizard is currently adding every property required by Sentry CLI in `sentry.properties`, including the auth token (that shouldn't be exposed). This PR fixes this behavior by adding the auth token to `.sentryclirc` (the Sentry CLI config file), which is added to the `.gitignore`. `sentry.properties` can now be safely committed.