### PR TITLE
feat(sourcemaps): Add spans for indivudiual wizard steps

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -6,6 +6,7 @@ import {
   makeNodeTransport,
   NodeClient,
   runWithAsyncContext,
+  trace,
 } from '@sentry/node';
 import packageJson from '../package.json';
 
@@ -26,6 +27,7 @@ export async function withTelemetry<F>(
   const transaction = sentryHub.startTransaction({
     name: 'sentry-wizard-execution',
     status: 'ok',
+    op: 'wizard.flow',
   });
   sentryHub.getScope().setSpan(transaction);
   const sentrySession = sentryHub.startSession();
@@ -74,6 +76,8 @@ function createSentryInstance(enabled: boolean, integration: string) {
     },
 
     transport: makeNodeTransport,
+
+    debug: true,
   });
 
   const hub = new Hub(client);
@@ -83,4 +87,8 @@ function createSentryInstance(enabled: boolean, integration: string) {
   hub.setTag('platform', process.platform);
 
   return { sentryHub: hub, sentryClient: client };
+}
+
+export function traceStep<T>(step: string, callback: () => T): T {
+  return trace({ name: step, op: 'wizard.step' }, () => callback());
 }


### PR DESCRIPTION
This PR adds a small telemetry utilitly function `traceStep` which can be used to create a span for a specific wizard step within a flow. For now we use the utility function in the sourcemaps wizard flow:

![image](https://github.com/getsentry/sentry-wizard/assets/8420481/77c4b1a6-98d0-46ec-9cc5-810079b87117)

ref #290 