### PR TITLE
feat(sveltekit): Read hook file paths from `svelte.config.js`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.build.json",
 
     "compilerOptions": {
+        "moduleResolution": "node16",
+        "module": "node16",
         "types": [
             "node"
         ],


### PR DESCRIPTION
To respect custom hooks file locations that users can specifiy in `svelte.config.js`, we import the svelte config and use these custom paths if they're available. Otherwise, we fall back to the default paths.

This PR adjusts the `tsconfig.json` to use `node16` module resolution and code generation. This allows us to keep using tsc for the moment and preserve `await import` calls (so that they're not transpiled to `require`). I checked and it seems like the transpiled code is mostly equal to what we had before. However, reading the config will only work if users are using Node 16+. For older Node versions, the wizard will emit a warning and instruct people to use it with Node 16. IMO this is fine for the SvelteKit setup flow because SvelteKit requires Node 16 anyway as a minimum version.

closes #247 

#skip-changelog