### PR TITLE
fix(rn): Change RN Android app/build.gradle patch to match android section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: Merge next.config.js files automatically (#222)
+- feat(rn): Support patching app/build.gradle RN 0.71.0 and Expo SDK 43+ bare workflow ([#229](https://github.com/getsentry/sentry-wizard/pull/229))
 
 ## 2.4.2
 

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -13,6 +13,12 @@ import { MobileProject } from './MobileProject';
 const xcode = require('xcode');
 
 export class ReactNative extends MobileProject {
+
+  /**
+   * All React Native versions have app/build.gradle with android section.
+   */
+  private static buildGradleAndroidSectionBeginning: RegExp = /^android {/m;
+
   protected _answers: Answers;
   protected _sentryCli: SentryCli;
 
@@ -220,11 +226,12 @@ export class ReactNative extends MobileProject {
     if (contents.indexOf(applyFrom) >= 0) {
       return Promise.resolve(null);
     }
+
     return Promise.resolve(
       contents.replace(
-        /^apply from: "..\/..\/node_modules\/react-native\/react.gradle"/m,
+        ReactNative.buildGradleAndroidSectionBeginning,
         // eslint-disable-next-line prefer-template
-        match => match + '\n' + applyFrom,
+        match => applyFrom + '\n' + match,
       ),
     );
   }

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -17,7 +17,7 @@ export class ReactNative extends MobileProject {
   /**
    * All React Native versions have app/build.gradle with android section.
    */
-  private static buildGradleAndroidSectionBeginning: RegExp = /^android {/m;
+  private static _buildGradleAndroidSectionBeginning: RegExp = /^android {/m;
 
   protected _answers: Answers;
   protected _sentryCli: SentryCli;
@@ -229,7 +229,7 @@ export class ReactNative extends MobileProject {
 
     return Promise.resolve(
       contents.replace(
-        ReactNative.buildGradleAndroidSectionBeginning,
+        ReactNative._buildGradleAndroidSectionBeginning,
         // eslint-disable-next-line prefer-template
         match => applyFrom + '\n' + match,
       ),

--- a/lib/Steps/Integrations/__tests__/ReactNative.ts
+++ b/lib/Steps/Integrations/__tests__/ReactNative.ts
@@ -1,7 +1,7 @@
 jest.mock('../../../Helper/Logging.ts'); // We mock logging to not pollute the output
 import * as fs from 'fs';
-import * as path from 'path';
 import { Answers } from 'inquirer';
+import * as path from 'path';
 import * as process from 'process';
 import * as rimraf from 'rimraf';
 

--- a/lib/Steps/Integrations/__tests__/ReactNative.ts
+++ b/lib/Steps/Integrations/__tests__/ReactNative.ts
@@ -1,5 +1,6 @@
 jest.mock('../../../Helper/Logging.ts'); // We mock logging to not pollute the output
 import * as fs from 'fs';
+import * as path from 'path';
 import { Answers } from 'inquirer';
 import * as process from 'process';
 import * as rimraf from 'rimraf';
@@ -10,8 +11,10 @@ import { ReactNative } from '../ReactNative';
 const testDir = 'rn-test';
 const iosIndexJs = 'index.ios.js';
 const appTsx = 'src/App.tsx';
+const appBuildGradle = 'android/app/build.gradle';
 
 const dummyJsContent = 'import React from "react";\n';
+const dummyAppBuildGradleContent = 'apply plugin: "com.facebook.react"\n\nandroid {\n}\n';
 
 const testArgs = {
   debug: false,
@@ -23,8 +26,17 @@ const testArgs = {
   url: 'https://not.used',
 };
 
-const testAnswers: Answers = {
+const mockIosAnswers: Answers = {
   shouldConfigurePlatforms: { 'ios': true },
+  config: {
+    dsn: {
+      public: 'dns.public.com',
+    },
+  },
+};
+
+const mockAndroidAnswers: Answers = {
+  shouldConfigurePlatforms: { 'android': true },
   config: {
     dsn: {
       public: 'dns.public.com',
@@ -41,8 +53,10 @@ describe('ReactNative', () => {
     fs.mkdirSync(testDir);
     process.chdir(testDir);
     fs.writeFileSync(iosIndexJs, dummyJsContent);
-    fs.mkdirSync('src');
+    fs.mkdirSync(path.dirname(appTsx), { recursive: true });
     fs.writeFileSync(appTsx, dummyJsContent);
+    fs.mkdirSync(path.dirname(appBuildGradle), { recursive: true });
+    fs.writeFileSync(appBuildGradle, dummyAppBuildGradleContent);
   });
 
   afterEach(() => {
@@ -52,7 +66,7 @@ describe('ReactNative', () => {
 
   test('patches js files', async () => {
     const project = new ReactNative(testArgs as Args);
-    await project.emit(testAnswers);
+    await project.emit(mockIosAnswers);
 
     const patchedIosIndexJs = fs.readFileSync(iosIndexJs, 'utf8');
     const patchedAppTsx = fs.readFileSync(appTsx, 'utf8');
@@ -63,5 +77,16 @@ describe('ReactNative', () => {
       '});\n\n';
     expect(patchedIosIndexJs).toEqual(expectedPatch);
     expect(patchedAppTsx).toEqual(expectedPatch);
+  });
+
+  test('patches android app build gradle file', async () => {
+    const project = new ReactNative(testArgs as Args);
+    await project.emit(mockAndroidAnswers);
+
+    const patchedAppBuildGradle = fs.readFileSync(appBuildGradle, 'utf8');
+    const expectedPatch = 'apply plugin: "com.facebook.react"\n\n' +
+      'apply from: "../../node_modules/@sentry/react-native/sentry.gradle"\n' +
+      'android {\n}\n';
+    expect(patchedAppBuildGradle).toEqual(expectedPatch);
   });
 });


### PR DESCRIPTION
Fixes changes in RN 0.71 and Expo since version 43.

## Context
- https://github.com/getsentry/sentry-react-native/issues/2757
- https://github.com/getsentry/sentry-wizard/issues/225

closes: https://github.com/getsentry/sentry-wizard/issues/225