### PR TITLE
chore: improve Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## Unreleased
 
-- feat: Add support for SvelteKit SDK Setup (#251)
+- feat(sveltekit): Add support for SvelteKit SDK Setup (#251)
+
+  Set up the Sentry SvelteKit SDK in your app with one command: 
+
+  ```sh
+  npx @sentry/wizard -i sveltekit
+  ```
+
+- feat(rn): Add code snippet to send the first Sentry Error ([#263](https://github.com/getsentry/sentry-wizard/pull/263))
+- fix(rn): Show loader when installing dependencies (#264)
 - ref(nextjs): Clean up minor things (#258)
 - ref(nextjs): Replace old Next.js wizard (#262)
-- fix(rn): Show loader when installing dependencies (#264)
-- feat(rn): Add code snippet to send the first Sentry Error ([#263](https://github.com/getsentry/sentry-wizard/pull/263))
 
 ## 3.1.0
 


### PR DESCRIPTION
Before we release 3.2.0 let's polish the changelog a little

ironically:
#skip-changelog