### PR TITLE
ref(nextjs): Default to hiding source maps in nextjs config

### DIFF
--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -7,6 +7,16 @@ const { withSentryConfig } = require('@sentry/nextjs');
 
 const moduleExports = {
   // Your existing module.exports
+
+  sentry: {
+    // Use `hidden-source-map` rather than `source-map` as the Webpack `devtool`
+    // for client-side builds. (This will be the default starting in
+    // `@sentry/nextjs` version 8.0.0.) See
+    // https://webpack.js.org/configuration/devtool/ and
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
+    // for more information.
+    hideSourceMaps: true,
+  },
 };
 
 const sentryWebpackPluginOptions = {


### PR DESCRIPTION
This adds a default value for `hideSourceMaps` to the `next.config.js` the wizard provides, so that new users will use `hidden-source-map` as their Webpack `devtool` by default in client-side builds. (This prevents browser devtools from seeing sourcemaps and therefore prevents original source code from showing up automatically in the `Sources` tab. (More information on `devtool` values can be found [here](https://webpack.js.org/configuration/devtool/).)

In conjunction with https://github.com/getsentry/sentry-javascript/pull/5649, https://github.com/getsentry/sentry-docs/pull/5464, and https://github.com/vercel/next.js/pull/40079, this is the first step in addressing the concerns raised in https://github.com/getsentry/sentry-javascript/issues/4489. See [here](https://github.com/getsentry/sentry-javascript/issues/4489#issuecomment-1231137629) for more details.