### PR TITLE
Tweak RN Android build.gradle "apply from"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(reactnative): Improve `build.gradle` patch so that it's more likely to work without changes in monorepos (#352)
+
 ## 3.9.1
 
 - ref(sourcemaps): Handle no vite config found case (#391)

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -371,7 +371,7 @@ The snippet will create a button that, when tapped, sends a test event to Sentry
   private _unpatchBuildGradle(contents: string): Promise<string> {
     return Promise.resolve(
       contents.replace(
-        /^\s*apply from: project(["']:sentry_react-native["']).projectDir.getParent\(\) + ["']\/sentry.gradle["'];?\s*?\r?\n/m,
+        /^\s*apply from: .+\/sentry.gradle["'];?\s*?\r?\n/m,
         '',
       ),
     );

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -354,7 +354,7 @@ The snippet will create a button that, when tapped, sends a test event to Sentry
 
   private _patchBuildGradle(contents: string): Promise<string | null> {
     const applyFrom =
-      'apply from: "../../node_modules/@sentry/react-native/sentry.gradle"';
+      'apply from: project(":sentry_react-native").projectDir.getParent() + "/sentry.gradle"';
     if (contents.indexOf(applyFrom) >= 0) {
       return Promise.resolve(null);
     }
@@ -371,7 +371,7 @@ The snippet will create a button that, when tapped, sends a test event to Sentry
   private _unpatchBuildGradle(contents: string): Promise<string> {
     return Promise.resolve(
       contents.replace(
-        /^\s*apply from: ["']..\/..\/node_modules\/@sentry\/react-native\/sentry.gradle["'];?\s*?\r?\n/m,
+        /^\s*apply from: project(["']:sentry_react-native["']).projectDir.getParent\(\) + ["']\/sentry.gradle["'];?\s*?\r?\n/m,
         '',
       ),
     );

--- a/lib/Steps/Integrations/ReactNative.ts
+++ b/lib/Steps/Integrations/ReactNative.ts
@@ -370,10 +370,7 @@ The snippet will create a button that, when tapped, sends a test event to Sentry
 
   private _unpatchBuildGradle(contents: string): Promise<string> {
     return Promise.resolve(
-      contents.replace(
-        /^\s*apply from: .+\/sentry.gradle["'];?\s*?\r?\n/m,
-        '',
-      ),
+      contents.replace(/^\s*apply from: .+\/sentry.gradle["'];?\s*?\r?\n/m, ''),
     );
   }
 

--- a/lib/Steps/Integrations/__tests__/ReactNative.ts
+++ b/lib/Steps/Integrations/__tests__/ReactNative.ts
@@ -107,7 +107,7 @@ describe('ReactNative', () => {
     const patchedAppBuildGradle = fs.readFileSync(appBuildGradle, 'utf8');
     const expectedPatch =
       'apply plugin: "com.facebook.react"\n\n' +
-      'apply from: "../../node_modules/@sentry/react-native/sentry.gradle"\n' +
+      'apply from: project(":sentry_react-native").projectDir.getParent() + "/sentry.gradle"\n' +
       'android {\n}\n';
     expect(patchedAppBuildGradle).toEqual(expectedPatch);
   });


### PR DESCRIPTION
Using the project reference means it's less likely to need a manual change for monorepo or non-standard directory layouts