### PR TITLE
feat(sourcemaps): Add setup flow for sentry-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(sourcemaps): Add bundler selection prompt (#304)
 - feat(sourcemaps): Add Login and Project Selection flow (#300)
 - feat(sourcemaps): Add setup flow for Vite (#308)
+- feat(sourcemaps): Add setup flow for sentry-cli (#314)
 - feat(sourcemaps): Add Sourcemaps as selectable integration (#302)
 - feat: Add empty sourcemaps wizard (#295)
 - feat: Add single tenant to self-hosted question (#277)

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 
 import {
   abortIfCancelled,
-  addSentryCliRc,
   askForProjectSelection,
   askForSelfHosted,
   askForWizardLogin,
@@ -14,6 +13,7 @@ import {
 import { isUnicodeSupported } from '../utils/vendor/is-unicorn-supported';
 import { SourceMapUploadToolConfigurationOptions } from './tools/types';
 import { configureVitePlugin } from './tools/vite';
+import { configureSentryCLI } from './tools/sentry-cli';
 
 interface SourceMapsWizardOptions {
   promoCode?: string;
@@ -53,8 +53,6 @@ export async function runSourcemapsWizard(
     url: sentryUrl,
     authToken: apiKeys.token,
   });
-
-  await addSentryCliRc(apiKeys.token);
 
   const arrow = isUnicodeSupported() ? '→' : '->';
 
@@ -128,7 +126,9 @@ async function startToolSetupFlow(
     case 'vite':
       await configureVitePlugin(options);
       break;
+    case 'sentry-cli':
+      await configureSentryCLI(options);
+      break;
     // TODO: implement other bundlers
-    // TODO: add CLI flow as fallback
   }
 }

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -126,9 +126,9 @@ async function startToolSetupFlow(
     case 'vite':
       await configureVitePlugin(options);
       break;
-    case 'sentry-cli':
+    // TODO: implement other bundlers
+    default:
       await configureSentryCLI(options);
       break;
-    // TODO: implement other bundlers
   }
 }

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -28,7 +28,7 @@ export const configureSentryCLI: SourceMapUploadToolConfigurationFunction =
       const rawArtifactPath = await abortIfCancelled(
         clack.text({
           message:
-            'Provide a path to the folder that contains your build artifacts:',
+            'Where are your build artifacts located?',
           placeholder: `path${path.sep}to${path.sep}your${path.sep}build${path.sep}output`,
         }),
       );

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -75,9 +75,15 @@ export const configureSentryCLI: SourceMapUploadToolConfigurationFunction =
     );
 
     packageDotJson.scripts = packageDotJson.scripts || {};
-    packageDotJson.scripts[
-      'sentry:ci'
-    ] = `sentry-cli sourcemaps inject --org ${options.orgSlug} --project ${options.projectSlug} ${relativePosixArtifactPath} && sentry-cli sourcemaps upload --org ${options.orgSlug} --project ${options.projectSlug} ${relativePosixArtifactPath}`;
+    packageDotJson.scripts['sentry:ci'] = `sentry-cli sourcemaps inject --org ${
+      options.orgSlug
+    } --project ${
+      options.projectSlug
+    } ${relativePosixArtifactPath} && sentry-cli${
+      options.selfHosted ? ` --url ${options.url}` : ''
+    }  sourcemaps upload --org ${options.orgSlug} --project ${
+      options.projectSlug
+    } ${relativePosixArtifactPath}`;
 
     await fs.promises.writeFile(
       path.join(process.cwd(), 'package.json'),

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -27,9 +27,8 @@ export const configureSentryCLI: SourceMapUploadToolConfigurationFunction =
     do {
       const rawArtifactPath = await abortIfCancelled(
         clack.text({
-          message:
-            'Where are your build artifacts located?',
-          placeholder: `path${path.sep}to${path.sep}your${path.sep}build${path.sep}output`,
+          message: 'Where are your build artifacts located?',
+          placeholder: `.${path.sep}out`,
         }),
       );
 

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -1,0 +1,120 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import chalk from 'chalk';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+  abortIfCancelled,
+  addSentryCliRc,
+  getPackageDotJson,
+  hasPackageInstalled,
+  installPackage,
+} from '../../utils/clack-utils';
+
+import { SourceMapUploadToolConfigurationFunction } from './types';
+
+export const configureSentryCLI: SourceMapUploadToolConfigurationFunction =
+  async (options) => {
+    const packageDotJson = await getPackageDotJson();
+
+    await installPackage({
+      packageName: '@sentry/cli',
+      alreadyInstalled: hasPackageInstalled('@sentry/cli', packageDotJson),
+    });
+
+    let validPath = false;
+    let relativeArtifactPath;
+    do {
+      const rawArtifactPath = await abortIfCancelled(
+        clack.text({
+          message:
+            'Provide a path to the folder that contains your build artifacts:',
+          placeholder: `path${path.sep}to${path.sep}your${path.sep}build${path.sep}output`,
+        }),
+      );
+
+      if (path.isAbsolute(rawArtifactPath)) {
+        relativeArtifactPath = path.relative(process.cwd(), rawArtifactPath);
+      } else {
+        relativeArtifactPath = rawArtifactPath;
+      }
+
+      try {
+        await fs.promises.access(
+          path.join(process.cwd(), relativeArtifactPath),
+        );
+        validPath = true;
+      } catch {
+        validPath = await abortIfCancelled(
+          clack.select({
+            message: `We couldn't find artifacts at ${relativeArtifactPath}. Are you sure that this is the location that contains your build artifacts?`,
+            options: [
+              {
+                label: 'No, let me verify.',
+                value: false,
+              },
+              { label: 'Yes, I am sure!', value: true },
+            ],
+            initialValue: false,
+          }),
+        );
+      }
+    } while (!validPath);
+
+    const relativePosixArtifactPath = relativeArtifactPath
+      .split(path.sep)
+      .join(path.posix.sep);
+
+    await abortIfCancelled(
+      clack.select({
+        message: `Verify that your build tool is generating source maps. ${chalk.dim(
+          '(Your build output folder should contain .js.map files after a build)',
+        )}`,
+        options: [{ label: 'I checked. Continue!', value: true }],
+        initialValue: true,
+      }),
+    );
+
+    packageDotJson.scripts = packageDotJson.scripts || {};
+    packageDotJson.scripts[
+      'sentry:ci'
+    ] = `sentry-cli sourcemaps inject --org ${options.orgSlug} --project ${options.projectSlug} ${relativePosixArtifactPath} && sentry-cli sourcemaps upload --org ${options.orgSlug} --project ${options.projectSlug} ${relativePosixArtifactPath}`;
+
+    await fs.promises.writeFile(
+      path.join(process.cwd(), 'package.json'),
+      JSON.stringify(packageDotJson, null, 2),
+    );
+
+    clack.log.info(
+      `Added a ${chalk.cyan('sentry:ci')} script to your ${chalk.cyan(
+        'package.json',
+      )}. Make sure to run this script ${chalk.bold(
+        'after',
+      )} building your application but ${chalk.bold('before')} deploying!`,
+    );
+
+    const addedToCI = await abortIfCancelled(
+      clack.select({
+        message: `Did you add running the ${chalk.cyan(
+          'sentry:ci',
+        )} script to your CI pipeline ${chalk.bold('after the build step')}?`,
+        options: [
+          { label: 'Yes, continue!', value: true },
+          {
+            label: "I'll do it later...",
+            value: false,
+            hint: chalk.yellow(
+              'You need to run the command after each build for source maps to work properly.',
+            ),
+          },
+        ],
+        initialValue: true,
+      }),
+    );
+
+    if (!addedToCI) {
+      clack.log.info("Don't forget! :)");
+    }
+
+    await addSentryCliRc(options.authToken);
+  };

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -21,6 +21,7 @@ interface WizardProjectData {
 }
 
 export type PackageDotJson = {
+  scripts?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
 };
@@ -356,12 +357,16 @@ export async function addSentryCliRc(authToken: string): Promise<void> {
           `${clircContents}\n[auth]\ntoken=${authToken}\n`,
           { encoding: 'utf8', flag: 'w' },
         );
-        clack.log.success(`Added auth token to ${chalk.bold('.sentryclirc')}`);
+        clack.log.success(
+          `Added auth token to ${chalk.bold(
+            '.sentryclirc',
+          )} for you to test uploading source maps locally.`,
+        );
       } catch {
         clack.log.warning(
           `Failed to add auth token to ${chalk.bold(
             '.sentryclirc',
-          )}. Uploading source maps during build will likely not work.`,
+          )}. Uploading source maps during build will likely not work locally.`,
         );
       }
     }
@@ -373,13 +378,15 @@ export async function addSentryCliRc(authToken: string): Promise<void> {
         { encoding: 'utf8', flag: 'w' },
       );
       clack.log.success(
-        `Created ${chalk.bold('.sentryclirc')} with auth token.`,
+        `Created ${chalk.bold(
+          '.sentryclirc',
+        )} with auth token for you to test uploading source maps locally.`,
       );
     } catch {
       clack.log.warning(
         `Failed to create ${chalk.bold(
           '.sentryclirc',
-        )} with auth token. Uploading source maps during build will likely not work.`,
+        )} with auth token. Uploading source maps during build will likely not work locally.`,
       );
     }
   }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-wizard/issues/312

Adds catch-all sourcemap flow that:
- Will install `@sentry/cli`
- Asks the user to provide a path to their build artifacts
- Asks the user to verify that their build tool is generating source maps
- Will create a `package.json` script `sentry:ci` that will inject debug IDs into build artifacts and upload the artifacts
- Create a `.sentryclirc` file with an auth token so that the user can try the whole flow locally