### PR TITLE
ref(sourcemaps): Temporarily remove Rollup and esbuild options

### DIFF
--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -137,16 +137,17 @@ async function askForUsedBundlerTool(): Promise<SupportedBundlersTools> {
           value: 'vite',
           hint: 'Configure source maps upload using Vite',
         },
-        {
-          label: 'esbuild',
-          value: 'esbuild',
-          hint: 'Configure source maps upload using esbuild',
-        },
-        {
-          label: 'Rollup',
-          value: 'rollup',
-          hint: 'Configure source maps upload using Rollup',
-        },
+        // TODO: Implement rollup and esbuild flows
+        // {
+        //   label: 'esbuild',
+        //   value: 'esbuild',
+        //   hint: 'Configure source maps upload using esbuild',
+        // },
+        // {
+        //   label: 'Rollup',
+        //   value: 'rollup',
+        //   hint: 'Configure source maps upload using Rollup',
+        // },
         {
           label: 'None of the above',
           value: 'sentry-cli',


### PR DESCRIPTION
We'll ship the first iteration without these flows so let's remove them temporarily from the tool selection step

#skip-changelog