### PR TITLE
feat(onboarding): Add project_platform as query param if -s and -i are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - adds logic to add @sentry/nextjs if it's missing when running the wizard ([#219](https://github.com/getsentry/sentry-wizard/pull/219))
+- adds project_platform as query param if -s and -i are set ([#221](https://github.com/getsentry/sentry-wizard/pull/221))
 
 
 ## 2.4.0

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Options:
                                              [array] [choices: "ios", "android"]
   -u, --url          The url to your Sentry installation
                      env: SENTRY_WIZARD_URL      [default: "https://sentry.io/"]
+  -s, --signup       Redirect to signup page if not logged in          [boolean]
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Options:
                                              [array] [choices: "ios", "android"]
   -u, --url          The url to your Sentry installation
                      env: SENTRY_WIZARD_URL      [default: "https://sentry.io/"]
-  -s, --signup       Redirect to signup page if not logged in          [boolean]
+  -s, --signup       Redirect to signup page if not logged in
+                     Use if don't have a Sentry account                [boolean]
 ```
 
 ## Resources

--- a/bin.ts
+++ b/bin.ts
@@ -41,6 +41,12 @@ const argv = require('yargs')
     alias: 'url',
     default: DEFAULT_URL,
     describe: 'The url to your Sentry installation\nenv: SENTRY_WIZARD_URL',
+  })
+  .option('s', {
+    alias: 'signup',
+    default: false,
+    describe: 'Redirect to signup page if not logged in',
+    type: 'boolean',
   }).argv;
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -55,7 +55,7 @@ export function mapIntegrationToPlatform(type: string): string {
     case Integration.nextjs:
       return 'javascript-nextjs';
     default:
-      return 'react-native';
+      throw new Error(`Unknown integration ${type}`);
   }
 }
 

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -44,6 +44,21 @@ export function getIntegrationDescription(type: string): string {
   }
 }
 
+export function mapIntegrationToPlatform(type: string): string {
+  switch (type) {
+    case Integration.reactNative:
+      return 'react-native';
+    case Integration.cordova:
+      return 'cordova';
+    case Integration.electron:
+      return 'javascript-electron';
+    case Integration.nextjs:
+      return 'javascript-nextjs';
+    default:
+      return 'react-native';
+  }
+}
+
 export function getIntegrationChoices(): any[] {
   return Object.keys(Integration).map((type: string) => ({
     name: getIntegrationDescription(type),
@@ -59,6 +74,7 @@ export interface Args {
   platform: Platform[];
   skipConnect: boolean;
   quiet: boolean;
+  signup: boolean;
 }
 
 export const DEFAULT_URL = 'https://sentry.io/';

--- a/lib/Helper/__tests__/SentryCli.ts
+++ b/lib/Helper/__tests__/SentryCli.ts
@@ -12,6 +12,7 @@ const args: Args = {
   skipConnect: false,
   uninstall: false,
   url: 'https://localhost:1234',
+  signup: false,
 };
 
 const demoAnswers: Answers = {

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -1,4 +1,5 @@
 import { Answers } from 'inquirer';
+import { URL } from 'url';
 
 import { mapIntegrationToPlatform } from '../Constants';
 import { BottomBar } from '../Helper/BottomBar';
@@ -30,16 +31,19 @@ export class OpenSentry extends BaseStep {
 
       BottomBar.hide();
 
-      let urlToOpen = `${baseUrl}account/settings/wizard/${data.hash}/`;
+      const urlObj = new URL(`${baseUrl}account/settings/wizard/${data.hash}/`);
       if (this._argv.signup) {
-        urlToOpen += '?signup=1';
+        urlObj.searchParams.set('signup', '1');
         // integration maps to platform in the wizard
         if (this._argv.integration) {
-          urlToOpen += `&project_platform=${mapIntegrationToPlatform(
-            this._argv.integration,
-          )}`;
+          urlObj.searchParams.set(
+            'project_platform',
+            mapIntegrationToPlatform(this._argv.integration),
+          );
         }
       }
+
+      const urlToOpen = urlObj.toString();
 
       opn(urlToOpen);
       nl();

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -4,6 +4,7 @@ import { BottomBar } from '../Helper/BottomBar';
 import { dim, green, l, nl, red } from '../Helper/Logging';
 import { getCurrentIntegration } from '../Helper/Wizard';
 import { BaseStep } from './BaseStep';
+import { mapIntegrationToPlatform } from '../Constants';
 
 const opn = require('opn');
 const r2 = require('r2');
@@ -29,7 +30,16 @@ export class OpenSentry extends BaseStep {
 
       BottomBar.hide();
 
-      const urlToOpen = `${baseUrl}account/settings/wizard/${data.hash}/`;
+      let urlToOpen = `${baseUrl}account/settings/wizard/${data.hash}/`;
+      if (this._argv.signup) {
+        urlToOpen += '?signup=1';
+        // integration maps to platform in the wizard
+        if (this._argv.integration) {
+          urlToOpen += `&project_platform=${mapIntegrationToPlatform(
+            this._argv.integration,
+          )}`;
+        }
+      }
 
       opn(urlToOpen);
       nl();

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -1,10 +1,10 @@
 import { Answers } from 'inquirer';
 
+import { mapIntegrationToPlatform } from '../Constants';
 import { BottomBar } from '../Helper/BottomBar';
 import { dim, green, l, nl, red } from '../Helper/Logging';
 import { getCurrentIntegration } from '../Helper/Wizard';
 import { BaseStep } from './BaseStep';
-import { mapIntegrationToPlatform } from '../Constants';
 
 const opn = require('opn');
 const r2 = require('r2');

--- a/lib/Steps/SentryProjectSelector.ts
+++ b/lib/Steps/SentryProjectSelector.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 
 import { BaseStep } from './BaseStep';
 
-function sleep(n): Promise<void> {
+function sleep(n: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, n));
 }
 

--- a/lib/Steps/SentryProjectSelector.ts
+++ b/lib/Steps/SentryProjectSelector.ts
@@ -3,6 +3,10 @@ import * as _ from 'lodash';
 
 import { BaseStep } from './BaseStep';
 
+function sleep(n): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, n));
+}
+
 export class SentryProjectSelector extends BaseStep {
   public async emit(answers: Answers): Promise<any> {
     this.debug(answers);
@@ -22,6 +26,9 @@ export class SentryProjectSelector extends BaseStep {
     let selectedProject = null;
     if (answers.wizard.projects.length === 1) {
       selectedProject = { selectedProject: answers.wizard.projects[0] };
+      // the wizard CLI closes too quickly when we skip the prompt
+      // as it will cause the UI to be stuck saying Waiting for wizard to connect
+      await sleep(1000);
     } else {
       selectedProject = await prompt([
         {


### PR DESCRIPTION
This PR adds the `project_platform` query parameter if we set the `signup` and `integration` option when running the wizard. The purpose of this is so we can automatically create that project during signup as implemented [here](https://github.com/getsentry/getsentry/pull/9122).

Note we shouldn't merge this until all the dependent PRs are merged.