### PR TITLE
feat(sourcemaps): Create `.env.sentry-build-plugin` instead of `.sentryclirc` to set auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat(sourcemaps): Add Login and Project Selection flow (#300)
 - feat(sourcemaps): Add setup flow for Vite (#308)
 - feat(sourcemaps): Add Sourcemaps as selectable integration (#302)
+- feat(sourcemaps): Create `.env.sentry-build-plugin` instead of `.sentryclirc` to set auth token (#313)
 - feat: Add empty sourcemaps wizard (#295)
 - feat: Add single tenant to self-hosted question (#277)
 - feat: Add telemetry helper (#309)

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -54,8 +54,6 @@ export async function runSourcemapsWizard(
     authToken: apiKeys.token,
   });
 
-  await addSentryCliRc(apiKeys.token);
-
   clack.log.step(
     'Add the Sentry auth token as an environment variable to your CI setup:',
   );

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 
 import {
   abortIfCancelled,
-  addSentryCliRc,
   askForProjectSelection,
   askForSelfHosted,
   askForWizardLogin,

--- a/src/sourcemaps/tools/vite.ts
+++ b/src/sourcemaps/tools/vite.ts
@@ -3,6 +3,7 @@ import clack, { select } from '@clack/prompts';
 import chalk from 'chalk';
 import {
   abortIfCancelled,
+  addDotEnvSentryBuildPluginFile,
   getPackageDotJson,
   hasPackageInstalled,
   installPackage,
@@ -62,4 +63,6 @@ export const configureVitePlugin: SourceMapUploadToolConfigurationFunction =
         initialValue: true,
       }),
     );
+
+    await addDotEnvSentryBuildPluginFile(options.authToken);
   };

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -443,7 +443,7 @@ SENTRY_AUTH_TOKEN="${authToken}"
       clack.log.warning(
         `Failed to create ${chalk.bold(
           DOT_ENV_FILE,
-        )} with auth token. Uploading source maps during build will likely not work.`,
+        )} with auth token. Uploading source maps during build will likely not work locally.`,
       );
     }
   }

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -428,7 +428,7 @@ SENTRY_AUTH_TOKEN="${authToken}"
         clack.log.warning(
           `Failed to add auth token to ${chalk.bold(
             DOT_ENV_FILE,
-          )}. Uploading source maps during build will likely not work.`,
+          )}. Uploading source maps during build will likely not work locally.`,
         );
       }
     }
@@ -438,7 +438,7 @@ SENTRY_AUTH_TOKEN="${authToken}"
         encoding: 'utf8',
         flag: 'w',
       });
-      clack.log.success(`Created ${chalk.bold(DOT_ENV_FILE)} with auth token.`);
+      clack.log.success(`Created ${chalk.bold(DOT_ENV_FILE)} with auth token for you to test source map uploading locally.`);
     } catch {
       clack.log.warning(
         `Failed to create ${chalk.bold(


### PR DESCRIPTION
Picking up values from `.env.sentry-build-plugin` was added in the latest plugin release. Let's use it in the wizard now.