### PR TITLE
Patch React Native xcode RN 0.69

### DIFF
--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -231,9 +231,9 @@ export class ReactNative extends MobileProject {
     for (const script of buildScripts) {
       if (
         !script.shellScript.match(
-          /(packager|scripts)\/react-native-xcode\.sh\b/,
+          /\/scripts\/react-native-xcode\.sh/i,
         ) ||
-        script.shellScript.match(/sentry-cli\s+react-native[\s-]xcode/)
+        script.shellScript.match(/sentry-cli\s+react-native\s+xcode/i)
       ) {
         continue;
       }
@@ -243,9 +243,10 @@ export class ReactNative extends MobileProject {
         'export SENTRY_PROPERTIES=sentry.properties\n' +
         'export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"\n' +
         code.replace(
-          /^.*?\/(packager|scripts)\/react-native-xcode\.sh\s*/m,
-          (match: any) =>
-            `../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ${match}`,
+          '$REACT_NATIVE_XCODE',
+          () =>
+            // eslint-disable-next-line no-useless-escape
+            '\\\"../node_modules/@sentry/cli/bin/sentry-cli react-native xcode $REACT_NATIVE_XCODE\\\"',
         );
       script.shellScript = JSON.stringify(code);
     }

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -340,38 +340,20 @@ export class ReactNative extends MobileProject {
       }
 
       // ignore scripts that do not invoke the react-native-xcode command.
-      if (!script.shellScript.match(/sentry-cli\s+react-native[\s-]xcode\b/)) {
+      if (!script.shellScript.match(/sentry-cli\s+react-native\s+xcode/i)) {
         continue;
       }
 
       script.shellScript = JSON.stringify(
         JSON.parse(script.shellScript)
-          // "legacy" location for this.  This is what happens if users followed
-          // the old documentation for where to add the bundle command
-          .replace(
-            /^..\/node_modules\/@sentry\/react-native\/bin\/bundle-frameworks\s*?\r\n?/m,
-            '',
-          )
-          // legacy location for dsym upload
-          .replace(
-            /^..\/node_modules\/@sentry\/cli\/bin\/sentry-cli upload-dsym\s*?\r?\n/m,
-            '',
-          )
           // remove sentry properties export
           .replace(/^export SENTRY_PROPERTIES=sentry.properties\r?\n/m, '')
           // unwrap react-native-xcode.sh command.  In case someone replaced it
           // entirely with the sentry-cli command we need to put the original
           // version back in.
           .replace(
-            /^(?:..\/node_modules\/@sentry\/cli\/bin\/)?sentry-cli\s+react-native[\s-]xcode(\s+.*?)$/m,
-            (match: any, m1: string) => {
-              const rv = m1.trim();
-              if (rv === '') {
-                return '../node_modules/react-native/scripts/react-native-xcode.sh';
-              } else {
-                return rv;
-              }
-            },
+            /\.\.\/node_modules\/@sentry\/cli\/bin\/sentry-cli\s+react-native\s+xcode\s+\$REACT_NATIVE_XCODE/i,
+            '$REACT_NATIVE_XCODE',
           ),
       );
     }
@@ -386,9 +368,6 @@ export class ReactNative extends MobileProject {
       }
 
       if (
-        script.shellScript.match(
-          /@sentry\/react-native\/bin\/bundle-frameworks\b/,
-        ) ||
         script.shellScript.match(
           /@sentry\/cli\/bin\/sentry-cli\s+upload-dsym\b/,
         )

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "fix:eslint": "eslint . --format stylish --fix",
     "test": "yarn build && jest",
     "try": "ts-node bin.ts",
-    "tryUninstall": "ts-node bin.ts --uninstall",
+    "try:uninstall": "ts-node bin.ts --uninstall",
     "test:watch": "jest --watch --notify"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "fix:eslint": "eslint . --format stylish --fix",
     "test": "yarn build && jest",
     "try": "ts-node bin.ts",
+    "tryUninstall": "ts-node bin.ts --uninstall",
     "test:watch": "jest --watch --notify"
   },
   "jest": {


### PR DESCRIPTION
Fix https://github.com/getsentry/sentry-react-native/issues/2267
No need of doing https://docs.sentry.io/platforms/react-native/troubleshooting/#react-native-069-and-higher manually
We should bump a minor 1.3.0 since it's not compatible with RN < 0.69

Next: uninstall steps are broken already even for the current version of RN.
Wondering if we should get rid of the uninstall patches or not.
https://github.com/getsentry/sentry-wizard/pull/66/files Adds `EXTRA_PACKAGER_ARGS` but does not remove it during uninstall steps.
It does not unpatch the App.js that calls `Sentry.init`.
It does not delete the sentry.properties files, but just comment the fields such as `#defaults.org=`.