### PR TITLE
feat(nextjs): Add logic to add `@sentry/nextjs` if it's missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.1
+
+- adds logic to add @sentry/nextjs if it's missing when running the wizard ([#219](https://github.com/getsentry/sentry-wizard/pull/219))
+
+
 ## 2.4.0
 
 - Raise nextjs version limit to include 13 (#206)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.1
+## Unreleased
 
 - adds logic to add @sentry/nextjs if it's missing when running the wizard ([#219](https://github.com/getsentry/sentry-wizard/pull/219))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/wizard",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "homepage": "https://github.com/getsentry/sentry-wizard",
   "repository": "https://github.com/getsentry/sentry-wizard",
   "description": "Sentry wizard helping you to configure your project",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/wizard",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "homepage": "https://github.com/getsentry/sentry-wizard",
   "repository": "https://github.com/getsentry/sentry-wizard",
   "description": "Sentry wizard helping you to configure your project",


### PR DESCRIPTION
This PR adds logic to add the `@sentry/nextjs` package if it's not installed and we either have a `yarn.lock` or `package-lock.json` file. The purpose of this change is to enable a more seamless installation process where the user doesn't require the additional step of installing `@sentry/nextjs`.

Note that this only works if there is a lock file because we need that to know which package manager to install. IMO this is probably OK. I would imagine most folks would already have that file if they are thinking about adding Sentry. I think it's unlikely that people at Sentry before even installing packages and running whatever they are using locally.

Also note that this means the `nextjs` installation works slightly differently than the other platforms. In the future, we can back propagate these changes if we find them to be helpful.

- [ ] Adding tests
- [x] Update changelog