### PR TITLE
Fix typo: `hideSourcemaps` → `hideSourceMaps`

### DIFF
--- a/lib/Helper/test-fixtures/next.config.1-merged.js
+++ b/lib/Helper/test-fixtures/next.config.1-merged.js
@@ -14,5 +14,5 @@ module.exports = nextConfig;
 module.exports = withSentryConfig(
   module.exports,
   { silent: true },
-  { hideSourcemaps: true },
+  { hideSourceMaps: true },
 );

--- a/lib/Helper/test-fixtures/next.config.3-merged.js
+++ b/lib/Helper/test-fixtures/next.config.3-merged.js
@@ -17,5 +17,5 @@ module.exports = nextConfig;
 module.exports = withSentryConfig(
   module.exports,
   { silent: true },
-  { hideSourcemaps: true },
+  { hideSourceMaps: true },
 );

--- a/lib/Helper/test-fixtures/next.config.4-merged.js
+++ b/lib/Helper/test-fixtures/next.config.4-merged.js
@@ -17,5 +17,5 @@ module.exports = (phase, { defaultConfig }) => {
 module.exports = withSentryConfig(
   module.exports,
   { silent: true },
-  { hideSourcemaps: true },
+  { hideSourceMaps: true },
 );

--- a/scripts/NextJs/configs/next.config.template.js
+++ b/scripts/NextJs/configs/next.config.template.js
@@ -8,5 +8,5 @@ const { withSentryConfig } = require('@sentry/nextjs');
 module.exports = withSentryConfig(
   module.exports,
   { silent: true },
-  { hideSourcemaps: true },
+  { hideSourceMaps: true },
 );


### PR DESCRIPTION
This PR fixes a small typo in the template for "next.config.js" which [triggers a build warning](https://github.com/getsentry/sentry-javascript/blob/master/packages/nextjs/src/config/webpack.ts#L612) that `hideSourceMaps` is unset.