### PR TITLE
chore(dev): Remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @hazat @kamilogorek


### PR DESCRIPTION
This removes the codeowners file, since the wizard now falls under the purview of the frontend SDK team.