### PR TITLE
fix: Don't crash in environments without browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Don't crash in environments without browser (#272)
+
 ## 3.2.1
 
 - ref(sveltekit): Prepend Vite plugin (#271)
@@ -8,13 +12,14 @@
 
 - feat(sveltekit): Add support for SvelteKit SDK Setup (#251)
 
-  Set up the Sentry SvelteKit SDK in your app with one command: 
+  Set up the Sentry SvelteKit SDK in your app with one command:
 
   ```sh
   npx @sentry/wizard -i sveltekit
   ```
 
-- feat(rn): Add code snippet to send the first Sentry Error ([#263](https://github.com/getsentry/sentry-wizard/pull/263))
+- feat(rn): Add code snippet to send the first Sentry Error
+  ([#263](https://github.com/getsentry/sentry-wizard/pull/263))
 - fix(rn): Show loader when installing dependencies (#264)
 - ref(nextjs): Clean up minor things (#258)
 - ref(nextjs): Replace old Next.js wizard (#262)

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -48,7 +48,10 @@ export class OpenSentry extends BaseStep {
 
       const urlToOpen = urlObj.toString();
 
-      await this.tryToOpen(urlToOpen);
+      opn(urlToOpen).catch(() => {
+        // opn throws in environments that don't have a browser (e.g. remote shells) so we just noop here
+      });
+
       nl();
       l('Please open');
       green(urlToOpen);
@@ -68,13 +71,5 @@ export class OpenSentry extends BaseStep {
       );
       return {};
     }
-  }
-
-  async tryToOpen(urlToOpen: string) {
-    try {
-        await opn(urlToOpen)
-      } catch (e) {
-        // Browser not found. Do nothing
-      }
   }
 }

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -48,7 +48,7 @@ export class OpenSentry extends BaseStep {
 
       const urlToOpen = urlObj.toString();
 
-      opn(urlToOpen);
+      await this.tryToOpen(urlToOpen);
       nl();
       l('Please open');
       green(urlToOpen);
@@ -68,5 +68,13 @@ export class OpenSentry extends BaseStep {
       );
       return {};
     }
+  }
+
+  async tryToOpen(urlToOpen: string) {
+    try {
+        await opn(urlToOpen)
+      } catch (e) {
+        // Browser not found. Do nothing
+      }
   }
 }


### PR DESCRIPTION
Hello :)

We are using docker without browsers and there are an error when the cli tries to open the url automatically.

https://github.com/getsentry/sentry-wizard/assets/8685132/7eafc84f-833f-466c-b66d-cd89ad9eb615

