### PR TITLE
feat(sveltekit): Create Sentry CLI config files

### DIFF
--- a/lib/Helper/Git.ts
+++ b/lib/Helper/Git.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+
+import { green, red } from './Logging';
+
+const GITIGNORE_FILENAME = '.gitignore';
+
+/**
+ * Adds the given file to the .gitignore file.
+ *
+ * @param filepath the file(path) to add to the .gitignore file
+ * @param errorMsg the error message to display if the file couldn't be added
+ */
+export async function addToGitignore(
+  filepath: string,
+  errorMsg: string,
+): Promise<void> {
+  /**
+   * Don't check whether the given file is ignored because:
+   * 1. It's tricky to check it without git.
+   * 2. Git might not be installed or accessible.
+   * 3. It's convenient to use a module to interact with git, but it would
+   *    increase the size x2 approximately. Docs say to run the Wizard without
+   *    installing it, and duplicating the size would slow the set-up down.
+   * 4. The Wizard is meant to be run once.
+   * 5. A message is logged informing users it's been added to the gitignore.
+   * 6. It will be added to the gitignore as many times as it runs - not a big
+   *    deal.
+   * 7. It's straightforward to remove it from the gitignore.
+   */
+  try {
+    await fs.promises.appendFile(
+      GITIGNORE_FILENAME,
+      `\n# Sentry\n${filepath}\n`,
+    );
+    green(`✓ ${filepath} added to ${GITIGNORE_FILENAME}`);
+  } catch {
+    red(errorMsg);
+  }
+}

--- a/lib/Helper/SentryCli.ts
+++ b/lib/Helper/SentryCli.ts
@@ -89,9 +89,7 @@ export class SentryCli {
    * @param sentryCli instance of the Sentry CLI
    * @param cliProps the properties to write to the files
    */
-  public async createSentryCliConfig(
-    cliProps: SentryCliProps,
-  ): Promise<void> {
+  public async createSentryCliConfig(cliProps: SentryCliProps): Promise<void> {
     const { 'auth/token': authToken, ...cliPropsToWrite } = cliProps;
 
     /**

--- a/lib/Helper/SentryCli.ts
+++ b/lib/Helper/SentryCli.ts
@@ -1,8 +1,15 @@
+import * as fs from 'fs';
 import type { Answers } from 'inquirer';
 import * as _ from 'lodash';
 import * as path from 'path';
 
 import type { Args } from '../Constants';
+import { addToGitignore } from './Git';
+import { green, l, nl, red } from './Logging';
+
+const SENTRYCLIRC_FILENAME = '.sentryclirc';
+const GITIGNORE_FILENAME = '.gitignore';
+const PROPERTIES_FILENAME = 'sentry.properties';
 
 export interface SentryCliProps {
   [s: string]: string;
@@ -70,5 +77,74 @@ export class SentryCli {
       }
     }
     return dumpedSections.join('\n');
+  }
+
+  /**
+   * Creates `.sentryclirc` and `sentry.properties` files with the CLI properties
+   * obtained from the user answers (or from logging into Sentry).
+   * The `.sentryclirc` only contains the auth token and will be added to the
+   * user's `.gitignore` file. The properties file contains the rest of the
+   * properties (org, project, etc.).
+   *
+   * @param sentryCli instance of the Sentry CLI
+   * @param cliProps the properties to write to the files
+   */
+  public async createSentryCliConfig(
+    cliProps: SentryCliProps,
+  ): Promise<void> {
+    const { 'auth/token': authToken, ...cliPropsToWrite } = cliProps;
+
+    /**
+     * To not commit the auth token to the VCS, instead of adding it to the
+     * properties file (like the rest of props), it's added to the Sentry CLI
+     * config, which is added to the gitignore. This way makes the properties
+     * file safe to commit without exposing any auth tokens.
+     */
+    if (authToken) {
+      try {
+        await fs.promises.appendFile(
+          SENTRYCLIRC_FILENAME,
+          this.dumpConfig({ auth: { token: authToken } }),
+        );
+        green(`✓ Successfully added the auth token to ${SENTRYCLIRC_FILENAME}`);
+      } catch {
+        red(
+          `⚠ Could not add the auth token to ${SENTRYCLIRC_FILENAME}, ` +
+            `please add it to identify your user account:\n${authToken}`,
+        );
+        nl();
+      }
+    } else {
+      red(
+        `⚠ Did not find an auth token, please add your token to ${SENTRYCLIRC_FILENAME}`,
+      );
+      l(
+        'To generate an auth token, visit https://sentry.io/settings/account/api/auth-tokens/',
+      );
+      l(
+        'To learn how to configure Sentry CLI, visit ' +
+          'https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-sentry-cli',
+      );
+    }
+
+    await addToGitignore(
+      SENTRYCLIRC_FILENAME,
+      `⚠ Could not add ${SENTRYCLIRC_FILENAME} to ${GITIGNORE_FILENAME}, ` +
+        'please add it to not commit your auth key.',
+    );
+
+    try {
+      await fs.promises.writeFile(
+        `./${PROPERTIES_FILENAME}`,
+        this.dumpProperties(cliPropsToWrite),
+      );
+      green('✓ Successfully created sentry.properties');
+    } catch {
+      red(`⚠ Could not add org and project data to ${PROPERTIES_FILENAME}`);
+      l(
+        'See docs for a manual setup: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-sentry-cli',
+      );
+    }
+    nl();
   }
 }

--- a/lib/Steps/Integrations/NextJs.ts
+++ b/lib/Steps/Integrations/NextJs.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 import * as path from 'path';
 
 import type { Args } from '../../Constants';
+import { addToGitignore } from '../../Helper/Git';
 import { debug, green, l, nl, red } from '../../Helper/Logging';
 import { mergeConfigFile } from '../../Helper/MergeConfig';
 import { checkPackageVersion, hasPackageInstalled } from '../../Helper/Package';
@@ -196,7 +197,7 @@ export class NextJs extends BaseIntegration {
       );
     }
 
-    await this._addToGitignore(
+    await addToGitignore(
       SENTRYCLIRC_FILENAME,
       `⚠ Could not add ${SENTRYCLIRC_FILENAME} to ${GITIGNORE_FILENAME}, ` +
         'please add it to not commit your auth key.',
@@ -215,34 +216,6 @@ export class NextJs extends BaseIntegration {
       );
     }
     nl();
-  }
-
-  private async _addToGitignore(
-    filepath: string,
-    errorMsg: string,
-  ): Promise<void> {
-    /**
-     * Don't check whether the given file is ignored because:
-     * 1. It's tricky to check it without git.
-     * 2. Git might not be installed or accessible.
-     * 3. It's convenient to use a module to interact with git, but it would
-     *    increase the size x2 approximately. Docs say to run the Wizard without
-     *    installing it, and duplicating the size would slow the set-up down.
-     * 4. The Wizard is meant to be run once.
-     * 5. A message is logged informing users it's been added to the gitignore.
-     * 6. It will be added to the gitignore as many times as it runs - not a big
-     *    deal.
-     * 7. It's straightforward to remove it from the gitignore.
-     */
-    try {
-      await fs.promises.appendFile(
-        GITIGNORE_FILENAME,
-        `\n# Sentry\n${filepath}\n`,
-      );
-      green(`✓ ${filepath} added to ${GITIGNORE_FILENAME}`);
-    } catch {
-      red(errorMsg);
-    }
   }
 
   private async _createNextConfig(
@@ -378,7 +351,7 @@ export class NextJs extends BaseIntegration {
       const originalFilePath = path.join(destinationDir, originalFileName);
       // makes copy of original next.config.js
       fs.writeFileSync(originalFilePath, fs.readFileSync(destinationPath));
-      await this._addToGitignore(
+      await addToGitignore(
         originalFilePath,
         'Unable to add next.config.original.js to gitignore',
       );
@@ -397,7 +370,7 @@ export class NextJs extends BaseIntegration {
       } else {
         // if merge fails, we'll create a copy of the `next.config.js` template and ask them to merge
         fs.copyFileSync(templatePath, mergeableFilePath);
-        await this._addToGitignore(
+        await addToGitignore(
           mergeableFilePath,
           'Unable to add next.config.wizard.js template to gitignore',
         );

--- a/lib/Steps/Integrations/SvelteKit.ts
+++ b/lib/Steps/Integrations/SvelteKit.ts
@@ -29,8 +29,13 @@ export class SvelteKit extends BaseIntegration {
     this._sentryCli = new SentryCli(this._argv);
   }
 
-  public async emit(_answers: Answers): Promise<Answers> {
+  public async emit(answers: Answers): Promise<Answers> {
+    nl();
     info('Setting up SvelteKit SDK');
+
+    // const dsn = answers.config?.dsn?.public || null;
+    const sentryCliProps = this._sentryCli.convertAnswersToProperties(answers);
+    await this._sentryCli.createSentryCliConfig(sentryCliProps);
 
     // TODO: The actual SDK setup
 


### PR DESCRIPTION
This PR adds the creation of Sentry CLI config files to the SvelteKit SDK. Since the NextJS integration already does this, this PR extracts a couple of methods from the NextJS integration class to be reused for SvelteKit.

#skip-changelog

ref #244 