### PR TITLE
chore(repo): Add `merge_target` option to prepare release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
+        default: master
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -26,3 +30,5 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}
+


### PR DESCRIPTION
cc @lforst 

#skip-changelog