### PR TITLE
fix(rn): Upload debug files from `$DWARF_DSYM_FOLDER_PATH` during Xcode build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(rn): Upload debug files from `$DWARF_DSYM_FOLDER_PATH` during Xcode build
+- fix(rn): Upload debug files from `$DWARF_DSYM_FOLDER_PATH` during Xcode build ([#240](https://github.com/getsentry/sentry-wizard/pull/240))
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(rn): Upload debug files from `$DWARF_DSYM_FOLDER_PATH` during Xcode build
+
 ## 2.6.0
 
 - feat(rn): Support patching app/build.gradle RN 0.71.0 and Expo SDK 43+ bare workflow ([#229](https://github.com/getsentry/sentry-wizard/pull/229))

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -290,7 +290,7 @@ export class ReactNative extends MobileProject {
         shellScript:`
 export SENTRY_PROPERTIES=sentry.properties
 [[ $SENTRY_INCLUDE_NATIVE_SOURCES == "true" ]] && INCLUDE_SOURCES_FLAG="--include-sources" || INCLUDE_SOURCES_FLAG=""
-../node_modules/@sentry/cli/bin/sentry-cli debug-files upload "$INCLUDE_SOURCES_FLAG"
+../node_modules/@sentry/cli/bin/sentry-cli debug-files upload "$INCLUDE_SOURCES_FLAG" "$DWARF_DSYM_FOLDER_PATH"
 `,
       },
     );


### PR DESCRIPTION
- context: https://github.com/getsentry/sentry-docs/pull/6490

Reading from the env was removed in `sentry-cli` v2.
- https://github.com/getsentry/sentry-cli/pull/1172/files#diff-cb8bf951f1ff97b04c8463d418fd8439d96fcd0724b12fff24b07113e6447b7dL227