### PR TITLE
fix: Backfill `url` arg only in old wizard flows

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { DEFAULT_URL, Integration, Platform } from './lib/Constants';
+import { Integration, Platform } from './lib/Constants';
 import { run } from './lib/Setup';
 import { runNextjsWizard } from './src/nextjs/nextjs-wizard';
 import { runSourcemapsWizard } from './src/sourcemaps/sourcemaps-wizard';
@@ -45,7 +45,6 @@ const argv = require('yargs')
   })
   .option('u', {
     alias: 'url',
-    default: undefined,
     describe: 'The url to your Sentry installation\nenv: SENTRY_WIZARD_URL',
   })
   .option('s', {
@@ -67,7 +66,7 @@ const argv = require('yargs')
 // Collect argv options that are relevant for the new wizard
 // flows based on `clack`
 const wizardOptions: WizardOptions = {
-  url: argv.u as string | undefined,
+  url: argv.url as string | undefined,
   promoCode: argv['promo-code'] as string | undefined,
 };
 
@@ -91,17 +90,5 @@ switch (argv.i) {
     ).catch(console.error);
     break;
   default:
-    runOldWizard();
-}
-
-function runOldWizard() {
-  // For the `clack`-based wizard flows, we don't want a default url value
-  // For backwards-compatibility with the other flows, we fill it in here
-  const argvWithUrlDefaults = {
-    ...argv,
-    url: argv.url || DEFAULT_URL,
-    u: argv.u || DEFAULT_URL,
-  };
-
-  void run(argvWithUrlDefaults);
+    void run(argv);
 }

--- a/lib/Helper/Wizard.ts
+++ b/lib/Helper/Wizard.ts
@@ -2,25 +2,16 @@ import type { Answers } from 'inquirer';
 import * as _ from 'lodash';
 
 import type { Args } from '../Constants';
-import { DEFAULT_URL } from '../Constants';
 import type { IStep } from '../Steps/BaseStep';
 import type { BaseIntegration } from '../Steps/Integrations/BaseIntegration';
 import { BottomBar } from './BottomBar';
 import { debug, dim, nl, red } from './Logging';
 
 function sanitizeAndValidateArgs(argv: Args): void {
-  if (!argv.url) {
-    argv.url = DEFAULT_URL;
-    dim(`no URL provided, fallback to ${argv.url}`);
-  }
   if (argv.quiet === undefined) {
     argv.quiet = true;
     dim('will activate quiet mode for you');
   }
-  let baseUrl = argv.url;
-  baseUrl += baseUrl.endsWith('/') ? '' : '/';
-  baseUrl = baseUrl.replace(/:\/(?!\/)/g, '://');
-  argv.url = baseUrl;
   // @ts-ignore skip-connect does not exist on args
   if (argv['skip-connect']) {
     // @ts-ignore skip-connect does not exist on args

--- a/lib/Setup.ts
+++ b/lib/Setup.ts
@@ -6,6 +6,7 @@ import * as Step from './Steps';
 
 export async function run(argv: any): Promise<any> {
   const args = { ...argv, ...readEnvironment() };
+
   if (args.uninstall === undefined) {
     args.uninstall = false;
   }


### PR DESCRIPTION
Previously, in #331 we backfilled the `url` arg as soon as we entered the old wizard execution, which caused our clack-based flows (which were invoked by shim classes in this case) to have a pre-defined default url. Since we explicitly ask users for self-hosted/SaaS in these flows, we don't want a default value for this arg but only use it when users specified it explicitly. 

This PR reduces the backfilling to the old non-clack flows.

ref #290 

since #331 wasn't released yet:
#skip-changelog