### PR TITLE
meta: Update changelog with external contribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Typo in gitignore insertion (#322)
+
 ## 3.3.1
 
 - feat(sourcemaps): Record in telemetry which build tool was selected (#321)


### PR DESCRIPTION
Updates the changelog with item from external contrib.

Danger doesn't seem to run for forks.

#skip-changelog