### PR TITLE
feat(promotions): promo code option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat: Add logic to add @sentry/nextjs if it's missing when running the wizard (#219)
 - fix: Print localhost with `http` instead of `https` (#212)
 - feat: Add project_platform as query param if -s and -i are set (#221)
+- feat: Add promo code option used for signup flows (#223)
 
 ## 2.4.0
 

--- a/bin.ts
+++ b/bin.ts
@@ -47,6 +47,10 @@ const argv = require('yargs')
     default: false,
     describe: 'Redirect to signup page if not logged in',
     type: 'boolean',
+  })
+  .option('promo-code', {
+    alias: 'promo-code',
+    describe: 'A promo code that will be applied during signup',
   }).argv;
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -75,6 +75,7 @@ export interface Args {
   skipConnect: boolean;
   quiet: boolean;
   signup: boolean;
+  promoCode?: string;
 }
 
 export const DEFAULT_URL = 'https://sentry.io/';

--- a/lib/Helper/Wizard.ts
+++ b/lib/Helper/Wizard.ts
@@ -27,6 +27,8 @@ function sanitizeAndValidateArgs(argv: Args): void {
     // @ts-ignore skip-connect does not exist on args
     delete argv['skip-connect'];
   }
+  // @ts-ignore skip-connect does not exist on args
+  argv.promoCode = argv['promo-code'];
 }
 
 export function getCurrentIntegration(answers: Answers): BaseIntegration {

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -42,7 +42,7 @@ export class OpenSentry extends BaseStep {
           );
         }
         if (this._argv.promoCode) {
-          urlObj.searchParams.set('promo_code', this._argv.promoCode);
+          urlObj.searchParams.set('code', this._argv.promoCode);
         }
       }
 

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -41,6 +41,9 @@ export class OpenSentry extends BaseStep {
             mapIntegrationToPlatform(this._argv.integration),
           );
         }
+        if (this._argv.promoCode) {
+          urlObj.searchParams.set('promo_code', this._argv.promoCode);
+        }
       }
 
       const urlToOpen = urlObj.toString();


### PR DESCRIPTION
This PR adds an option called `--promo-code` that will pre-fill in the promo code field during signup as shown below. Note this argument only means anything if the `-s` signup argument is passed and the user is currently not logged in. We intend to use this option for specific campaigns to give folks discounts when signing up from this flow.

<img width="663" alt="Screen Shot 2023-01-06 at 1 10 03 PM" src="https://user-images.githubusercontent.com/8533851/211100632-80beda23-bdaf-4a72-9f98-3d2428a1fcbe.png">
