### PR TITLE
chore(ci): Set changelog release policy to auto and add Danger workflow

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 minVersion: 0.23.1
-changelogPolicy: simple
+changelogPolicy: auto
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,9 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+jobs:
+  danger:
+    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
I don't know if the changelog was updated manually on purpose, if so let me know. Otherwise, I think the auto policy could be enabled so there is no need for PRs like this one https://github.com/getsentry/sentry-wizard/pull/202

Probably a Danger workflow should be in place otherwise release/pr without changelog could go thru.

#skip-changelog