### PR TITLE
[DO NOT MERGE] feat(nextjs): Add `autoWrapDataFetchers` experiment to Next.js config

### DIFF
--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -16,6 +16,13 @@ const moduleExports = {
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
     // for more information.
     hideSourceMaps: true,
+
+    // This option will automatically provide performance monitoring for Next.js
+    // data-fetching methods and API routes, making the manual wrapping of API
+    // routes via `withSentry` redundant.
+    // In future versions, this behavior will become the default in the future,
+    // for now it is under `experiments`.
+    experiments: { autoWrapDataFetchers: true },
   },
 };
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5505

Adds the `experiments.autoWrapDataFetchers` option to the default Next.js config so we can test the behaviour as the default for new onboarding users without affecting existing ones.