### PR TITLE
feat(sourcemaps): Add `tsc` flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(sourcemaps): Add `tsc` flow (#324)
+
 ## 3.3.2
 
 - fix: Typo in gitignore insertion (#322)

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -93,9 +93,9 @@ export async function configureSentryCLI(
 
   const addedToCI = await abortIfCancelled(
     clack.select({
-      message: `Did you add running the ${chalk.cyan(
+      message: `Did you add a step to your CI pipeline that runs the ${chalk.cyan(
         'sentry:ci',
-      )} script to your CI pipeline ${chalk.bold('after the build step')}?`,
+      )} script ${chalk.bold('right after')} building your application?`,
       options: [
         { label: 'Yes, continue!', value: true },
         {

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -12,117 +12,121 @@ import {
   installPackage,
 } from '../../utils/clack-utils';
 
-import { SourceMapUploadToolConfigurationFunction } from './types';
+import { SourceMapUploadToolConfigurationOptions } from './types';
 
-export const configureSentryCLI: SourceMapUploadToolConfigurationFunction =
-  async (options) => {
-    const packageDotJson = await getPackageDotJson();
+export async function configureSentryCLI(
+  options: SourceMapUploadToolConfigurationOptions,
+  configureSourcemapGenerationFlow: () => Promise<void> = defaultConfigureSourcemapGenerationFlow,
+): Promise<void> {
+  const packageDotJson = await getPackageDotJson();
 
-    await installPackage({
-      packageName: '@sentry/cli',
-      alreadyInstalled: hasPackageInstalled('@sentry/cli', packageDotJson),
-    });
+  await installPackage({
+    packageName: '@sentry/cli',
+    alreadyInstalled: hasPackageInstalled('@sentry/cli', packageDotJson),
+  });
 
-    let validPath = false;
-    let relativeArtifactPath;
-    do {
-      const rawArtifactPath = await abortIfCancelled(
-        clack.text({
-          message: 'Where are your build artifacts located?',
-          placeholder: `.${path.sep}out`,
-        }),
-      );
-
-      if (path.isAbsolute(rawArtifactPath)) {
-        relativeArtifactPath = path.relative(process.cwd(), rawArtifactPath);
-      } else {
-        relativeArtifactPath = rawArtifactPath;
-      }
-
-      try {
-        await fs.promises.access(
-          path.join(process.cwd(), relativeArtifactPath),
-        );
-        validPath = true;
-      } catch {
-        validPath = await abortIfCancelled(
-          clack.select({
-            message: `We couldn't find artifacts at ${relativeArtifactPath}. Are you sure that this is the location that contains your build artifacts?`,
-            options: [
-              {
-                label: 'No, let me verify.',
-                value: false,
-              },
-              { label: 'Yes, I am sure!', value: true },
-            ],
-            initialValue: false,
-          }),
-        );
-      }
-    } while (!validPath);
-
-    const relativePosixArtifactPath = relativeArtifactPath
-      .split(path.sep)
-      .join(path.posix.sep);
-
-    await abortIfCancelled(
-      clack.select({
-        message: `Verify that your build tool is generating source maps. ${chalk.dim(
-          '(Your build output folder should contain .js.map files after a build)',
-        )}`,
-        options: [{ label: 'I checked. Continue!', value: true }],
-        initialValue: true,
+  let validPath = false;
+  let relativeArtifactPath;
+  do {
+    const rawArtifactPath = await abortIfCancelled(
+      clack.text({
+        message: 'Where are your build artifacts located?',
+        placeholder: `.${path.sep}out`,
       }),
     );
 
-    packageDotJson.scripts = packageDotJson.scripts || {};
-    packageDotJson.scripts['sentry:ci'] = `sentry-cli sourcemaps inject --org ${
-      options.orgSlug
-    } --project ${
-      options.projectSlug
-    } ${relativePosixArtifactPath} && sentry-cli${
-      options.selfHosted ? ` --url ${options.url}` : ''
-    }  sourcemaps upload --org ${options.orgSlug} --project ${
-      options.projectSlug
-    } ${relativePosixArtifactPath}`;
-
-    await fs.promises.writeFile(
-      path.join(process.cwd(), 'package.json'),
-      JSON.stringify(packageDotJson, null, 2),
-    );
-
-    clack.log.info(
-      `Added a ${chalk.cyan('sentry:ci')} script to your ${chalk.cyan(
-        'package.json',
-      )}. Make sure to run this script ${chalk.bold(
-        'after',
-      )} building your application but ${chalk.bold('before')} deploying!`,
-    );
-
-    const addedToCI = await abortIfCancelled(
-      clack.select({
-        message: `Did you add running the ${chalk.cyan(
-          'sentry:ci',
-        )} script to your CI pipeline ${chalk.bold('after the build step')}?`,
-        options: [
-          { label: 'Yes, continue!', value: true },
-          {
-            label: "I'll do it later...",
-            value: false,
-            hint: chalk.yellow(
-              'You need to run the command after each build for source maps to work properly.',
-            ),
-          },
-        ],
-        initialValue: true,
-      }),
-    );
-
-    Sentry.setTag('added-ci-script', addedToCI);
-
-    if (!addedToCI) {
-      clack.log.info("Don't forget! :)");
+    if (path.isAbsolute(rawArtifactPath)) {
+      relativeArtifactPath = path.relative(process.cwd(), rawArtifactPath);
+    } else {
+      relativeArtifactPath = rawArtifactPath;
     }
 
-    await addSentryCliRc(options.authToken);
-  };
+    try {
+      await fs.promises.access(path.join(process.cwd(), relativeArtifactPath));
+      validPath = true;
+    } catch {
+      validPath = await abortIfCancelled(
+        clack.select({
+          message: `We couldn't find artifacts at ${relativeArtifactPath}. Are you sure that this is the location that contains your build artifacts?`,
+          options: [
+            {
+              label: 'No, let me verify.',
+              value: false,
+            },
+            { label: 'Yes, I am sure!', value: true },
+          ],
+          initialValue: false,
+        }),
+      );
+    }
+  } while (!validPath);
+
+  const relativePosixArtifactPath = relativeArtifactPath
+    .split(path.sep)
+    .join(path.posix.sep);
+
+  await configureSourcemapGenerationFlow();
+
+  packageDotJson.scripts = packageDotJson.scripts || {};
+  packageDotJson.scripts['sentry:ci'] = `sentry-cli sourcemaps inject --org ${
+    options.orgSlug
+  } --project ${
+    options.projectSlug
+  } ${relativePosixArtifactPath} && sentry-cli${
+    options.selfHosted ? ` --url ${options.url}` : ''
+  } sourcemaps upload --org ${options.orgSlug} --project ${
+    options.projectSlug
+  } ${relativePosixArtifactPath}`;
+
+  await fs.promises.writeFile(
+    path.join(process.cwd(), 'package.json'),
+    JSON.stringify(packageDotJson, null, 2),
+  );
+
+  clack.log.info(
+    `Added a ${chalk.cyan('sentry:ci')} script to your ${chalk.cyan(
+      'package.json',
+    )}. Make sure to run this script ${chalk.bold(
+      'after',
+    )} building your application but ${chalk.bold('before')} deploying!`,
+  );
+
+  const addedToCI = await abortIfCancelled(
+    clack.select({
+      message: `Did you add running the ${chalk.cyan(
+        'sentry:ci',
+      )} script to your CI pipeline ${chalk.bold('after the build step')}?`,
+      options: [
+        { label: 'Yes, continue!', value: true },
+        {
+          label: "I'll do it later...",
+          value: false,
+          hint: chalk.yellow(
+            'You need to run the command after each build for source maps to work properly.',
+          ),
+        },
+      ],
+      initialValue: true,
+    }),
+  );
+
+  Sentry.setTag('added-ci-script', addedToCI);
+
+  if (!addedToCI) {
+    clack.log.info("Don't forget! :)");
+  }
+
+  await addSentryCliRc(options.authToken);
+}
+
+async function defaultConfigureSourcemapGenerationFlow(): Promise<void> {
+  await abortIfCancelled(
+    clack.select({
+      message: `Verify that your build tool is generating source maps. ${chalk.dim(
+        '(Your build output folder should contain .js.map files after a build)',
+      )}`,
+      options: [{ label: 'I checked. Continue!', value: true }],
+      initialValue: true,
+    }),
+  );
+}

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -3,8 +3,27 @@ import clack, { select } from '@clack/prompts';
 import chalk from 'chalk';
 import { abortIfCancelled } from '../../utils/clack-utils';
 
-const getCodeSnippet = () =>
-  chalk.gray(`
+export async function configureTscSourcemapGenerationFlow(): Promise<void> {
+  clack.log.step(
+    `Add the following code to your ${chalk.bold(
+      'tsconfig.json',
+    )} file to ensure you are generating source maps:`,
+  );
+
+  // Intentially logging directly to console here so that the code can be copied/pasted directly
+  // eslint-disable-next-line no-console
+  console.log(codeSnippet);
+
+  await abortIfCancelled(
+    select({
+      message: 'Did you update your config like in the snippet above?',
+      options: [{ label: 'Yes, continue!', value: true }],
+      initialValue: true,
+    }),
+  );
+}
+
+const codeSnippet = chalk.gray(`
 {
   "compilerOptions": {
     ${chalk.greenBright('"sourceMap": true,')}
@@ -16,21 +35,3 @@ const getCodeSnippet = () =>
   }
 }
 `);
-
-export async function configureTscSourcemapGenerationFlow(): Promise<void> {
-  clack.log.step(
-    `Add the following code to your TS config file to ensure you are generating source maps:`,
-  );
-
-  // Intentially logging directly to console here so that the code can be copied/pasted directly
-  // eslint-disable-next-line no-console
-  console.log(getCodeSnippet());
-
-  await abortIfCancelled(
-    select({
-      message: 'Did you copy the snippet above?',
-      options: [{ label: 'Yes, continue!', value: true }],
-      initialValue: true,
-    }),
-  );
-}

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -18,7 +18,7 @@ export async function configureTscSourcemapGenerationFlow(): Promise<void> {
 
   await abortIfCancelled(
     select({
-      message: 'Did you update your config like in the snippet above?',
+      message: 'Did you update your config as shown in the snippet above?',
       options: [{ label: 'Yes, continue!', value: true }],
       initialValue: true,
     }),

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -7,7 +7,9 @@ export async function configureTscSourcemapGenerationFlow(): Promise<void> {
   clack.log.step(
     `Add the following code to your ${chalk.bold(
       'tsconfig.json',
-    )} file to ensure you are generating source maps:`,
+    )} file: ${chalk.dim(
+      '(This ensures that source maps are generated correctly)',
+    )}`,
   );
 
   // Intentially logging directly to console here so that the code can be copied/pasted directly

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -1,0 +1,36 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack, { select } from '@clack/prompts';
+import chalk from 'chalk';
+import { abortIfCancelled } from '../../utils/clack-utils';
+
+const getCodeSnippet = () =>
+  chalk.gray(`
+{
+  "compilerOptions": {
+    ${chalk.greenBright('"sourceMap": true,')}
+    ${chalk.greenBright('"inlineSources": true,')}
+
+    // Set \`sourceRoot\` to  "/" to strip the build path prefix from
+    // generated source code references. This will improve issue grouping in Sentry.
+    ${chalk.greenBright('"sourceRoot": "/"')}
+  }
+}
+`);
+
+export async function configureTscSourcemapGenerationFlow(): Promise<void> {
+  clack.log.step(
+    `Add the following code to your TS config file to ensure you are generating source maps:`,
+  );
+
+  // Intentially logging directly to console here so that the code can be copied/pasted directly
+  // eslint-disable-next-line no-console
+  console.log(getCodeSnippet());
+
+  await abortIfCancelled(
+    select({
+      message: 'Did you copy the snippet above?',
+      options: [{ label: 'Yes, continue!', value: true }],
+      initialValue: true,
+    }),
+  );
+}


### PR DESCRIPTION
Adds a separate tsc wizard to the sourcemaps flow that mostly reuses the sentry cli flow but has a separate prompt to instruct users to correctly configure their tsconfig.json.

Ref:
https://github.com/getsentry/sentry-wizard/issues/305
https://github.com/getsentry/sentry-wizard/issues/290