### PR TITLE
feat: Open browser when logging in (sourcemaps, sveltekit, nextjs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: Open browser when logging in (sourcemaps, sveltekit, nextjs)
+- feat: Open browser when logging in (sourcemaps, sveltekit, nextjs) (#328)
 
 ## 3.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: Open browser when logging in (sourcemaps, sveltekit, nextjs)
+
 ## 3.4.0
 
 - feat(sourcemaps): Add setup flow for esbuild (#327)

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -186,7 +186,7 @@ export async function askForWizardLogin(options: {
   const urlToOpen = loginUrl.toString();
   clack.log.info(
     `${chalk.bold(
-      `Please open the following link in your browser to ${
+      `If the browser window didn't open automatically, please open the following link to ${
         hasSentryAccount ? 'log' : 'sign'
       } into Sentry:`,
     )}\n\n${chalk.cyan(urlToOpen)}`,

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -11,6 +11,10 @@ import { promisify } from 'util';
 import * as Sentry from '@sentry/node';
 import { windowedSelect } from './vendor/clack-custom-select';
 
+const opn = require('opn') as (
+  url: string,
+) => Promise<childProcess.ChildProcess>;
+
 const SAAS_URL = 'https://sentry.io/';
 
 interface WizardProjectData {
@@ -179,13 +183,18 @@ export async function askForWizardLogin(options: {
     loginUrl.searchParams.set('code', options.promoCode);
   }
 
+  const urlToOpen = loginUrl.toString();
   clack.log.info(
     `${chalk.bold(
       `Please open the following link in your browser to ${
         hasSentryAccount ? 'log' : 'sign'
       } into Sentry:`,
-    )}\n\n${chalk.cyan(loginUrl.toString())}`,
+    )}\n\n${chalk.cyan(urlToOpen)}`,
   );
+
+  opn(urlToOpen).catch(() => {
+    // opn throws in environments that don't have a browser (e.g. remote shells) so we just noop here
+  });
 
   const loginSpinner = clack.spinner();
 


### PR DESCRIPTION
With this PR, the wizard will automatically open the browser when asking the user to sign into Sentry. We used to have this functionality in our old wizard but removed it temporarily when switching to `clack`. Now we're gonna bring it back 🚀 

I initially wanted to switch to `open` instead of `opn` because the name of the library changed and `opn` is deprecated since a while. However, `open` is esm-only and we transpile to CJS. I tried a bunch of things and the only thing that works without changing our build setup is to dynamically import the module. This however is only available since node 14 (13) which would raise our minimum supported Node version from 6.9 to 14 :( 

So I guess the solution here is to switch to rollup and convert `open` to cjs when building... While we should definitely do this, it would be out of scope for this PR.

ref #290  