### PR TITLE
ref(sourcemaps): Always collect source maps wizard telemetry

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -2,7 +2,7 @@
 import { Integration, Platform } from './lib/Constants';
 import { run } from './lib/Setup';
 import { runNextjsWizard } from './src/nextjs/nextjs-wizard';
-import { runSourcemapsWizard } from './src/sourcemaps/sourcemaps-wizard';
+import { runSourcemapsWizardWithTelemetry } from './src/sourcemaps/sourcemaps-wizard';
 import { runSvelteKitWizard } from './src/sveltekit/sveltekit-wizard';
 import { runAppleWizard } from './src/apple/apple-wizard';
 import { withTelemetry } from './src/telemetry';
@@ -81,25 +81,22 @@ switch (argv.i) {
     runSvelteKitWizard(wizardOptions).catch(console.error);
     break;
   case 'sourcemaps':
-    withTelemetry(
-      {
-        enabled: !argv['disable-telemetry'],
-        integration: 'sourcemaps',
-      },
-      () => runSourcemapsWizard(wizardOptions),
+    runSourcemapsWizardWithTelemetry({
+      ...wizardOptions,
+      telemetryEnabled: !argv['disable-telemetry'],
       // eslint-disable-next-line no-console
-    ).catch(console.error);
+    }).catch(console.error);
     break;
   case 'ios':
     withTelemetry(
       {
         enabled: !argv['disable-telemetry'],
-        integration: 'ios'
+        integration: 'ios',
       },
       () => runAppleWizard(wizardOptions),
       // eslint-disable-next-line no-console
     ).catch(console.error);
-    break
+    break;
   default:
     void run(argv);
 }

--- a/bin.ts
+++ b/bin.ts
@@ -2,7 +2,7 @@
 import { Integration, Platform } from './lib/Constants';
 import { run } from './lib/Setup';
 import { runNextjsWizard } from './src/nextjs/nextjs-wizard';
-import { runSourcemapsWizardWithTelemetry } from './src/sourcemaps/sourcemaps-wizard';
+import { runSourcemapsWizard } from './src/sourcemaps/sourcemaps-wizard';
 import { runSvelteKitWizard } from './src/sveltekit/sveltekit-wizard';
 import { runAppleWizard } from './src/apple/apple-wizard';
 import { withTelemetry } from './src/telemetry';
@@ -69,6 +69,7 @@ const argv = require('yargs')
 const wizardOptions: WizardOptions = {
   url: argv.url as string | undefined,
   promoCode: argv['promo-code'] as string | undefined,
+  telemetryEnabled: !argv['disable-telemetry'],
 };
 
 switch (argv.i) {
@@ -81,11 +82,8 @@ switch (argv.i) {
     runSvelteKitWizard(wizardOptions).catch(console.error);
     break;
   case 'sourcemaps':
-    runSourcemapsWizardWithTelemetry({
-      ...wizardOptions,
-      telemetryEnabled: !argv['disable-telemetry'],
-      // eslint-disable-next-line no-console
-    }).catch(console.error);
+    // eslint-disable-next-line no-console
+    runSourcemapsWizard(wizardOptions).catch(console.error);
     break;
   case 'ios':
     withTelemetry(

--- a/lib/Helper/__tests__/SentryCli.ts
+++ b/lib/Helper/__tests__/SentryCli.ts
@@ -14,7 +14,7 @@ const args: Args = {
   uninstall: false,
   url: 'https://localhost:1234',
   signup: false,
-  disableTelemetry: false
+  disableTelemetry: false,
 };
 
 const demoAnswers: Answers = {

--- a/lib/Steps/Integrations/Apple.ts
+++ b/lib/Steps/Integrations/Apple.ts
@@ -5,28 +5,31 @@ import { runAppleWizard } from '../../../src/apple/apple-wizard';
 import { withTelemetry } from '../../../src/telemetry';
 
 export class Apple extends BaseIntegration {
-    argv: Args;
-    public constructor(protected _argv: Args) {
-        super(_argv);
-        this.argv = _argv;
-    }
+  argv: Args;
+  public constructor(protected _argv: Args) {
+    super(_argv);
+    this.argv = _argv;
+  }
 
-    public async emit(_answers: Answers): Promise<Answers> {
-        await withTelemetry(
-            {
-                enabled: !this.argv.disableTelemetry,
-                integration: 'ios'
-            },
-            async () =>
-                await runAppleWizard({ promoCode: this._argv.promoCode, url: this._argv.url, })
-            ,
-            // eslint-disable-next-line no-console
-        ).catch(console.error);
+  public async emit(_answers: Answers): Promise<Answers> {
+    await withTelemetry(
+      {
+        enabled: !this.argv.disableTelemetry,
+        integration: 'ios',
+      },
+      async () =>
+        await runAppleWizard({
+          promoCode: this._argv.promoCode,
+          url: this._argv.url,
+          telemetryEnabled: !this._argv.disableTelemetry,
+        }),
+      // eslint-disable-next-line no-console
+    ).catch(console.error);
 
-        return {};
-    }
+    return {};
+  }
 
-    public async shouldConfigure(_answers: Answers): Promise<Answers> {
-        return this._shouldConfigure;
-    }
+  public async shouldConfigure(_answers: Answers): Promise<Answers> {
+    return this._shouldConfigure;
+  }
 }

--- a/lib/Steps/Integrations/NextJsShim.ts
+++ b/lib/Steps/Integrations/NextJsShim.ts
@@ -17,6 +17,7 @@ export class NextJsShim extends BaseIntegration {
     await runNextjsWizard({
       promoCode: this._argv.promoCode,
       url: this._argv.url,
+      telemetryEnabled: !this._argv.disableTelemetry,
     });
     return {};
   }

--- a/lib/Steps/Integrations/SourceMapsShim.ts
+++ b/lib/Steps/Integrations/SourceMapsShim.ts
@@ -1,5 +1,5 @@
 import type { Answers } from 'inquirer';
-import { runSourcemapsWizard } from '../../../src/sourcemaps/sourcemaps-wizard';
+import { runSourcemapsWizardWithTelemetry } from '../../../src/sourcemaps/sourcemaps-wizard';
 
 import type { Args } from '../../Constants';
 import { BaseIntegration } from './BaseIntegration';
@@ -14,9 +14,10 @@ export class SourceMapsShim extends BaseIntegration {
   }
 
   public async emit(_answers: Answers): Promise<Answers> {
-    await runSourcemapsWizard({
+    await runSourcemapsWizardWithTelemetry({
       promoCode: this._argv.promoCode,
       url: this._argv.url,
+      telemetryEnabled: !this._argv.disableTelemetry,
     });
     return {};
   }

--- a/lib/Steps/Integrations/SourceMapsShim.ts
+++ b/lib/Steps/Integrations/SourceMapsShim.ts
@@ -1,5 +1,5 @@
 import type { Answers } from 'inquirer';
-import { runSourcemapsWizardWithTelemetry } from '../../../src/sourcemaps/sourcemaps-wizard';
+import { runSourcemapsWizard } from '../../../src/sourcemaps/sourcemaps-wizard';
 
 import type { Args } from '../../Constants';
 import { BaseIntegration } from './BaseIntegration';
@@ -14,7 +14,7 @@ export class SourceMapsShim extends BaseIntegration {
   }
 
   public async emit(_answers: Answers): Promise<Answers> {
-    await runSourcemapsWizardWithTelemetry({
+    await runSourcemapsWizard({
       promoCode: this._argv.promoCode,
       url: this._argv.url,
       telemetryEnabled: !this._argv.disableTelemetry,

--- a/lib/Steps/Integrations/SvelteKitShim.ts
+++ b/lib/Steps/Integrations/SvelteKitShim.ts
@@ -17,6 +17,7 @@ export class SvelteKitShim extends BaseIntegration {
     await runSvelteKitWizard({
       promoCode: this._argv.promoCode,
       url: this._argv.url,
+      telemetryEnabled: !this._argv.disableTelemetry,
     });
     return {};
   }

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -20,10 +20,10 @@ import { configureWebPackPlugin } from './tools/webpack';
 import { configureTscSourcemapGenerationFlow } from './tools/tsc';
 import { configureRollupPlugin } from './tools/rollup';
 import { configureEsbuildPlugin } from './tools/esbuild';
-import { WizardOptions } from '../utils/types';
+import { WizardOptions, WizardWithTelemetryOptions } from '../utils/types';
 import { configureCRASourcemapGenerationFlow } from './tools/create-react-app';
 import { ensureMinimumSdkVersionIsInstalled } from './utils/sdk-version';
-import { traceStep } from '../telemetry';
+import { traceStep, withTelemetry } from '../telemetry';
 import { URL } from 'url';
 import { checkIfMoreSuitableWizardExistsAndAskForRedirect } from './utils/other-wizards';
 import { configureAngularSourcemapGenerationFlow } from './tools/angular';
@@ -38,9 +38,23 @@ type SupportedTools =
   | 'create-react-app'
   | 'angular';
 
-export async function runSourcemapsWizard(
-  options: WizardOptions,
+export async function runSourcemapsWizardWithTelemetry(
+  options: WizardWithTelemetryOptions,
 ): Promise<void> {
+  const { telemetryEnabled, ...wizardOptions } = options;
+
+  return withTelemetry(
+    {
+      enabled: telemetryEnabled,
+      integration: 'sourcemaps',
+    },
+    () => {
+      return runSourcemapsWizard(wizardOptions);
+    },
+  );
+}
+
+async function runSourcemapsWizard(options: WizardOptions): Promise<void> {
   printWelcome({
     wizardName: 'Sentry Source Maps Upload Configuration Wizard',
     message:

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -20,7 +20,7 @@ import { configureWebPackPlugin } from './tools/webpack';
 import { configureTscSourcemapGenerationFlow } from './tools/tsc';
 import { configureRollupPlugin } from './tools/rollup';
 import { configureEsbuildPlugin } from './tools/esbuild';
-import { WizardOptions, WizardWithTelemetryOptions } from '../utils/types';
+import { WizardOptions } from '../utils/types';
 import { configureCRASourcemapGenerationFlow } from './tools/create-react-app';
 import { ensureMinimumSdkVersionIsInstalled } from './utils/sdk-version';
 import { traceStep, withTelemetry } from '../telemetry';
@@ -38,23 +38,21 @@ type SupportedTools =
   | 'create-react-app'
   | 'angular';
 
-export async function runSourcemapsWizardWithTelemetry(
-  options: WizardWithTelemetryOptions,
+export async function runSourcemapsWizard(
+  options: WizardOptions,
 ): Promise<void> {
-  const { telemetryEnabled, ...wizardOptions } = options;
-
   return withTelemetry(
     {
-      enabled: telemetryEnabled,
+      enabled: options.telemetryEnabled,
       integration: 'sourcemaps',
     },
-    () => {
-      return runSourcemapsWizard(wizardOptions);
-    },
+    () => runSourcemapsWizardWithTelemetry(options),
   );
 }
 
-async function runSourcemapsWizard(options: WizardOptions): Promise<void> {
+async function runSourcemapsWizardWithTelemetry(
+  options: WizardOptions,
+): Promise<void> {
   printWelcome({
     wizardName: 'Sentry Source Maps Upload Configuration Wizard',
     message:

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,10 @@
 export type WizardOptions = {
   /**
+   * Controls whether the wizard should send telemetry data to Sentry.
+   */
+  telemetryEnabled: boolean;
+
+  /**
    * The promo code to use while signing up for Sentry.
    * This can be passed via the --promo-code arg.
    */
@@ -10,8 +15,4 @@ export type WizardOptions = {
    * This can be passed via the `-u` or `--url` arg.
    */
   url?: string;
-};
-
-export type WizardWithTelemetryOptions = WizardOptions & {
-  telemetryEnabled: boolean;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -11,3 +11,7 @@ export type WizardOptions = {
    */
   url?: string;
 };
+
+export type WizardWithTelemetryOptions = WizardOptions & {
+  telemetryEnabled: boolean;
+};


### PR DESCRIPTION
Previously, we only collected telemetry when the source maps wizard was directly started with the `-i sourcemaps` arg. This is probably the majority of cases anyway. However, for the sake of consistency, we should always collect telemetry. Therefore, this PR slightly refactors the location of the `withTelemetry` call so that we're now always using it. 

#skip-changelog
ref #290