### PR TITLE
feat(sourcemaps|telemetry): Add tags for installed SDK and project platform

### DIFF
--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -75,6 +75,8 @@ export async function ensureMinimumSdkVersionIsInstalled(): Promise<void> {
   const { name: installedSdkName, version: installedSdkVersionOrRange } =
     installedSdkPackage;
 
+  Sentry.setTag('installed-sdk', installedSdkName);
+
   const minInstalledVersion = getMinInstalledVersion(
     installedSdkVersionOrRange,
     installedSdkName,
@@ -198,6 +200,7 @@ async function handleAutoUpdateSdk(packageName: string) {
 
 async function handleNoSdkInstalled(): Promise<void> {
   Sentry.setTag('initial-sdk-version', 'none');
+  Sentry.setTag('installed-sdk', 'none');
 
   clack.log.warn(
     `${chalk.yellowBright(

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -34,6 +34,7 @@ export interface SentryProjectData {
   id: string;
   slug: string;
   name: string;
+  platform: string;
   organization: {
     slug: string;
   };
@@ -251,6 +252,7 @@ export async function askForProjectSelection(
   );
 
   Sentry.setTag('project', selection.slug);
+  Sentry.setTag('project-platform', selection.platform);
   Sentry.setUser({ id: selection.organization.slug });
 
   return selection;


### PR DESCRIPTION
This PR adds two tags to the (sourcemaps) wizard execution transaction:

- `installed-sdk` to capture which SDK is installed when the wizard was started
- `project-platform` the platform of the selected project. The API request to get the projects already returns this field, we just didn't use it before

cc @smeubank 

ref #290

not user-facing, so:
#skip-changelog