### PR TITLE
Suggestion - use with-environment.sh with collect-modules.sh

### DIFF
--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -396,7 +396,7 @@ The snippet will create a button that, when tapped, sends a test event to Sentry
             // eslint-disable-next-line no-useless-escape
             '\\"../node_modules/@sentry/cli/bin/sentry-cli react-native xcode $REACT_NATIVE_XCODE\\"',
         ) +
-        '\n/bin/sh ../node_modules/@sentry/react-native/scripts/collect-modules.sh\n';
+        '\n/bin/sh -c "$WITH_ENVIRONMENT ../node_modules/@sentry/react-native/scripts/collect-modules.sh"\n';
       script.shellScript = JSON.stringify(code);
     }
   }
@@ -507,7 +507,7 @@ export SENTRY_PROPERTIES=sentry.properties
           // remove sentry properties export
           .replace(/^export SENTRY_PROPERTIES=sentry.properties\r?\n/m, '')
           .replace(
-            /^\/bin\/sh ..\/node_modules\/@sentry\/react-native\/scripts\/collect-modules.sh\r?\n/m,
+            /^\/bin\/sh -c "$WITH_ENVIRONMENT ..\/node_modules\/@sentry\/react-native\/scripts\/collect-modules.sh"\r?\n/m,
             '',
           )
           // unwrap react-native-xcode.sh command.  In case someone replaced it


### PR DESCRIPTION
In a similar vein to https://github.com/getsentry/sentry-wizard/pull/329, I think it'd be helpful to call the `with-environment.sh` script with `collect-modules.sh` as well as the bundle + upload debug symbols processes so that overrides can be provided via `.xcode.env` / `.xcode.env.local`.

As an example, we're using this to set `MODULES_PATHS` overrides in our monorepo.