### PR TITLE
Fix gitignore typo 

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -413,7 +413,7 @@ export async function addSentryCliRc(authToken: string): Promise<void> {
     }
   }
 
-  await addAuthTokenFileToGitIgnore('.sentyclirc');
+  await addAuthTokenFileToGitIgnore('.sentryclirc');
 }
 
 export async function addDotEnvSentryBuildPluginFile(


### PR DESCRIPTION
`.sentryclirc` is spelled wrong so it is not ignored by git