### PR TITLE
feat(nextjs): Add `sentry.edge.config.js` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(nextjs): Add sentry.edge.config.js template (#227)
+
 ## 2.4.1
 
 - feat: Add logic to add @sentry/nextjs if it's missing when running the wizard (#219)

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -30,6 +30,7 @@ const TEMPLATE_DESTINATIONS: { [key: string]: string[] } = {
   'next.config.js': ['.'],
   'sentry.server.config.js': ['.'],
   'sentry.client.config.js': ['.'],
+  'sentry.edge.config.js': ['.'],
 };
 
 let appPackage: any = {};

--- a/scripts/NextJs/configs/sentry.edge.config.js
+++ b/scripts/NextJs/configs/sentry.edge.config.js
@@ -1,0 +1,17 @@
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever middleware or an Edge route handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from '@sentry/nextjs';
+
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+Sentry.init({
+  dsn: SENTRY_DSN || '___DSN___',
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+  // ...
+  // Note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
+});


### PR DESCRIPTION
Release [`7.31.0`](https://github.com/getsentry/sentry-javascript/releases/tag/7.31.0) of the Next.js SDK allows for error and performance instrumentation on Next.js middleware and edge routes but requires users to set up an additional `init` call in a separate file.

This PR adds that file to the templates the Wizards creates.