### PR TITLE
Update nextjs-templates.ts: fix spelling of Vercel

### DIFF
--- a/src/templates/nextjs-templates.ts
+++ b/src/templates/nextjs-templates.ts
@@ -104,7 +104,7 @@ export function getSentryConfigContents(
   } else if (config === 'edge') {
     primer = `// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
 // The config you add here will be used whenever one of the edge features is loaded.
-// Note that this config is unrelated to the Verel Edge Runtime and is also required when running locally.
+// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/`;
   }
 


### PR DESCRIPTION
#skip-changelog
