### PR TITLE
fix(nextjs): Do not capture 404s as exceptions in `_error`

### DIFF
--- a/scripts/NextJs/configs/_error.js
+++ b/scripts/NextJs/configs/_error.js
@@ -23,7 +23,7 @@ MyError.getInitialProps = async (context) => {
   // getInitialProps has run
   errorInitialProps.hasGetInitialPropsRun = true;
 
-  // Returning early beacause we don't want to log 404 errors to Sentry.
+  // Returning early because we don't want to log 404 errors to Sentry.
   if (res?.statusCode === 404) {
     return errorInitialProps;
   }

--- a/scripts/NextJs/configs/_error.js
+++ b/scripts/NextJs/configs/_error.js
@@ -14,11 +14,10 @@ const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
   return <NextErrorComponent statusCode={statusCode} />;
 };
 
-MyError.getInitialProps = async ({ res, err, asPath }) => {
-  const errorInitialProps = await NextErrorComponent.getInitialProps({
-    res,
-    err,
-  });
+MyError.getInitialProps = async (context) => {
+  const errorInitialProps = await NextErrorComponent.getInitialProps(context);
+  
+  const { res, err, asPath } = context;
 
   // Workaround for https://github.com/vercel/next.js/issues/8592, mark when
   // getInitialProps has run
@@ -47,13 +46,15 @@ MyError.getInitialProps = async ({ res, err, asPath }) => {
     return errorInitialProps;
   }
 
-  // If this point is reached, getInitialProps was called without any
-  // information about what the error might be. This is unexpected and may
-  // indicate a bug introduced in Next.js, so record it in Sentry
-  Sentry.captureException(
-    new Error(`_error.js getInitialProps missing data at path: ${asPath}`),
-  );
-  await Sentry.flush(2000);
+  if (res?.statusCode !== 404) {
+    // If this point is reached, getInitialProps was called without any
+    // information about what the error might be. This is unexpected and may
+    // indicate a bug introduced in Next.js, so record it in Sentry
+    Sentry.captureException(
+      new Error(`_error.js getInitialProps missing data at path: ${asPath}`),
+    );
+    await Sentry.flush(2000);
+  }
 
   return errorInitialProps;
 };

--- a/scripts/NextJs/configs/_error.js
+++ b/scripts/NextJs/configs/_error.js
@@ -23,6 +23,11 @@ MyError.getInitialProps = async (context) => {
   // getInitialProps has run
   errorInitialProps.hasGetInitialPropsRun = true;
 
+  // Returning early beacause we don't want to log 404 errors to Sentry.
+  if (res?.statusCode === 404) {
+    return errorInitialProps;
+  }
+  
   // Running on the server, the response object (`res`) is available.
   //
   // Next.js will pass an err on the server if a page's data fetching methods
@@ -46,15 +51,13 @@ MyError.getInitialProps = async (context) => {
     return errorInitialProps;
   }
 
-  if (res?.statusCode !== 404) {
-    // If this point is reached, getInitialProps was called without any
-    // information about what the error might be. This is unexpected and may
-    // indicate a bug introduced in Next.js, so record it in Sentry
-    Sentry.captureException(
-      new Error(`_error.js getInitialProps missing data at path: ${asPath}`),
-    );
-    await Sentry.flush(2000);
-  }
+  // If this point is reached, getInitialProps was called without any
+  // information about what the error might be. This is unexpected and may
+  // indicate a bug introduced in Next.js, so record it in Sentry
+  Sentry.captureException(
+    new Error(`_error.js getInitialProps missing data at path: ${asPath}`),
+  );
+  await Sentry.flush(2000);
 
   return errorInitialProps;
 };


### PR DESCRIPTION
By checking the status code of the response it's possible to filter out errors for not found pages. 

I've also updated it to pass the full page context to `getInitialProps`, because otherwise this example would fail to build when converted to typescript. 