### PR TITLE
fix(sourcemaps): Adjust initial-sdk-version tag value

### DIFF
--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -158,7 +158,7 @@ https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#upgradi
 }
 
 async function handleAutoUpdateSdk(packageName: string) {
-  Sentry.setTag('initial-sdk-version', '>=7.0.0 <= 7.47.0');
+  Sentry.setTag('initial-sdk-version', '>=7.0.0 <7.47.0');
 
   const shouldUpdate = await abortIfCancelled(
     clack.select({


### PR DESCRIPTION
Noticed that the tag for a v7 version that's not yet compatible with debug ids was off by one

#skip-changelog