### PR TITLE
fix(nextjs): Fix `.sentryclirc` formatting in nextjs step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+# 1.2.13
+
+* Fix `.sentryclirc` file formatting (#131)
+
 ## 1.2.12
 
 * Don't expose auth token in `sentry.properties` (#128)

--- a/lib/Helper/SentryCli.ts
+++ b/lib/Helper/SentryCli.ts
@@ -8,6 +8,8 @@ export interface SentryCliProps {
   [s: string]: string;
 }
 
+type SentryCliConfig = Record<string, SentryCliProps>;
+
 export class SentryCli {
   // eslint-disable-next-line @typescript-eslint/typedef
   private _resolve = require.resolve;
@@ -51,5 +53,18 @@ export class SentryCli {
     }
     // eslint-disable-next-line prefer-template
     return rv.join('\n') + '\n';
+  }
+
+  public dumpConfig(config: SentryCliConfig): string {
+    const dumpedSections: string[] = [];
+    for (const sectionName in config) {
+      // eslint-disable-next-line no-prototype-builtins
+      if (config.hasOwnProperty(sectionName)) {
+        const props = this.dumpProperties(config[sectionName]);
+        const section = `[${sectionName}]\n${props}`;
+        dumpedSections.push(section);
+      }
+    }
+    return dumpedSections.join('\n');
   }
 }

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -109,7 +109,7 @@ export class NextJs extends BaseIntegration {
       try {
         await fs.promises.appendFile(
           SENTRYCLIRC_FILENAME,
-          this._sentryCli.dumpProperties({ 'auth/token': authToken }),
+          this._sentryCli.dumpConfig({ auth: { token: authToken } }),
         );
         green(`✓ Successfully added the auth token to ${SENTRYCLIRC_FILENAME}`);
       } catch {


### PR DESCRIPTION
`.sentryclirc` should be an `ini` file, see [sentry-cli docs](https://docs.sentry.io/product/cli/configuration/#to-authenticate-manually). This PR fixes the formatting.

Similar PR to https://github.com/getsentry/sentry-wizard/pull/129, but wrapping the logic in a method for further usage.

Should resolve https://github.com/getsentry/sentry-javascript/issues/3968.