### PR TITLE
ref: Extract project selection from NextJs and SvelteKit wizards

### DIFF
--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -18,7 +18,7 @@ import {
   getPackageDotJson,
   installPackage,
   printWelcome,
-  SentryProjectData,
+  selectProject,
 } from '../utils/clack-utils';
 import {
   getNextjsConfigCjsAppendix,
@@ -54,17 +54,10 @@ export async function runNextjsWizard(
   const { projects, apiKeys } = await askForWizardLogin({
     promoCode: options.promoCode,
     url: sentryUrl,
+    platform: 'javascript-nextjs',
   });
 
-  const selectedProject: SentryProjectData | symbol = await clack.select({
-    message: 'Select your Sentry project.',
-    options: projects.map((project) => {
-      return {
-        value: project,
-        label: `${project.organization.slug}/${project.slug}`,
-      };
-    }),
-  });
+  const selectedProject = await selectProject(projects);
 
   abortIfCancelled(selectedProject);
 

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -12,7 +12,7 @@ import {
   hasPackageInstalled,
   installPackage,
   printWelcome,
-  SentryProjectData,
+  selectProject,
 } from '../utils/clack-utils';
 import { createExamplePage } from './sdk-example';
 import { createOrMergeSvelteKitFiles, loadSvelteConfig } from './sdk-setup';
@@ -41,17 +41,10 @@ export async function runSvelteKitWizard(
   const { projects, apiKeys } = await askForWizardLogin({
     promoCode: options.promoCode,
     url: sentryUrl,
+    platform: 'javascript-sveltekit',
   });
 
-  const selectedProject: SentryProjectData | symbol = await clack.select({
-    message: 'Select your Sentry project.',
-    options: projects.map((project) => {
-      return {
-        value: project,
-        label: `${project.organization.slug}/${project.slug}`,
-      };
-    }),
-  });
+  const selectedProject = await selectProject(projects);
 
   abortIfCancelled(selectedProject);
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -102,6 +102,7 @@ export async function confirmContinueEvenThoughNoGitRepo(): Promise<void> {
 export async function askForWizardLogin(options: {
   url: string;
   promoCode?: string;
+  platform?: 'javascript-nextjs' | 'javascript-sveltekit';
 }): Promise<WizardProjectData> {
   const hasSentryAccount = await clack.confirm({
     message: 'Do you already have a Sentry account?',
@@ -131,7 +132,9 @@ export async function askForWizardLogin(options: {
 
   if (!hasSentryAccount) {
     loginUrl.searchParams.set('signup', '1');
-    loginUrl.searchParams.set('project_platform', 'javascript-nextjs');
+    if (options.platform) {
+      loginUrl.searchParams.set('project_platform', options.platform);
+    }
   }
 
   if (options.promoCode) {
@@ -182,6 +185,20 @@ export async function askForWizardLogin(options: {
   loginSpinner.stop('Login complete.');
 
   return data;
+}
+
+export function selectProject(
+  projects: SentryProjectData[],
+): Promise<SentryProjectData | symbol> {
+  return clack.select({
+    message: 'Select your Sentry project.',
+    options: projects.map((project) => {
+      return {
+        value: project,
+        label: `${project.organization.slug}/${project.slug}`,
+      };
+    }),
+  });
 }
 
 export async function installPackage({


### PR DESCRIPTION
In light of #290 we want to prepare the login and project selection flow to be reusable. After going through the two JS wizards, most of the logic is already reusable so what's left are just two minor refactors which this PR addresses.

* extract the project selection step
* make the platform query param configurable (I missed this while working on SvelteKit, so this is also kind of a fix)

closes #292 
ref #290

Since this isn't user-facing:
#skip-changelog