### PR TITLE
feat(nextjs): Remove option to auto-wrap data fetchers and API routes

### DIFF
--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -16,11 +16,6 @@ const moduleExports = {
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
     // for more information.
     hideSourceMaps: true,
-
-    // This option will automatically provide performance monitoring for Next.js
-    // data-fetching methods and API routes, making the manual wrapping of API
-    // routes via `withSentry` redundant.
-    autoInstrumentServerFunctions: true,
   },
 };
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5505

As we set the default of the `autoInstrumentServerFunctions` option in the Next.js SDK to `true` in https://github.com/getsentry/sentry-javascript/pull/5919 it is no longer needed in the wizard.