### PR TITLE
feat(sourcemaps): Add Rollup plugin flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(sourcemaps): Add Rollup plugin flow #325
+
 ## 3.3.2
 
 - fix: Typo in gitignore insertion (#322)

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -16,6 +16,7 @@ import { SourceMapUploadToolConfigurationOptions } from './tools/types';
 import { configureVitePlugin } from './tools/vite';
 import { configureSentryCLI } from './tools/sentry-cli';
 import { configureWebPackPlugin } from './tools/webpack';
+import { configureRollupPlugin } from './tools/rollup';
 
 interface SourceMapsWizardOptions {
   promoCode?: string;
@@ -139,16 +140,16 @@ async function askForUsedBundlerTool(): Promise<SupportedBundlersTools> {
           value: 'vite',
           hint: 'Configure source maps upload using Vite',
         },
-        // TODO: Implement rollup and esbuild flows
+        {
+          label: 'Rollup',
+          value: 'rollup',
+          hint: 'Configure source maps upload using Rollup',
+        },
+        // TODO: Implement esbuild flow
         // {
         //   label: 'esbuild',
         //   value: 'esbuild',
         //   hint: 'Configure source maps upload using esbuild',
-        // },
-        // {
-        //   label: 'Rollup',
-        //   value: 'rollup',
-        //   hint: 'Configure source maps upload using Rollup',
         // },
         {
           label: 'None of the above',
@@ -172,6 +173,9 @@ async function startToolSetupFlow(
       break;
     case 'webpack':
       await configureWebPackPlugin(options);
+      break;
+    case 'rollup':
+      await configureRollupPlugin(options);
       break;
     // TODO: implement other bundlers
     default:

--- a/src/sourcemaps/tools/rollup.ts
+++ b/src/sourcemaps/tools/rollup.ts
@@ -16,27 +16,27 @@ import {
 
 const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
   chalk.gray(`
-  ${chalk.greenBright(
-    'import { sentryRollupPlugin } from "@sentry/rollup-plugin";',
-  )}
+${chalk.greenBright(
+  'import { sentryRollupPlugin } from "@sentry/rollup-plugin";',
+)}
 
-  export default {
-    output: {
-      ${chalk.greenBright(
-        'sourcemap: true, // Source map generation must be turned on',
-      )}
-    },
-    plugins: [
-      // Put the Sentry rollup plugin after all other plugins
-      ${chalk.greenBright(`sentryRollupPlugin({
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: "${options.orgSlug}",
-        project: "${options.projectSlug}",${
-        options.selfHosted ? `\n      url: "${options.url}",` : ''
-      }
-      }),`)}
-    ],
-  };
+export default {
+  output: {
+    ${chalk.greenBright(
+      'sourcemap: true, // Source map generation must be turned on',
+    )}
+  },
+  plugins: [
+    // Put the Sentry rollup plugin after all other plugins
+    ${chalk.greenBright(`sentryRollupPlugin({
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "${options.orgSlug}",
+      project: "${options.projectSlug}",${
+      options.selfHosted ? `\n      url: "${options.url}",` : ''
+    }
+    }),`)}
+  ],
+};
 `);
 
 export const configureRollupPlugin: SourceMapUploadToolConfigurationFunction =

--- a/src/sourcemaps/tools/rollup.ts
+++ b/src/sourcemaps/tools/rollup.ts
@@ -50,7 +50,7 @@ export const configureRollupPlugin: SourceMapUploadToolConfigurationFunction =
     });
 
     clack.log.step(
-      `Add the following code to your ${chalk.bold('rollup.config.js')} file:`,
+      `Add the following code to your rollup config:`,
     );
 
     // Intentially logging directly to console here so that the code can be copied/pasted directly

--- a/src/sourcemaps/tools/rollup.ts
+++ b/src/sourcemaps/tools/rollup.ts
@@ -1,0 +1,69 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack, { select } from '@clack/prompts';
+import chalk from 'chalk';
+import {
+  abortIfCancelled,
+  addDotEnvSentryBuildPluginFile,
+  getPackageDotJson,
+  hasPackageInstalled,
+  installPackage,
+} from '../../utils/clack-utils';
+
+import {
+  SourceMapUploadToolConfigurationFunction,
+  SourceMapUploadToolConfigurationOptions,
+} from './types';
+
+const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
+  chalk.gray(`
+  ${chalk.greenBright(
+    'import { sentryRollupPlugin } from "@sentry/rollup-plugin";',
+  )}
+
+  export default {
+    output: {
+      ${chalk.greenBright(
+        'sourcemap: true, // Source map generation must be turned on',
+      )}
+    },
+    plugins: [
+      // Put the Sentry rollup plugin after all other plugins
+      ${chalk.greenBright(`sentryRollupPlugin({
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        org: "${options.orgSlug}",
+        project: "${options.projectSlug}",${
+        options.selfHosted ? `\n      url: "${options.url}",` : ''
+      }
+      }),`)}
+    ],
+  };
+`);
+
+export const configureRollupPlugin: SourceMapUploadToolConfigurationFunction =
+  async (options) => {
+    await installPackage({
+      packageName: '@sentry/rollup-plugin',
+      alreadyInstalled: hasPackageInstalled(
+        '@sentry/rollup-plugin',
+        await getPackageDotJson(),
+      ),
+    });
+
+    clack.log.step(
+      `Add the following code to your ${chalk.bold('rollup.config.js')} file:`,
+    );
+
+    // Intentially logging directly to console here so that the code can be copied/pasted directly
+    // eslint-disable-next-line no-console
+    console.log(getCodeSnippet(options));
+
+    await abortIfCancelled(
+      select({
+        message: 'Did you copy the snippet above?',
+        options: [{ label: 'Yes, continue!', value: true }],
+        initialValue: true,
+      }),
+    );
+
+    await addDotEnvSentryBuildPluginFile(options.authToken);
+  };


### PR DESCRIPTION
This PR adds the source maps setup flow for rollup (with our rollup plugin). It's basically identical to the Vite/Webpack flows, just with adjusted code snippets and package installs.

(Tested w/ a node app that's bundled with rollup - works as expected)

ref #305 