### PR TITLE
fix: Always check for both, nextjs and sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Always check for both, `next` and `@sentry/nextjs` presence and version (#209)
+
 ## 2.3.0
 
 - feat(react-native): Xcode plugin debug files upload can include source using env

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -112,15 +112,11 @@ export class NextJs extends BaseIntegration {
     nl();
 
     let userAnswers: Answers = { continue: true };
-    if (
-      (!this._checkPackageVersion('next', COMPATIBLE_NEXTJS_VERSIONS, true) ||
-        !this._checkPackageVersion(
-          '@sentry/nextjs',
-          COMPATIBLE_SDK_VERSIONS,
-          true,
-        )) &&
-      !this._argv.quiet
-    ) {
+    const hasCompatibleNextjsVersion = this._checkPackageVersion('next', COMPATIBLE_NEXTJS_VERSIONS, true);
+    const hasCompatibleSdkVersion = this._checkPackageVersion('@sentry/nextjs', COMPATIBLE_SDK_VERSIONS, true);
+    const hasAllPackagesCompatible = hasCompatibleNextjsVersion && hasCompatibleSdkVersion;
+
+    if (!hasAllPackagesCompatible && !this._argv.quiet) {
       userAnswers = await prompt({
         message:
           'There were errors during your project checkup, do you still want to continue?',


### PR DESCRIPTION
Prior to that change, `@sentry/nextjs` check was never called if `next` was there, as `true || fn()` will not call `fn`.