### PR TITLE
meta(changelog): Update version to release `1.2.13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-# 1.2.13
+## 1.2.13
 
 * Fix `.sentryclirc` file formatting (#131)
 


### PR DESCRIPTION
There was a missing `#`, so Craft couldn't find the version for the release.