### PR TITLE
feat(sourcemaps): Add Sourcemaps as selectable integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat: Add single tenant to self-hosted question (#277)
 - feat: Improve error handling of incorrect self-hosted URLs (#299)
 - feat(sourcemaps): Add Login and Project Selection flow (#300)
+- feat(sourcemaps): Add Sourcemaps as selectable integration (#302)
 
 ## 3.2.3
 

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -43,12 +43,14 @@ export function getIntegrationDescription(type: string): string {
       return 'Next.js';
     case Integration.sveltekit:
       return 'SvelteKit';
+    case Integration.sourcemaps:
+      return 'Configure Source Maps Upload';
     default:
       return 'React Native';
   }
 }
 
-export function mapIntegrationToPlatform(type: string): string {
+export function mapIntegrationToPlatform(type: string): string | undefined {
   switch (type) {
     case Integration.reactNative:
       return 'react-native';
@@ -60,12 +62,19 @@ export function mapIntegrationToPlatform(type: string): string {
       return 'javascript-nextjs';
     case Integration.sveltekit:
       return 'javascript-sveltekit';
+    case Integration.sourcemaps:
+      return undefined;
     default:
       throw new Error(`Unknown integration ${type}`);
   }
 }
 
-export function getIntegrationChoices(): any[] {
+type IntegrationChoice = {
+  name: string;
+  value: string;
+};
+
+export function getIntegrationChoices(): IntegrationChoice[] {
   return Object.keys(Integration).map((type: string) => ({
     name: getIntegrationDescription(type),
     value: type,

--- a/lib/Steps/Integrations/SourceMapsShim.ts
+++ b/lib/Steps/Integrations/SourceMapsShim.ts
@@ -1,0 +1,29 @@
+import type { Answers } from 'inquirer';
+import { runSourcemapsWizard } from '../../../src/sourcemaps/sourcemaps-wizard';
+
+import type { Args } from '../../Constants';
+import { BaseIntegration } from './BaseIntegration';
+
+/**
+ * This class just redirects to the `sourcemaps-wizard.ts` flow
+ * for anyone calling the wizard without the '-i sveltekit' flag.
+ */
+export class SourceMapsShim extends BaseIntegration {
+  public constructor(protected _argv: Args) {
+    super(_argv);
+  }
+
+  public async emit(_answers: Answers): Promise<Answers> {
+    await runSourcemapsWizard({ promoCode: this._argv.promoCode });
+    return {};
+  }
+
+  // public async shouldConfigure(_answers: Answers): Promise<Answers> {
+  //   // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  //   if (this._shouldConfigure) {
+  //     return this._shouldConfigure;
+  //   }
+  //   // eslint-disable-next-line @typescript-eslint/unbound-method
+  //   return this.shouldConfigure;
+  // }
+}

--- a/lib/Steps/Integrations/SourceMapsShim.ts
+++ b/lib/Steps/Integrations/SourceMapsShim.ts
@@ -17,13 +17,4 @@ export class SourceMapsShim extends BaseIntegration {
     await runSourcemapsWizard({ promoCode: this._argv.promoCode });
     return {};
   }
-
-  // public async shouldConfigure(_answers: Answers): Promise<Answers> {
-  //   // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  //   if (this._shouldConfigure) {
-  //     return this._shouldConfigure;
-  //   }
-  //   // eslint-disable-next-line @typescript-eslint/unbound-method
-  //   return this.shouldConfigure;
-  // }
 }

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -36,10 +36,10 @@ export class OpenSentry extends BaseStep {
         urlObj.searchParams.set('signup', '1');
         // integration maps to platform in the wizard
         if (this._argv.integration) {
-          urlObj.searchParams.set(
-            'project_platform',
-            mapIntegrationToPlatform(this._argv.integration),
-          );
+          const platform = mapIntegrationToPlatform(this._argv.integration);
+          if (platform) {
+            urlObj.searchParams.set('project_platform', platform);
+          }
         }
         if (this._argv.promoCode) {
           urlObj.searchParams.set('code', this._argv.promoCode);


### PR DESCRIPTION
When starting the wizard without the `-i` argument, source maps should still show up as a selectable "integration" (naming isn't ideal here) in the prompt at the beginning of the wizard flow.

This PR adds this and cleans up a few `any` usages. At some point we probably want to refactor/remove this duality of old (class-based) integrations and the newer streamlined ones but I'd argue this is out of scope for now. Hence the `SourceMapsShim` class.

closes #301  