### PR TITLE
feat(sveltekit): Add example page creation

### DIFF
--- a/src/sveltekit/sdk-example.ts
+++ b/src/sveltekit/sdk-example.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+
+import { PartialSvelteConfig } from './sdk-setup';
+import {
+  getSentryExampleApiRoute,
+  getSentryExampleSveltePage,
+} from '../templates/sveltekit-templates';
+
+/**
+ * Creates example page and API route to test Sentry
+ */
+export async function createExamplePage(
+  svelteConfig: PartialSvelteConfig,
+  projectProps: {
+    selfHosted: boolean;
+    url: string;
+    orgSlug: string;
+    projectId: string;
+  },
+): Promise<void> {
+  const routesDirectory = svelteConfig.kit?.files?.routes || 'src/routes';
+  const exampleRoutePath = path.resolve(
+    path.join(routesDirectory, 'sentry-example'),
+  );
+
+  if (!fs.existsSync(routesDirectory)) {
+    clack.log.warn(
+      `Couldn't find your routes directory. Creating it now: ${routesDirectory}`,
+    );
+    fs.mkdirSync(routesDirectory, { recursive: true });
+  }
+
+  if (!fs.existsSync(exampleRoutePath)) {
+    fs.mkdirSync(exampleRoutePath);
+  } else {
+    clack.log.warn(
+      `It seems like a sentry example page already exists (${path.basename(
+        exampleRoutePath,
+      )}). Skipping creation of example route.`,
+    );
+    return;
+  }
+
+  await fs.promises.writeFile(
+    path.join(exampleRoutePath, '+page.svelte'),
+    getSentryExampleSveltePage(projectProps),
+  );
+
+  await fs.promises.writeFile(
+    path.join(exampleRoutePath, '+server.js'),
+    getSentryExampleApiRoute(),
+  );
+}

--- a/src/sveltekit/sdk-setup.ts
+++ b/src/sveltekit/sdk-setup.ts
@@ -17,21 +17,25 @@ import {
   getServerHooksTemplate,
 } from '../templates/sveltekit-templates';
 
-type PartialSvelteConfig = {
+const SVELTE_CONFIG_FILE = 'svelte.config.js';
+
+export type PartialSvelteConfig = {
   kit?: {
     files?: {
       hooks?: {
         client?: string;
         server?: string;
       };
+      routes?: string;
     };
   };
 };
 
-const SVELTE_CONFIG_FILE = 'svelte.config.js';
-
-export async function createOrMergeSvelteKitFiles(dsn: string): Promise<void> {
-  const { clientHooksPath, serverHooksPath } = await getHooksConfigDirs();
+export async function createOrMergeSvelteKitFiles(
+  dsn: string,
+  svelteConfig: PartialSvelteConfig,
+): Promise<void> {
+  const { clientHooksPath, serverHooksPath } = getHooksConfigDirs(svelteConfig);
 
   // full file paths with correct file ending (or undefined if not found)
   const originalClientHooksFile = findHooksFile(clientHooksPath);
@@ -64,11 +68,10 @@ export async function createOrMergeSvelteKitFiles(dsn: string): Promise<void> {
  * Attempts to read the svelte.config.js file to find the location of the hooks files.
  * If users specified a custom location, we'll use that. Otherwise, we'll use the default.
  */
-async function getHooksConfigDirs(): Promise<{
+function getHooksConfigDirs(svelteConfig: PartialSvelteConfig): {
   clientHooksPath: string;
   serverHooksPath: string;
-}> {
-  const svelteConfig = await loadSvelteConfig();
+} {
   const relativeUserClientHooksPath = svelteConfig?.kit?.files?.hooks?.client;
   const relativeUserServerHooksPath = svelteConfig?.kit?.files?.hooks?.server;
   const userClientHooksPath =
@@ -358,7 +361,7 @@ Skipping adding Sentry functionality to ${chalk.cyan(
   return false;
 }
 
-async function loadSvelteConfig(): Promise<PartialSvelteConfig> {
+export async function loadSvelteConfig(): Promise<PartialSvelteConfig> {
   const configFilePath = path.join(process.cwd(), SVELTE_CONFIG_FILE);
 
   try {

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -14,7 +14,8 @@ import {
   printWelcome,
   SentryProjectData,
 } from '../utils/clack-utils';
-import { createOrMergeSvelteKitFiles } from './sdk-setup';
+import { createExamplePage } from './sdk-example';
+import { createOrMergeSvelteKitFiles, loadSvelteConfig } from './sdk-setup';
 
 import { setupCLIConfig } from './sentry-cli-setup';
 
@@ -35,7 +36,7 @@ export async function runSvelteKitWizard(
   const packageJson = await getPackageDotJson();
   await ensurePackageIsInstalled(packageJson, '@sveltejs/kit', 'Sveltekit');
 
-  const { url: sentryUrl } = await askForSelfHosted();
+  const { url: sentryUrl, selfHosted } = await askForSelfHosted();
 
   const { projects, apiKeys } = await askForWizardLogin({
     promoCode: options.promoCode,
@@ -63,8 +64,10 @@ export async function runSvelteKitWizard(
 
   const dsn = selectedProject.keys[0].dsn.public;
 
+  const svelteConfig = await loadSvelteConfig();
+
   try {
-    await createOrMergeSvelteKitFiles(dsn);
+    await createOrMergeSvelteKitFiles(dsn, svelteConfig);
   } catch (e: unknown) {
     clack.log.error('Error while setting up the SvelteKit SDK:');
     clack.log.info(
@@ -79,9 +82,36 @@ export async function runSvelteKitWizard(
     return;
   }
 
+  try {
+    await createExamplePage(svelteConfig, {
+      selfHosted,
+      url: sentryUrl,
+      orgSlug: selectedProject.organization.slug,
+      projectId: selectedProject.id,
+    });
+  } catch (e: unknown) {
+    clack.log.error('Error while creating an example page to test Sentry:');
+    clack.log.info(
+      chalk.dim(
+        typeof e === 'object' && e != null && 'toString' in e
+          ? e.toString()
+          : typeof e === 'string'
+          ? e
+          : 'Unknown error',
+      ),
+    );
+    return;
+  }
+
   //TODO: Adjust the link once SvelteKit docs are live
+  //TODO: Also adjust the link in example page template!
   clack.outro(`
 ${chalk.green('Successfully installed the Sentry SvelteKit SDK!')}
+
+${chalk.cyan(
+  'You can validate your setup by starting your dev environment (`npm run dev`) and visiting "/sentry-example-page".',
+)}
+
 Check out the SDK documentation for further configuration:
 https://github.com/getsentry/sentry-javascript/blob/develop/packages/sveltekit/README.md
   `);

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -109,7 +109,7 @@ export async function runSvelteKitWizard(
 ${chalk.green('Successfully installed the Sentry SvelteKit SDK!')}
 
 ${chalk.cyan(
-  'You can validate your setup by starting your dev environment (`npm run dev`) and visiting "/sentry-example-page".',
+  'You can validate your setup by starting your dev environment (`npm run dev`) and visiting "/sentry-example".',
 )}
 
 Check out the SDK documentation for further configuration:

--- a/src/templates/sveltekit-templates.ts
+++ b/src/templates/sveltekit-templates.ts
@@ -123,7 +123,6 @@ Feel free to delete this file and the entire sentry route.
 
 <style>
   main {
-    /* min-height: 100vh; */
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/templates/sveltekit-templates.ts
+++ b/src/templates/sveltekit-templates.ts
@@ -40,3 +40,134 @@ export const handle = sequence(sentryHandle());
 export const handleError = handleErrorWithSentry();
 `;
 }
+
+/**
+ * +page.svelte with Sentry example
+ */
+export function getSentryExampleSveltePage(options: {
+  selfHosted: boolean;
+  url: string;
+  orgSlug: string;
+  projectId: string;
+}) {
+  const issuesPageLink = options.selfHosted
+    ? `${options.url}organizations/${options.orgSlug}/issues/?project=${options.projectId}`
+    : `https://${options.orgSlug}.sentry.io/issues/?project=${options.projectId}`;
+
+  return `<!-- 
+This is just a very simple API route that throws an example error.
+Feel free to delete this file and the entire sentry route.  
+-->
+
+<script>
+  import * as Sentry from '@sentry/sveltekit';
+
+  async function getSentryData() {
+    const transaction = Sentry.startTransaction({
+      name: 'Example Frontend Transaction'
+    });
+
+    Sentry.configureScope((scope) => {
+      scope.setSpan(transaction);
+    });
+
+    try {
+      const res = await fetch('/test-sentry');
+      if (!res.ok) {
+        throw new Error('Sentry Example Frontend Error');
+      }
+    } finally {
+      transaction.finish();
+    }
+  }
+</script>
+
+<div>
+  <head>
+    <title>Sentry Onboarding</title>
+    <meta name="description" content="Test Sentry for your SvelteKit app!" />
+  </head>
+
+  <main>
+    <h1>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44">
+        <path
+          fill="currentColor"
+          d="M124.32,28.28,109.56,9.22h-3.68V34.77h3.73V15.19l15.18,19.58h3.26V9.22h-3.73ZM87.15,23.54h13.23V20.22H87.14V12.53h14.93V9.21H83.34V34.77h18.92V31.45H87.14ZM71.59,20.3h0C66.44,19.06,65,18.08,65,15.7c0-2.14,1.89-3.59,4.71-3.59a12.06,12.06,0,0,1,7.07,2.55l2-2.83a14.1,14.1,0,0,0-9-3c-5.06,0-8.59,3-8.59,7.27,0,4.6,3,6.19,8.46,7.52C74.51,24.74,76,25.78,76,28.11s-2,3.77-5.09,3.77a12.34,12.34,0,0,1-8.3-3.26l-2.25,2.69a15.94,15.94,0,0,0,10.42,3.85c5.48,0,9-2.95,9-7.51C79.75,23.79,77.47,21.72,71.59,20.3ZM195.7,9.22l-7.69,12-7.64-12h-4.46L186,24.67V34.78h3.84V24.55L200,9.22Zm-64.63,3.46h8.37v22.1h3.84V12.68h8.37V9.22H131.08ZM169.41,24.8c3.86-1.07,6-3.77,6-7.63,0-4.91-3.59-8-9.38-8H154.67V34.76h3.8V25.58h6.45l6.48,9.2h4.44l-7-9.82Zm-10.95-2.5V12.6h7.17c3.74,0,5.88,1.77,5.88,4.84s-2.29,4.86-5.84,4.86Z M29,2.26a4.67,4.67,0,0,0-8,0L14.42,13.53A32.21,32.21,0,0,1,32.17,40.19H27.55A27.68,27.68,0,0,0,12.09,17.47L6,28a15.92,15.92,0,0,1,9.23,12.17H4.62A.76.76,0,0,1,4,39.06l2.94-5a10.74,10.74,0,0,0-3.36-1.9l-2.91,5a4.54,4.54,0,0,0,1.69,6.24A4.66,4.66,0,0,0,4.62,44H19.15a19.4,19.4,0,0,0-8-17.31l2.31-4A23.87,23.87,0,0,1,23.76,44H36.07a35.88,35.88,0,0,0-16.41-31.8l4.67-8a.77.77,0,0,1,1.05-.27c.53.29,20.29,34.77,20.66,35.17a.76.76,0,0,1-.68,1.13H40.6q.09,1.91,0,3.81h4.78A4.59,4.59,0,0,0,50,39.43a4.49,4.49,0,0,0-.62-2.28Z"
+        />
+      </svg>
+    </h1>
+    <p>
+      Get Started with this <strong>simple Example:</strong>
+    </p>
+
+    <p>1. Send us a sample error:</p>
+    <button
+      type="button"
+      on:click={getSentryData}>
+      Throw error!
+    </button>
+
+    <p>
+      2. Look for the error on the
+      <a href="${issuesPageLink}">Issues Page</a>.
+    </p>
+    <p style="margin-top: 24px;">
+      For more information, take a look at the
+      <a href="https://github.com/getsentry/sentry-javascript/blob/develop/packages/sveltekit/README.md">
+        Sentry SvelteKit Documentation
+      </a>
+    </p>
+  </main>
+</div>
+
+<style>
+  main {
+    /* min-height: 100vh; */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  h1 {
+    font-size: 4rem;
+    margin: 14px 0;
+  }
+
+  svg {
+    height: 1em;
+  }
+
+  button {
+    padding: 12px;
+    cursor: pointer;
+    background-color: rgb(54, 45, 89);
+    border-radius: 4px;
+    border: none;
+    color: white;
+    font-size: 1em;
+    margin: 1em;
+    transition: all 0.25s ease-in-out;
+  }
+  button:hover {
+    background-color: #8c5393;
+    box-shadow: 4px;
+    box-shadow: 0px 0px 15px 2px rgba(140, 83, 147, 0.5);
+  }
+  button:active {
+    background-color: #c73852;
+  }
+</style>
+`;
+}
+
+export function getSentryExampleApiRoute() {
+  return `// This is just a very simple API route that throws an example error.
+// Feel free to delete this file and the entire sentry route.
+
+export const GET = async () => {
+  throw new Error("Sentry Example API Route Error");
+};
+`;
+}


### PR DESCRIPTION
This PR adds the creation of a sample SvelteKit route with a page and an API route to send example frontend and backend errors (+ a transaction) to Sentry. 

Example of page in the default Sverdle app:

![image](https://user-images.githubusercontent.com/8420481/235692474-0ba1601d-7058-44ea-b241-dadceb721d42.png)

yes, the button might feature a nice animation ;)

#skip-changelog

ref #244