### PR TITLE
fix(sourcemaps): Stop redirecting to old flow when starting without `-i` flag

### DIFF
--- a/lib/Steps/Integrations/SourceMapsShim.ts
+++ b/lib/Steps/Integrations/SourceMapsShim.ts
@@ -17,4 +17,8 @@ export class SourceMapsShim extends BaseIntegration {
     await runSourcemapsWizard({ promoCode: this._argv.promoCode });
     return {};
   }
+
+  public async shouldConfigure(_answers: Answers): Promise<Answers> {
+    return this._shouldConfigure;
+  }
 }


### PR DESCRIPTION
Seems like we need `shouldConfigure` in the source maps shim so that the old `Step`-based wizard doesn't start its login flow but immediately redirects to our new (clack-based) wizard.

#skip-changelog