### PR TITLE
feat(nextjs): Support Next.js v12

### DIFF
--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -10,7 +10,7 @@ import { debug, green, l, nl, red } from '../../Helper/Logging';
 import { SentryCli, SentryCliProps } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
 
-const COMPATIBLE_NEXTJS_VERSIONS = '>=10.0.8 <12.0.0';
+const COMPATIBLE_NEXTJS_VERSIONS = '>=10.0.8 <13.0.0';
 const PROPERTIES_FILENAME = 'sentry.properties';
 const SENTRYCLIRC_FILENAME = '.sentryclirc';
 const GITIGNORE_FILENAME = '.gitignore';


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-wizard/issues/151.

Limiting the maximum version to the next major, to avoid users installing it and having their apps crashing if it's not supported.