### PR TITLE
feat: Add telemetry helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@clack/prompts": "0.6.3",
     "@sentry/cli": "^1.72.0",
+    "@sentry/node": "^7.56.0",
     "axios": "1.3.5",
     "chalk": "^2.4.1",
     "glob": "^7.1.3",

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -95,13 +95,15 @@ export async function runNextjsWizard(
         existingConfigs.push(tsConfig);
       }
 
-      const overwriteExistingConfigs = await clack.confirm({
+      let overwriteExistingConfigs = await clack.confirm({
         message: `Found existing Sentry ${configVariant} config (${existingConfigs.join(
           ', ',
         )}). Overwrite ${existingConfigs.length > 1 ? 'them' : 'it'}?`,
       });
 
-      abortIfCancelled(overwriteExistingConfigs);
+      overwriteExistingConfigs = await abortIfCancelled(
+        overwriteExistingConfigs,
+      );
 
       shouldWriteFile = overwriteExistingConfigs;
 
@@ -176,13 +178,13 @@ export async function runNextjsWizard(
     let shouldInject = true;
 
     if (probablyIncludesSdk) {
-      const injectAnyhow = await clack.confirm({
+      let injectAnyhow = await clack.confirm({
         message: `${chalk.bold(
           nextConfigJs,
         )} already contains Sentry SDK configuration. Should the wizard modify it anyways?`,
       });
 
-      abortIfCancelled(injectAnyhow);
+      injectAnyhow = await abortIfCancelled(injectAnyhow);
 
       shouldInject = injectAnyhow;
     }
@@ -218,13 +220,13 @@ export async function runNextjsWizard(
     let shouldInject = true;
 
     if (probablyIncludesSdk) {
-      const injectAnyhow = await clack.confirm({
+      let injectAnyhow = await clack.confirm({
         message: `${chalk.bold(
           nextConfigMjs,
         )} already contains Sentry SDK configuration. Should the wizard modify it anyways?`,
       });
 
-      abortIfCancelled(injectAnyhow);
+      injectAnyhow = await abortIfCancelled(injectAnyhow);
       shouldInject = injectAnyhow;
     }
 
@@ -280,7 +282,7 @@ export async function runNextjsWizard(
         ),
       );
 
-      const shouldContinue = await clack.confirm({
+      let shouldContinue = await clack.confirm({
         message: `Are you done putting the snippet above into ${chalk.bold(
           nextConfigMjs,
         )}?`,
@@ -288,9 +290,9 @@ export async function runNextjsWizard(
         inactive: 'No, get me out of here',
       });
 
-      abortIfCancelled(shouldContinue);
+      shouldContinue = await abortIfCancelled(shouldContinue);
       if (!shouldContinue) {
-        abort();
+        await abort();
       }
     }
   }

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -69,7 +69,7 @@ export async function runSourcemapsWizard(
 }
 
 async function askForUsedBundlerTool(): Promise<SupportedBundlersTools> {
-  const selectedTool: SupportedBundlersTools | symbol = await clack.select({
+  let selectedTool: SupportedBundlersTools | symbol = await clack.select({
     message: 'Which bundler or build tool are you using?',
     options: [
       {
@@ -100,7 +100,7 @@ async function askForUsedBundlerTool(): Promise<SupportedBundlersTools> {
     ],
   });
 
-  abortIfCancelled(selectedTool);
+  selectedTool = await abortIfCancelled(selectedTool);
 
   return selectedTool;
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,77 @@
+import {
+  defaultStackParser,
+  Hub,
+  makeMain,
+  makeNodeTransport,
+  NodeClient,
+  runWithAsyncContext,
+} from '@sentry/node';
+import packageJson from '../package.json';
+
+export async function withTelemetry<F>(
+  callback: () => F | Promise<F>,
+  enabled: boolean,
+  integration: string,
+): Promise<F> {
+  const { sentryHub, sentryClient } = createSentryInstance(
+    enabled,
+    integration,
+  );
+
+  makeMain(sentryHub);
+
+  const transaction = sentryHub.startTransaction({
+    name: 'sentry-wizard-execution',
+  });
+  sentryHub.getScope().setSpan(transaction);
+  const sentrySession = sentryHub.startSession();
+  sentryHub.captureSession();
+
+  try {
+    return await runWithAsyncContext(() => callback());
+  } catch (e) {
+    sentryHub.captureException('Error during wizard execution.');
+    transaction.setStatus('internal_error');
+    sentrySession.status = 'crashed';
+    throw e;
+  } finally {
+    transaction.finish();
+    sentryHub.endSession();
+    await sentryClient.flush(3000);
+  }
+}
+
+function createSentryInstance(enabled: boolean, integration: string) {
+  const client = new NodeClient({
+    dsn: 'https://8871d3ff64814ed8960c96d1fcc98a27@o1.ingest.sentry.io/4505425820712960',
+    enabled: enabled,
+
+    tracesSampleRate: 1,
+    sampleRate: 1,
+
+    release: packageJson.version,
+    integrations: [],
+    tracePropagationTargets: ['sentry.io/api'],
+
+    stackParser: defaultStackParser,
+
+    beforeSend: (event) => {
+      event.exception?.values?.forEach((exception) => {
+        delete exception.stacktrace;
+      });
+
+      delete event.server_name; // Server name might contain PII
+      return event;
+    },
+
+    transport: makeNodeTransport,
+  });
+
+  const hub = new Hub(client);
+
+  hub.setTag('integration', integration);
+  hub.setTag('node', process.version);
+  hub.setTag('platform', process.platform);
+
+  return { sentryHub: hub, sentryClient: client };
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -13,6 +13,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "sourceMap": true,
-    "inlineSources": true
+    "inlineSources": true,
+    "resolveJsonModule": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,16 @@
   dependencies:
     requireindex "~1.1.0"
 
+"@sentry-internal/tracing@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.56.0.tgz#ba709258f2f0f3d8a36f9740403088b39212b843"
+  integrity sha512-OKI4Pz/O13gng8hT9rNc+gRV3+P7nnk1HnHlV8fgaQydS6DsRxoDL1sHa42tZGbh7K9jqNAP3TC6VjBOsr2tXA==
+  dependencies:
+    "@sentry/core" "7.56.0"
+    "@sentry/types" "7.56.0"
+    "@sentry/utils" "7.56.0"
+    tslib "^1.9.3"
+
 "@sentry-internal/typescript@7.48.0":
   version "7.48.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.48.0.tgz#27ba755a1414b3518f820086e447eba8ecdeb794"
@@ -758,6 +768,42 @@
     npmlog "^4.1.2"
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
+
+"@sentry/core@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.56.0.tgz#f4253e0d61f55444180a63e5278b62e57303f7cf"
+  integrity sha512-Nuyyfh09Yz27kPo74fXHlrdmZeK6zrlJVtxQ6LkwuoaTBcNcesNXVaOtr6gjvUGUmsfriVPP3Jero5LXufV7GQ==
+  dependencies:
+    "@sentry/types" "7.56.0"
+    "@sentry/utils" "7.56.0"
+    tslib "^1.9.3"
+
+"@sentry/node@^7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.56.0.tgz#ddeb34a848c8a544d0dbb5f2c3031615be040d2b"
+  integrity sha512-QXbWy/ypRxfFd8iP6zLvHInYZyjGKPrkVNYt43mhKAZHm764NxX/29vDfj1FztgG9Z6lVLIG2eyqTvLruYmsWw==
+  dependencies:
+    "@sentry-internal/tracing" "7.56.0"
+    "@sentry/core" "7.56.0"
+    "@sentry/types" "7.56.0"
+    "@sentry/utils" "7.56.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.56.0.tgz#9042a099cf9e8816d081886d24b88082a5d9f87a"
+  integrity sha512-5WjhVOQm75ItOytOx2jTx+5yw8/qJ316+g1Di8dS9+kgIi1zniqdMcX00C2yYe3FMUgFB49PegCUYulm9Evapw==
+
+"@sentry/utils@7.56.0":
+  version "7.56.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.56.0.tgz#e60e4935d17b2197584abf6ce61b522ad055352c"
+  integrity sha512-wgeX7bufxc//TjjSIE+gCMm8hVId7Jzvc+f441bYrWnNZBuzPIDW2BummCcPrKzSYe5GeYZDTZGV8YZGMLGBjw==
+  dependencies:
+    "@sentry/types" "7.56.0"
+    tslib "^1.9.3"
 
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
@@ -1694,6 +1740,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -3259,6 +3310,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
 magicast@^0.2.9:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.2.9.tgz#9b5de1c6ba40b3fa626834017f0f11800a033cbe"
@@ -3900,10 +3956,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
-  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
+semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -3911,6 +3967,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
+  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -4252,7 +4315,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Adds a telemetry helper `withTelemetry` that can be used to send anonymous crash behaviour to Sentry.

We had to adjust the `abort` and `abortIfCanceled` functions and their usages to accomodate async flushing of Sentry events.