### PR TITLE
feat(sveltekit): Add SvelteKit menu option and SDK installation

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -4,6 +4,7 @@ export enum Integration {
   cordova = 'cordova',
   electron = 'electron',
   nextjs = 'nextjs',
+  sveltekit = 'sveltekit',
 }
 
 /** Key value should be the same here */
@@ -39,6 +40,8 @@ export function getIntegrationDescription(type: string): string {
       return 'Electron';
     case Integration.nextjs:
       return 'Next.js';
+    case Integration.sveltekit:
+      return 'SvelteKit';
     default:
       return 'React Native';
   }
@@ -54,6 +57,8 @@ export function mapIntegrationToPlatform(type: string): string {
       return 'javascript-electron';
     case Integration.nextjs:
       return 'javascript-nextjs';
+    case Integration.sveltekit:
+      return 'javascript-sveltekit';
     default:
       throw new Error(`Unknown integration ${type}`);
   }

--- a/lib/Helper/Package.ts
+++ b/lib/Helper/Package.ts
@@ -59,3 +59,20 @@ function fulfillsVersionRange(
       : satisfies(cleanedUserVersion, acceptableVersions))
   );
 }
+
+/**
+ * Determines if the passed `package.json` object has the passed package installed.
+ *
+ * @param appPackage The `package.json` object
+ * @param packageName The name of the package to check for
+ *
+ * @returns `true` if the package is installed, `false` otherwise
+ */
+export function hasPackageInstalled(
+  appPackage: Record<string, any>,
+  packageName: string,
+): boolean {
+  const depsVersion = appPackage.dependencies[packageName];
+  const devDepsVersion = appPackage.devDependencies[packageName];
+  return !!depsVersion || !!devDepsVersion;
+}

--- a/lib/Helper/PackageManager.ts
+++ b/lib/Helper/PackageManager.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 
 import { green } from './Logging';
 
-export function getPackageMangerChoice(): PackageManager | null {
+export function getPackageManagerChoice(): PackageManager | null {
   if (fs.existsSync(path.join(process.cwd(), Yarn.LOCK_FILE))) {
     return new Yarn();
   }

--- a/lib/Steps/ChooseIntegration.ts
+++ b/lib/Steps/ChooseIntegration.ts
@@ -8,6 +8,7 @@ import { Cordova } from './Integrations/Cordova';
 import { Electron } from './Integrations/Electron';
 import { NextJs } from './Integrations/NextJs';
 import { ReactNative } from './Integrations/ReactNative';
+import { SvelteKit } from './Integrations/SvelteKit';
 
 let projectPackage: any = {};
 
@@ -53,6 +54,9 @@ export class ChooseIntegration extends BaseStep {
         break;
       case Integration.nextjs:
         integration = new NextJs(this._argv);
+        break;
+      case Integration.sveltekit:
+        integration = new SvelteKit(this._argv);
         break;
       default:
         integration = new ReactNative(this._argv);

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -9,8 +9,8 @@ import * as path from 'path';
 import type { Args } from '../../Constants';
 import { debug, green, l, nl, red } from '../../Helper/Logging';
 import { mergeConfigFile } from '../../Helper/MergeConfig';
-import { checkPackageVersion } from '../../Helper/Package';
-import { getPackageMangerChoice } from '../../Helper/PackageManager';
+import { checkPackageVersion, hasPackageInstalled } from '../../Helper/Package';
+import { getPackageManagerChoice } from '../../Helper/PackageManager';
 import type { SentryCliProps } from '../../Helper/SentryCli';
 import { SentryCli } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
@@ -116,8 +116,8 @@ export class NextJs extends BaseIntegration {
       true,
     );
 
-    const packageManager = getPackageMangerChoice();
-    const hasSdkInstalled = this._hasPackageInstalled('@sentry/nextjs');
+    const packageManager = getPackageManagerChoice();
+    const hasSdkInstalled = hasPackageInstalled(appPackage, '@sentry/nextjs');
 
     let hasCompatibleSdkVersion = false;
     // if no package but we have nextjs, let's add it if we can
@@ -253,7 +253,7 @@ export class NextJs extends BaseIntegration {
     // next.config.template.js used for merging next.config.js , not its own template,
     // so it shouldn't have a setTemplate call
     const filteredTemplates = templates.filter(
-      (template) => template !== 'next.config.template.js',
+      template => template !== 'next.config.template.js',
     );
     for (const template of filteredTemplates) {
       await this._setTemplate(
@@ -341,12 +341,6 @@ export class NextJs extends BaseIntegration {
     const templateContent = fs.readFileSync(sourcePath).toString();
     const filledTemplate = templateContent.replace('___DSN___', dsn);
     fs.writeFileSync(targetPath, filledTemplate);
-  }
-
-  private _hasPackageInstalled(packageName: string): boolean {
-    const depsVersion = _.get(appPackage, ['dependencies', packageName]);
-    const devDepsVersion = _.get(appPackage, ['devDependencies', packageName]);
-    return !!depsVersion || !!devDepsVersion;
   }
 
   private _spliceInPlace(

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -16,7 +16,7 @@ import {
 } from '../../Helper/File';
 import { dim, green, nl, red } from '../../Helper/Logging';
 import { checkPackageVersion } from '../../Helper/Package';
-import { getPackageMangerChoice } from '../../Helper/PackageManager';
+import { getPackageManagerChoice } from '../../Helper/PackageManager';
 import { SentryCli } from '../../Helper/SentryCli';
 import { MobileProject } from './MobileProject';
 
@@ -55,7 +55,7 @@ export class ReactNative extends MobileProject {
     nl();
 
     let userAnswers: Answers = { continue: true };
-    const packageManager = getPackageMangerChoice();
+    const packageManager = getPackageManagerChoice();
 
     const hasCompatibleReactNativeVersion = checkPackageVersion(
       this._readAppPackage(),

--- a/lib/Steps/Integrations/SvelteKit.ts
+++ b/lib/Steps/Integrations/SvelteKit.ts
@@ -1,0 +1,99 @@
+import { info } from 'console';
+import type { Answers } from 'inquirer';
+import { prompt } from 'inquirer';
+import * as path from 'path';
+
+import type { Args } from '../../Constants';
+import { nl } from '../../Helper/Logging';
+import { checkPackageVersion, hasPackageInstalled } from '../../Helper/Package';
+import { getPackageManagerChoice } from '../../Helper/PackageManager';
+import { SentryCli } from '../../Helper/SentryCli';
+import { BaseIntegration } from './BaseIntegration';
+
+const SVELTEKIT_SDK_PACKAGE = '@sentry/sveltekit';
+const COMPATIBLE_SVELTEKIT_VERSIONS = '>=1.0.0';
+const COMPATIBLE_SDK_VERSIONS = '>=7.48.0';
+
+let appPackage: any = {};
+
+try {
+  appPackage = require(path.join(process.cwd(), 'package.json'));
+} catch {
+  // We don't need to have this
+}
+
+export class SvelteKit extends BaseIntegration {
+  private _sentryCli: SentryCli;
+  public constructor(protected _argv: Args) {
+    super(_argv);
+    this._sentryCli = new SentryCli(this._argv);
+  }
+
+  public async emit(_answers: Answers): Promise<Answers> {
+    info('Setting up SvelteKit SDK');
+
+    // TODO: The actual SDK setup
+
+    return {};
+  }
+
+  public async shouldConfigure(_answers: Answers): Promise<Answers> {
+    if (this._shouldConfigure) {
+      return this._shouldConfigure;
+    }
+
+    nl();
+
+    let userAnswers: Answers = { continue: true };
+    const hasCompatibleSvelteKitVersion = checkPackageVersion(
+      appPackage,
+      '@sveltejs/kit',
+      COMPATIBLE_SVELTEKIT_VERSIONS,
+      true,
+    );
+
+    const packageManager = getPackageManagerChoice();
+    const hasSdkInstalled = hasPackageInstalled(
+      appPackage,
+      SVELTEKIT_SDK_PACKAGE,
+    );
+
+    let hasCompatibleSdkVersion = false;
+    // if no SDK is installed but SvelteKit was detected, let's add the SDK if we can
+    if (!hasSdkInstalled && packageManager && hasCompatibleSvelteKitVersion) {
+      await packageManager.installPackage(SVELTEKIT_SDK_PACKAGE);
+      // can assume it's compatible since we just installed it
+      hasCompatibleSdkVersion = true;
+    } else {
+      // otherwise, let's check the version and spit out the appropriate error
+      hasCompatibleSdkVersion = checkPackageVersion(
+        appPackage,
+        SVELTEKIT_SDK_PACKAGE,
+        COMPATIBLE_SDK_VERSIONS,
+        true,
+      );
+    }
+    const hasAllPackagesCompatible =
+      hasCompatibleSvelteKitVersion && hasCompatibleSdkVersion;
+
+    if (!hasAllPackagesCompatible && !this._argv.quiet) {
+      userAnswers = await prompt({
+        message:
+          'There were errors while checking your project config. Do you still want to continue?',
+        name: 'continue',
+        default: false,
+        type: 'confirm',
+      });
+    }
+
+    nl();
+
+    if (!userAnswers['continue']) {
+      throw new Error('Please install the required dependencies to continue.');
+    }
+
+    this._shouldConfigure = Promise.resolve({ sveltekit: true });
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    return this.shouldConfigure;
+  }
+}


### PR DESCRIPTION
This PR marks the first step of adding Wizard support for the SvelteKit SDK:

* Add `SvelteKit` integration class
* SvelteKit can be selected in the integration selection prompt
* Support for `-i sveltekit` option
* Check if compatible SvelteKit version or SvelteKit SDK version is installed
* Install `@sentry/sveltekit` package if not yet installed

I'm not sure about the release cadence of the wizard. Happy to merge the steps into a branch for now and release in one go later on if we don't want the halfway-finished SvelteKit menu option to show up before it is finished. 

For now:
#skip-changelog

ref #244 