### PR TITLE
feat(sourcemaps): Add setup flow for Webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - feat(sourcemaps): Add bundler selection prompt (#304)
 - feat(sourcemaps): Add Login and Project Selection flow (#300)
-- feat(sourcemaps): Add setup flow for Vite (#308)
 - feat(sourcemaps): Add setup flow for sentry-cli (#314)
+- feat(sourcemaps): Add setup flow for Vite (#308)
+- feat(sourcemaps): Add setup flow for Webpack (#317)
 - feat(sourcemaps): Add Sourcemaps as selectable integration (#302)
 - feat(sourcemaps): Create `.env.sentry-build-plugin` instead of `.sentryclirc` to set auth token (#313)
 - feat: Add empty sourcemaps wizard (#295)

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -14,6 +14,7 @@ import { isUnicodeSupported } from '../utils/vendor/is-unicorn-supported';
 import { SourceMapUploadToolConfigurationOptions } from './tools/types';
 import { configureVitePlugin } from './tools/vite';
 import { configureSentryCLI } from './tools/sentry-cli';
+import { configureWebPackPlugin } from './tools/webpack';
 
 interface SourceMapsWizardOptions {
   promoCode?: string;
@@ -158,6 +159,9 @@ async function startToolSetupFlow(
   switch (selctedTool) {
     case 'vite':
       await configureVitePlugin(options);
+      break;
+    case 'webpack':
+      await configureWebPackPlugin(options);
       break;
     // TODO: implement other bundlers
     default:

--- a/src/sourcemaps/tools/webpack.ts
+++ b/src/sourcemaps/tools/webpack.ts
@@ -1,0 +1,67 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack, { select } from '@clack/prompts';
+import chalk from 'chalk';
+import {
+  abortIfCancelled,
+  addDotEnvSentryBuildPluginFile,
+  getPackageDotJson,
+  hasPackageInstalled,
+  installPackage,
+} from '../../utils/clack-utils';
+
+import {
+  SourceMapUploadToolConfigurationFunction,
+  SourceMapUploadToolConfigurationOptions,
+} from './types';
+
+const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
+  chalk.gray(`
+${chalk.greenBright(
+  'const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");',
+)}
+
+module.exports = {
+  // ... other config options
+  ${chalk.greenBright(
+    'devtool: "source-map", // Source map generation must be turned on',
+  )}
+  plugins: [
+    ${chalk.greenBright(`sentryWebpackPlugin({
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "${options.orgSlug}",
+      project: "${options.projectSlug}",${
+      options.selfHosted ? `\n      url: "${options.url}",` : ''
+    }  
+    })`)},
+  ],
+};
+`);
+
+export const configureWebPackPlugin: SourceMapUploadToolConfigurationFunction =
+  async (options) => {
+    await installPackage({
+      packageName: '@sentry/webpack-plugin',
+      alreadyInstalled: hasPackageInstalled(
+        '@sentry/webpack-plugin',
+        await getPackageDotJson(),
+      ),
+    });
+
+    clack.log.step(
+      `Add the following code to your ${chalk.bold('webpack.config.js')} file:`,
+    );
+
+    // Intentially logging directly to console here so that the code can be copied/pasted directly
+    // eslint-disable-next-line no-console
+    console.log(getCodeSnippet(options));
+
+    await abortIfCancelled(
+      select({
+        message: 'Did you copy the snippet above?',
+        options: [{ label: 'Yes, continue!', value: true }],
+        initialValue: true,
+      }),
+    );
+
+    await addDotEnvSentryBuildPluginFile(options.authToken);
+  };


### PR DESCRIPTION
This PR adds a setup flow for webpack:
* install/update `@sentry/webpack-plugin`
* code snippet for `webpack.config.js`
* add `.env.sentry-build-plugin` file w/ auth token

ref #305  