### PR TITLE
feat(sourcemaps): Add setup flow for esbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- feat(sourcemaps): Add `tsc` flow (#324)
-- feat(sourcemaps): Add Rollup plugin flow (#325)
+- feat(sourcemaps): Add setup flow for esbuild (#327)
+- feat(sourcemaps): Add setup flow for Rollup (#325)
+- feat(sourcemaps): Add setup flow for `tsc` (#324)
 
 ## 3.3.2
 

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -18,6 +18,7 @@ import { configureSentryCLI } from './tools/sentry-cli';
 import { configureWebPackPlugin } from './tools/webpack';
 import { configureTscSourcemapGenerationFlow } from './tools/tsc';
 import { configureRollupPlugin } from './tools/rollup';
+import { configureEsbuildPlugin } from './tools/esbuild';
 
 interface SourceMapsWizardOptions {
   promoCode?: string;
@@ -146,21 +147,20 @@ async function askForUsedBundlerTool(): Promise<SupportedTools> {
           hint: 'Configure source maps upload using Vite',
         },
         {
-          label: 'tsc',
-          value: 'tsc',
-          hint: 'Configure source maps when using tsc as build tool',
+          label: 'esbuild',
+          value: 'esbuild',
+          hint: 'Configure source maps upload using esbuild',
         },
         {
           label: 'Rollup',
           value: 'rollup',
           hint: 'Configure source maps upload using Rollup',
         },
-        // TODO: Implement esbuild flow
-        // {
-        //   label: 'esbuild',
-        //   value: 'esbuild',
-        //   hint: 'Configure source maps upload using esbuild',
-        // },
+        {
+          label: 'tsc',
+          value: 'tsc',
+          hint: 'Configure source maps when using tsc as build tool',
+        },
         {
           label: 'None of the above',
           value: 'sentry-cli',
@@ -178,17 +178,20 @@ async function startToolSetupFlow(
   options: SourceMapUploadToolConfigurationOptions,
 ): Promise<void> {
   switch (selctedTool) {
-    case 'vite':
-      await configureVitePlugin(options);
-      break;
     case 'webpack':
       await configureWebPackPlugin(options);
       break;
-    case 'tsc':
-      await configureSentryCLI(options, configureTscSourcemapGenerationFlow);
+    case 'vite':
+      await configureVitePlugin(options);
+      break;
+    case 'esbuild':
+      await configureEsbuildPlugin(options);
       break;
     case 'rollup':
       await configureRollupPlugin(options);
+      break;
+    case 'tsc':
+      await configureSentryCLI(options, configureTscSourcemapGenerationFlow);
       break;
     default:
       await configureSentryCLI(options);

--- a/src/sourcemaps/tools/esbuild.ts
+++ b/src/sourcemaps/tools/esbuild.ts
@@ -1,0 +1,65 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import clack, { select } from '@clack/prompts';
+import chalk from 'chalk';
+import {
+  abortIfCancelled,
+  addDotEnvSentryBuildPluginFile,
+  getPackageDotJson,
+  hasPackageInstalled,
+  installPackage,
+} from '../../utils/clack-utils';
+
+import {
+  SourceMapUploadToolConfigurationFunction,
+  SourceMapUploadToolConfigurationOptions,
+} from './types';
+
+const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
+  chalk.gray(`
+${chalk.greenBright(
+  'const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");',
+)}
+
+require("esbuild").build({
+  ${chalk.greenBright(
+    'sourcemap: true, // Source map generation must be turned on',
+  )}
+  plugins: [
+    // Put the Sentry esbuild plugin after all other plugins
+    ${chalk.greenBright(`sentryEsbuildPlugin({
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "${options.orgSlug}",
+      project: "${options.projectSlug}",${
+      options.selfHosted ? `\n      url: "${options.url}",` : ''
+    }
+    }),`)}
+  ],
+});
+`);
+
+export const configureEsbuildPlugin: SourceMapUploadToolConfigurationFunction =
+  async (options) => {
+    await installPackage({
+      packageName: '@sentry/esbuild-plugin',
+      alreadyInstalled: hasPackageInstalled(
+        '@sentry/esbuild-plugin',
+        await getPackageDotJson(),
+      ),
+    });
+
+    clack.log.step(`Add the following code to your esbuild config:`);
+
+    // Intentially logging directly to console here so that the code can be copied/pasted directly
+    // eslint-disable-next-line no-console
+    console.log(getCodeSnippet(options));
+
+    await abortIfCancelled(
+      select({
+        message: 'Did you copy the snippet above?',
+        options: [{ label: 'Yes, continue!', value: true }],
+        initialValue: true,
+      }),
+    );
+
+    await addDotEnvSentryBuildPluginFile(options.authToken);
+  };


### PR DESCRIPTION
This PR adds the source maps setup flow for esbuild (with our esbuild plugin). It's basically identical to the Vite/Webpack flows, just with adjusted code snippets and package installs.

ref #305 