### PR TITLE
chore(nextjs): Raise nextjs version limit to include 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Raise nextjs version limit to include 13 (#206)
+
 ## 2.3.1
 
-- fix(nextjs): Always check for both, `next` and `@sentry/nextjs` presence and version (#209)
+- fix(nextjs): Always check for both `next` and `@sentry/nextjs` presence and version (#209)
 - fix: `cli.executable` property should be resolved from cwd (#211)
 
 ## 2.3.0

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -11,7 +11,7 @@ import { debug, green, l, nl, red } from '../../Helper/Logging';
 import { SentryCli, SentryCliProps } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
 
-const COMPATIBLE_NEXTJS_VERSIONS = '>=10.0.8 <13.0.0';
+const COMPATIBLE_NEXTJS_VERSIONS = '>=10.0.8 <14.0.0';
 const COMPATIBLE_SDK_VERSIONS = '>=7.3.0';
 const PROPERTIES_FILENAME = 'sentry.properties';
 const SENTRYCLIRC_FILENAME = '.sentryclirc';


### PR DESCRIPTION
This expands the version compatibility check to include next 13, so the wizard won't yell at people who try to use it.