### PR TITLE
automatic merging of next.config.js files

### DIFF
--- a/lib/Helper/MergeConfig.ts
+++ b/lib/Helper/MergeConfig.ts
@@ -1,0 +1,165 @@
+import * as fs from 'fs';
+import * as ts from 'ts';
+
+// checks if statement uses module.exports format
+function isModuleExport(statement: ts.Statement) {
+  if (statement.kind !== ts.SyntaxKind.ExpressionStatement) {
+    return false;
+  }
+  if (!statement.expression) {
+    return false;
+  }
+  const { left } = statement.expression;
+  // check if this is module.exports
+  return (
+    left.expression?.escapedText === 'module' &&
+    left.name?.escapedText === 'exports'
+  );
+}
+
+// checks if statement uses default export format
+function isDefaultExport(statement: ts.Statement) {
+  if (statement.kind !== ts.SyntaxKind.ExportAssignment) {
+    return false;
+  }
+  if (!statement.expression) {
+    return false;
+  }
+  return true;
+}
+
+// finds the the source variable name from the statement
+function getSourceVariableName(statement: ts.Statement, sourceText: string) {
+  let sourceVariableName, declarationText;
+  if (isModuleExport(statement)) {
+    const { right } = statement.expression;
+
+    // modules.exports = () => ({...})
+    if (
+      right?.kind === ts.SyntaxKind.ArrowFunction ||
+      right?.kind === ts.SyntaxKind.FunctionExpression
+    ) {
+      ({ sourceVariableName, declarationText } = parseFunction(
+        statement,
+        sourceText,
+      ));
+    }
+    // module.exports = {...}
+    else {
+      sourceVariableName = right?.escapedText;
+    }
+  }
+  // default export {...}
+  else if (isDefaultExport(statement)) {
+    sourceVariableName = statement.expression.escapedText;
+  }
+  return { variableName: sourceVariableName, text: declarationText };
+}
+
+// merges the config files
+function mergeOutput({
+  topText,
+  declarationText,
+  sourcePath,
+  templatePath,
+}: {
+  topText: string;
+  declarationText: string;
+  sourcePath: string;
+  templatePath: string;
+}) {
+  const baseFile = fs.readFileSync(templatePath, 'utf8');
+  const newText = baseFile
+    .replace('// INSERT TOP TEXT', topText)
+    .replace('// INSERT CONFIG TEXT', declarationText);
+  fs.writeFileSync(sourcePath, newText);
+}
+
+// parses the function statement for source variable name and declaration text
+function parseFunction(funcStatement: ts.Statement, sourceText: string) {
+  const { right } = funcStatement.expression;
+
+  let sourceVariableName, declarationText;
+
+  const functionStatement = right?.body.statements;
+  if (functionStatement) {
+    sourceVariableName =
+      functionStatement[functionStatement.length - 1].expression.escapedText;
+
+    if (functionStatement[0].declarationList) {
+      declarationText = getDeclaration(
+        functionStatement[0].declarationList,
+        sourceText,
+      );
+    }
+  }
+  return { sourceVariableName, declarationText };
+}
+
+// gets the declaration text from non-function statements
+function getDeclaration(
+  declarationList: ts.VariableDeclarationList,
+  sourceText: string,
+) {
+  const declaration = declarationList.declarations[0];
+  const { initializer } = declaration;
+  const text = sourceText.substring(initializer.pos, initializer.end).trim();
+  if (text[0] === '{' && text[text.length - 1] === '}') {
+    return text.substring(1, text.length - 1);
+  }
+}
+
+// merges the config files
+export function mergeConfigFile(sourcePath: string, templatePath: string) {
+  const node = ts.createSourceFile(
+    'sourceText.ts', // fileName
+    fs.readFileSync(sourcePath, 'utf8'), // sourceText
+    ts.ScriptTarget.Latest, // langugeVersion
+  );
+
+  const sourceText = node.text;
+
+  let topText = '',
+    declarationText,
+    sourceVariableName;
+
+  for (const statement of node.statements) {
+    const { variableName, text } = getSourceVariableName(statement, sourceText);
+    if (text) {
+      declarationText = text;
+    }
+    if (variableName) {
+      sourceVariableName = variableName;
+    }
+
+    if (statement.declarationList) {
+      declarationText = getDeclaration(statement.declarationList, sourceText);
+    }
+
+    if (statement.kind === ts.SyntaxKind.ImportDeclaration) {
+      let defaultImport = '',
+        namedImports = '',
+        separator = '';
+
+      if (statement.importClause.name) {
+        defaultImport = statement.importClause.name.escapedText;
+      }
+      if (statement.importClause.namedBindings) {
+        namedImports = `{${statement.importClause.namedBindings.elements
+          .map((el: ts.ImportSpecifier) => el.name.escapedText)
+          .join(', ')}}`;
+      }
+      if (defaultImport && namedImports) {
+        separator = ', ';
+      }
+      topText = topText.concat(
+        `import ${defaultImport}${separator}${namedImports} from "${statement.moduleSpecifier.text}";\n`,
+      );
+    }
+  }
+  if (declarationText) {
+    mergeOutput({ topText, declarationText, sourcePath, templatePath });
+    return true;
+  }
+  return false;
+}

--- a/scripts/NextJs/configs/next.config.template.js
+++ b/scripts/NextJs/configs/next.config.template.js
@@ -1,0 +1,38 @@
+// This file sets a custom webpack configuration to use your Next.js app
+// with Sentry.
+// https://nextjs.org/docs/api-reference/next.config.js/introduction
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+// INSERT TOP TEXT
+
+const { withSentryConfig } = require('@sentry/nextjs');
+
+/** @type {import('next').NextConfig} */
+const moduleExports = {
+  sentry: {
+    // Use `hidden-source-map` rather than `source-map` as the Webpack `devtool`
+    // for client-side builds. (This will be the default starting in
+    // `@sentry/nextjs` version 8.0.0.) See
+    // https://webpack.js.org/configuration/devtool/ and
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
+    // for more information.
+    hideSourceMaps: true,
+  },
+  // INSERT CONFIG TEXT
+};
+
+const sentryWebpackPluginOptions = {
+  // Additional config options for the Sentry Webpack plugin. Keep in mind that
+  // the following options are set automatically, and overriding them is not
+  // recommended:
+  //   release, url, org, project, authToken, configFile, stripPrefix,
+  //   urlPrefix, include, ignore
+
+  silent: true, // Suppresses all logs
+  // For all available options, see:
+  // https://github.com/getsentry/sentry-webpack-plugin#options.
+};
+
+// Make sure adding Sentry options is the last code to run before exporting, to
+// ensure that your source maps include changes from all other Webpack plugins
+module.exports = withSentryConfig(moduleExports, sentryWebpackPluginOptions);


### PR DESCRIPTION
This pr adds in automatic merging of the next.config.js files. If there is no existing next.config.js file, then we will add the existing default next.config.js file in. If we are able to merge Sentry's with the existing, then the file will be updated (with the original saved as next.config.original.js). If we are unable to merge, we will create a template file and ask them to merge (the status quo approach) . 