### PR TITLE
feat(rn): Add code snippet to send the first Sentry Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ref(nextjs): Clean up minor things (#258)
 - ref(nextjs): Replace old Next.js wizard (#262)
+- feat(rn): Add code snippet to send the first Sentry Error
 
 ## 3.1.0
 

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -14,7 +14,7 @@ import {
   matchFiles,
   patchMatchingFile,
 } from '../../Helper/File';
-import { dim, green, nl, red } from '../../Helper/Logging';
+import { dim, green, l, nl, red } from '../../Helper/Logging';
 import { checkPackageVersion } from '../../Helper/Package';
 import { getPackageMangerChoice } from '../../Helper/PackageManager';
 import { SentryCli } from '../../Helper/SentryCli';
@@ -134,6 +134,21 @@ export class ReactNative extends MobileProject {
     );
 
     await Promise.all(promises);
+
+    l(`
+Please put the following code snippet into your application:
+
+<Button title="Try!" onPress={ () => { Sentry.captureException(new Error('First error')) }}/>
+`);
+
+    if (!this._argv.quiet) {
+      await prompt({
+        message: 'Are you done adding the snippet above to your application?',
+        name: 'snippet',
+        default: true,
+        type: 'confirm',
+      });
+    }
 
     return answers;
   }


### PR DESCRIPTION
- closes: https://github.com/getsentry/sentry-wizard/issues/261

![Screenshot 2023-04-26 at 14 54 40](https://user-images.githubusercontent.com/31292499/234581122-5f055ef9-b181-4adb-aaf2-1f3c2bb90a57.png)
