### PR TITLE
fix(nextjs): Correctly set token in .sentryclirc

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -109,7 +109,7 @@ export class NextJs extends BaseIntegration {
       try {
         await fs.promises.appendFile(
           SENTRYCLIRC_FILENAME,
-          this._sentryCli.dumpProperties({ 'auth/token': authToken }),
+          `[auth]\ntoken=${authToken}`,
         );
         green(`✓ Successfully added the auth token to ${SENTRYCLIRC_FILENAME}`);
       } catch {


### PR DESCRIPTION
Should resolve https://github.com/getsentry/sentry-javascript/issues/3968

We need to fix docs as well: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-configuration-files, can do that afterwards