### PR TITLE
Fix the typo in the sentry option array

### DIFF
--- a/scripts/NextJs/configs/next.config.template.js
+++ b/scripts/NextJs/configs/next.config.template.js
@@ -8,5 +8,5 @@ const { withSentryConfig } = require('@sentry/nextjs');
 module.exports = withSentryConfig(
   module.exports,
   { silent: true },
-  { hideSourcemaps: true },
+  { hideSourceMaps: true },
 );


### PR DESCRIPTION
According to TS types and documentation, the spelling of the option is `hideSourceMaps`