### PR TITLE
feat(sourcemaps): Record in telemetry which build tool was selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(sourcemaps): Record in telemetry which build tool was selected (#321)
+
 ## 3.3.0
 
 - feat(sourcemaps): Add bundler selection prompt (#304)

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -48,6 +48,8 @@ export async function runSourcemapsWizard(
 
   const selectedTool = await askForUsedBundlerTool();
 
+  Sentry.setTag('selected-tool', selectedTool);
+
   await startToolSetupFlow(selectedTool, {
     selfHosted,
     orgSlug: selectedProject.organization.slug,


### PR DESCRIPTION
Sets the selected build tool as a tag. Small oversight from: https://github.com/getsentry/sentry-wizard/pull/318