### PR TITLE
C&P madness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ coverage/
 plugins
 
 .eslintcache
+package.tgz
+.yarnrc.yml
+yarn.lock
+.yarn

--- a/bin.ts
+++ b/bin.ts
@@ -3,6 +3,7 @@ import { DEFAULT_URL, Integration, Platform } from './lib/Constants';
 import { run } from './lib/Setup';
 import { runNextjsWizard } from './src/nextjs/nextjs-wizard';
 import { runSvelteKitWizard } from './src/sveltekit/sveltekit-wizard';
+import { runViteWizard } from './src/plugin/vite/plugin-wizard';
 export * from './lib/Setup';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -62,6 +63,9 @@ if (argv.i === 'nextjs') {
 } else if (argv.i === 'sveltekit') {
   // eslint-disable-next-line no-console
   runSvelteKitWizard({ promoCode: argv['promo-code'] }).catch(console.error);
+} else if (argv.i === 'vite') {
+  // eslint-disable-next-line no-console
+  runViteWizard({ promoCode: argv['promo-code'] }).catch(console.error);
 } else {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   run(argv);

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -5,6 +5,7 @@ export enum Integration {
   electron = 'electron',
   nextjs = 'nextjs',
   sveltekit = 'sveltekit',
+  vite = 'vite',
 }
 
 /** Key value should be the same here */
@@ -42,6 +43,8 @@ export function getIntegrationDescription(type: string): string {
       return 'Next.js';
     case Integration.sveltekit:
       return 'SvelteKit';
+    case Integration.vite:
+      return 'Vite';
     default:
       return 'React Native';
   }
@@ -59,6 +62,8 @@ export function mapIntegrationToPlatform(type: string): string {
       return 'javascript-nextjs';
     case Integration.sveltekit:
       return 'javascript-sveltekit';
+    case Integration.vite:
+      return 'vite';
     default:
       throw new Error(`Unknown integration ${type}`);
   }

--- a/lib/Steps/ChooseIntegration.ts
+++ b/lib/Steps/ChooseIntegration.ts
@@ -9,6 +9,7 @@ import { Electron } from './Integrations/Electron';
 import { NextJs } from './Integrations/NextJs';
 import { ReactNative } from './Integrations/ReactNative';
 import { SvelteKit } from './Integrations/SvelteKit';
+import { Vite } from './Integrations/Vite';
 
 let projectPackage: any = {};
 
@@ -57,6 +58,9 @@ export class ChooseIntegration extends BaseStep {
         break;
       case Integration.sveltekit:
         integration = new SvelteKit(this._argv);
+        break;
+      case Integration.vite:
+        integration = new Vite(this._argv);
         break;
       default:
         integration = new ReactNative(this._argv);

--- a/lib/Steps/Integrations/Vite.ts
+++ b/lib/Steps/Integrations/Vite.ts
@@ -1,0 +1,29 @@
+import type { Answers } from 'inquirer';
+import { runViteWizard } from '../../../src/plugin/vite/plugin-wizard';
+
+import type { Args } from '../../Constants';
+import { BaseIntegration } from './BaseIntegration';
+
+/**
+ * This class just redirects to the new `sveltekit-wizard.ts` flow
+ * for anyone calling the wizard without the '-i sveltekit' flag.
+ */
+export class Vite extends BaseIntegration {
+  public constructor(protected _argv: Args) {
+    super(_argv);
+  }
+
+  public async emit(_answers: Answers): Promise<Answers> {
+    await runViteWizard({ promoCode: this._argv.promoCode });
+    return {};
+  }
+
+  public async shouldConfigure(_answers: Answers): Promise<Answers> {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    if (this._shouldConfigure) {
+      return this._shouldConfigure;
+    }
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    return this.shouldConfigure;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@clack/prompts": "0.6.3",
     "@sentry/cli": "^1.72.0",
+    "@sentry/sentry-wizard": "file:/Users/steveneubank/Documents/GitHub/sentry-wizard/package.tgz",
     "axios": "1.3.5",
     "chalk": "^2.4.1",
     "glob": "^7.1.3",
@@ -47,20 +48,17 @@
     "@types/node": "^10.11.0",
     "@types/rimraf": "^3.0.2",
     "@types/semver": "^7.3.7",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "eslint": "^8.18.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-jest": "^25.3.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4",
-    "@typescript-eslint/eslint-plugin": "^5.13.0",
-    "@typescript-eslint/parser": "^5.13.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-jest": "^25.3.0"
-  },
-  "resolutions": {
-    "**/xmldom": "^0.6.0"
+    "typescript": "^5.0.4"
   },
   "engines": {
     "node": ">=6.9.5",

--- a/src/plugin/sentry-cli-setup.ts
+++ b/src/plugin/sentry-cli-setup.ts
@@ -1,0 +1,27 @@
+import { Args } from '../../lib/Constants';
+import { SentryCli } from '../../lib/Helper/SentryCli';
+import { SentryProjectData } from '../utils/clack-utils';
+
+export async function setupCLIConfig(
+  authToken: string,
+  selectedProject: SentryProjectData,
+  sentryUrl: string,
+): Promise<void> {
+  const cli = new SentryCli({ url: sentryUrl } as Args);
+
+  const answers = {
+    config: {
+      organization: {
+        slug: selectedProject.organization.slug,
+      },
+      project: {
+        slug: selectedProject.slug,
+      },
+      auth: {
+        token: authToken,
+      },
+    },
+  };
+  const props = cli.convertAnswersToProperties(answers);
+  await cli.createSentryCliConfig(props);
+}

--- a/src/plugin/vite/plugin-wizard.ts
+++ b/src/plugin/vite/plugin-wizard.ts
@@ -1,0 +1,95 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import chalk from 'chalk';
+
+import {
+  abortIfCancelled,
+  askForSelfHosted,
+  askForWizardLogin,
+  confirmContinueEvenThoughNoGitRepo,
+  ensurePackageIsInstalled,
+  getPackageDotJson,
+  hasPackageInstalled,
+  installPackage,
+  printWelcome,
+  SentryProjectData,
+} from '../../utils/clack-utils';
+import { createOrMergeViteFiles, loadViteConfig } from './vite-setup';
+
+import { setupCLIConfig } from '../sentry-cli-setup';
+
+interface ViteWizardOptions {
+  promoCode?: string;
+}
+
+export async function runViteWizard(
+  options: ViteWizardOptions,
+): Promise<void> {
+  printWelcome({
+    wizardName: 'Sentry Vite Wizard',
+    promoCode: options.promoCode,
+  });
+
+  await confirmContinueEvenThoughNoGitRepo();
+
+  const packageJson = await getPackageDotJson();
+  await ensurePackageIsInstalled(packageJson, 'vite', 'Vite');
+
+  const { url: sentryUrl, selfHosted } = await askForSelfHosted();
+
+  const { projects, apiKeys } = await askForWizardLogin({
+    promoCode: options.promoCode,
+    url: sentryUrl,
+  });
+
+  const selectedProject: SentryProjectData | symbol = await clack.select({
+    message: 'Select your Sentry project.',
+    options: projects.map((project) => {
+      return {
+        value: project,
+        label: `${project.organization.slug}/${project.slug}`,
+      };
+    }),
+  });
+
+  abortIfCancelled(selectedProject);
+
+  await installPackage({
+    packageName: '@sentry/vite-plugin',
+    alreadyInstalled: hasPackageInstalled('@sentry/vite-plugin', packageJson),
+  });
+
+  await setupCLIConfig(apiKeys.token, selectedProject, sentryUrl);
+
+  const dsn = selectedProject.keys[0].dsn.public;
+
+  const viteConfig = await loadViteConfig();
+
+  try {
+    await createOrMergeViteFiles(dsn, viteConfig);
+  } catch (e: unknown) {
+    clack.log.error('Error while setting up the SvelteKit SDK:');
+    clack.log.info(
+      chalk.dim(
+        typeof e === 'object' && e != null && 'toString' in e
+          ? e.toString()
+          : typeof e === 'string'
+            ? e
+            : 'Unknown error',
+      ),
+    );
+    return;
+  }
+
+
+  clack.outro(`
+${chalk.green('Successfully installed the Sentry Vite Plugin!')}
+
+${chalk.cyan(
+    'You can validate your setup by starting your dev environment (`npm run build`).',
+  )}
+
+Check out the SDK documentation for further configuration:
+https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite
+  `);
+}

--- a/src/plugin/vite/vite-setup.ts
+++ b/src/plugin/vite/vite-setup.ts
@@ -1,0 +1,128 @@
+import type { ExportNamedDeclaration, Program } from '@babel/types';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+import chalk from 'chalk';
+
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+// @ts-ignore - magicast is ESM and TS complains about that. It works though
+import type { ProxifiedModule } from 'magicast';
+// @ts-ignore - magicast is ESM and TS complains about that. It works though
+import { builders, generateCode, loadFile, parseModule } from 'magicast';
+// @ts-ignore - magicast is ESM and TS complains about that. It works though
+import { addVitePlugin } from 'magicast/helpers';
+
+
+const VITE_CONFIG_FILE = 'vite.config.js';
+
+export type PartialViteConfig = {
+  vite?: {
+
+  };
+};
+
+
+export async function createOrMergeViteFiles(
+  dsn: string,
+  viteConfig: PartialViteConfig,
+): Promise<void> {
+  const viteBundlerConfig = findHooksFile(path.resolve(process.cwd(), 'vite.config'));
+
+  if (viteBundlerConfig) {
+    await modifyViteConfig(viteBundlerConfig);
+  }
+}
+
+/**
+ * Checks if a hooks file exists and returns the full path to the file with the correct file type.
+ */
+function findHooksFile(hooksFile: string): string | undefined {
+  const possibleFileTypes = ['.js', '.ts', '.mjs'];
+  return possibleFileTypes
+    .map((type) => `${hooksFile}${type}`)
+    .find((file) => fs.existsSync(file));
+}
+
+/** Checks if the Sentry SvelteKit SDK is already mentioned in the file */
+function hasSentryContent(fileName: string, fileContent: string): boolean {
+  if (fileContent.includes('@sentry/vite-plugin')) {
+    clack.log.warn(
+      `File ${chalk.cyan(path.basename(fileName))} already contains Sentry code.
+Skipping adding Sentry functionality to ${chalk.cyan(
+        path.basename(fileName),
+      )}.`,
+    );
+    return true;
+  }
+  return false;
+}
+
+export async function loadViteConfig(): Promise<PartialViteConfig> {
+  const configFilePath = path.join(process.cwd(), VITE_CONFIG_FILE);
+
+  try {
+    if (!fs.existsSync(configFilePath)) {
+      return {};
+    }
+
+    const configUrl = url.pathToFileURL(configFilePath).href;
+    const viteConfigModule = (await import(configUrl)) as {
+      default: PartialViteConfig;
+    };
+
+    return viteConfigModule?.default || {};
+  } catch (e: unknown) {
+    clack.log.error(`Couldn't load ${VITE_CONFIG_FILE}.
+Please make sure, you're running this wizard with Node 16 or newer`);
+    clack.log.info(
+      chalk.dim(
+        typeof e === 'object' && e != null && 'toString' in e
+          ? e.toString()
+          : typeof e === 'string'
+            ? e
+            : 'Unknown error',
+      ),
+    );
+
+    return {};
+  }
+}
+
+async function modifyViteConfig(viteConfigPath: string): Promise<void> {
+  const viteConfigContent = (
+    await fs.promises.readFile(viteConfigPath, 'utf-8')
+  ).toString();
+
+  if (hasSentryContent(viteConfigPath, viteConfigContent)) {
+    return;
+  }
+
+  const viteModule = parseModule(viteConfigContent);
+
+  addVitePlugin(viteModule, {
+    imported: 'sentryVite',
+    from: '@sentry/vite-plugin',
+    constructor: 'sentryVite',
+    index: 0,
+  });
+
+  const code = generateCode(viteModule.$ast).code;
+  await fs.promises.writeFile(viteConfigPath, code);
+}
+
+/**
+ * We want to insert the init call on top of the file but after all import statements
+ */
+function getInitCallInsertionIndex(originalHooksModAST: Program): number {
+  // We need to deep-copy here because reverse mutates in place
+  const copiedBodyNodes = [...originalHooksModAST.body];
+  const lastImportDeclaration = copiedBodyNodes
+    .reverse()
+    .find((node) => node.type === 'ImportDeclaration');
+
+  const initCallInsertionIndex = lastImportDeclaration
+    ? originalHooksModAST.body.indexOf(lastImportDeclaration) + 1
+    : 0;
+  return initCallInsertionIndex;
+}


### PR DESCRIPTION
running locally works but running into issues with working with local package dependencies


```
steveneubank@FVFG428MQ05P sentry-wizard % npx @sentry/wizard -i vite

┌   Sentry Vite Wizard 
│
◇   ─────────────────────────────────────────────────────────────────╮
│                                                                    │
│  This Wizard will help you to set up Sentry for your application.  │
│  Thank you for using Sentry :)                                     │
│                                                                    │
├────────────────────────────────────────────────────────────────────╯
│
◇  Vite does not seem to be installed. Do you still want to continue?
│  Yes
│
◇  Are you using Sentry SaaS or self-hosted Sentry?
│  Sentry SaaS (sentry.io)
│
◇  Do you already have a Sentry account?
│  Yes
│
●  Please open the following link in your browser to log into Sentry:
│  
│  https://sentry.io/account/settings/wizard/uivc5pusdbkvhhf3dlnnhuamttkcpuu67z5rmh5ohge4vcb7mxzr6h700tczci50/
│
◇  Login complete.
│
◆  Select your Sentry project.
│  ● steven-eubank/react-vite
│  ○ steven-eubank/javascript-angular-xl
│  ○ steven-eubank/javascript-angularjs-tq
│  ○ steven-eubank/javascript-angular
│  ○ steven-eubank/javascript-angularjs
│  ○ steven-eubank/javascript-react
│  ○ steven-eubank/node-serverlesscloud-t5
│  ○ steven-eubank/node-serverlesscloud-vb
◇  Select your Sentry project.
│  steven-eubank/react-vite
│
◇  Installation failed.
│
■  Encountered the following error during installation:
│  
│  Error: Command failed: yarn add @sentry/vite-plugin@latest
│  
│  
│  If you think this issue is caused by the Sentry wizard, let us know here:
│  https://github.com/getsentry/sentry-wizard/issues
│
└  Wizard setup cancelled.

```

seems to be always something like this
```
steveneubank@FVFG428MQ05P vite-template-react % yarn add @sentry/vite-plugin@latest
➤ YN0000: ┌ Resolution step
➤ YN0032: │ fsevents@npm:2.3.2: Implicit dependencies on node-gyp are discouraged
➤ YN0061: │ @npmcli/move-file@npm:2.0.1 is deprecated: This functionality has been moved to @npmcli/fs
➤ YN0001: │ Error: @sentry/sentry-wizard@file:package.tgz::locator=%40sentry%2Fsentry-wizard%40file%3A%2FUsers%2Fsteveneubank%2FDocuments%2FGitHub%2Fvite-template-react%2Fpackage.tgz%23%2FUsers%2Fsteveneubank%2FDocuments%2FGitHub%2Fvite-template-react%2Fpackage.tgz%3A%3Ahash%3Dd28f5c%26locator%3Dvite-template-react%2540workspace%253A.: ENOENT: no such file or directory, open 'node_modules/@sentry/sentry-wizard/package.tgz'
    at Ll (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:4:1325)
    at Object.S_e (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:4:1593)
    at os.readFileBuffer (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:9:268124)
    at os.readFilePromise (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:9:267755)
    at ry.readFilePromise (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:9:5237)
    at ju.readFilePromise (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:9:5237)
    at /Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:551:3400
    at Object.bXe (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:134:53645)
    at m2 (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:551:3362)
    at async I2.getCandidates (/Users/steveneubank/.volta/tools/image/yarn/4.0.0-rc.40/bin/yarn.js:551:8189)
➤ YN0000: └ Completed in 5s 894ms
➤ YN0000: Failed with errors in 5s 898ms

```

some complexities with running a package that stored locally
```
steveneubank@FVFG428MQ05P vite-template-react % yarn add @sentry/vite-plugin@latest
➤ YN0000: ┌ Resolution step
➤ YN0014: │ @sentry/sentry-wizard@file:/Users/steveneubank/Documents/GitHub/vite-template-react/package.tgz: Only some patterns can be imported from legacy lockfiles (not "file:package.tgz")
➤ YN0014: │ @sentry/sentry-wizard@file:package.tgz: Only some patterns can be imported from legacy lockfiles (not "file:package.tgz")
➤ YN0032: │ fsevents@npm:2.3.2: Implicit dependencies on node-gyp are discouraged
➤ YN0061: │ @npmcli/move-file@npm:2.0.1 is deprecated: This functionality has been moved to @npmcli/fs
➤ YN0001: │ Error: @sentry/sentry-wizard@file:package.tgz::locator=%40sentry%2Fsentry-wizard%40file%3A%2FUsers%2Fsteveneubank%2FDocuments%2FGitHub%2Fvite-template-react%2Fpackage.tgz%23%2FUsers%2Fsteveneubank%2FDocuments%2FGitHub%2Fvite-template-react%2Fpackage.tgz%3A%3Ahash%3Dd28f5c%26locator%3Dvite-template-react%2540workspace%253A.: ENOENT: no such file or directory, open 'node_modules/@sentry/sentry-wizard/package.tgz'
```