### PR TITLE
ref(apple): Move `withTelemetry` into `runAppleWizard`

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -5,7 +5,6 @@ import { runNextjsWizard } from './src/nextjs/nextjs-wizard';
 import { runSourcemapsWizard } from './src/sourcemaps/sourcemaps-wizard';
 import { runSvelteKitWizard } from './src/sveltekit/sveltekit-wizard';
 import { runAppleWizard } from './src/apple/apple-wizard';
-import { withTelemetry } from './src/telemetry';
 import { WizardOptions } from './src/utils/types';
 export * from './lib/Setup';
 

--- a/bin.ts
+++ b/bin.ts
@@ -86,14 +86,8 @@ switch (argv.i) {
     runSourcemapsWizard(wizardOptions).catch(console.error);
     break;
   case 'ios':
-    withTelemetry(
-      {
-        enabled: !argv['disable-telemetry'],
-        integration: 'ios',
-      },
-      () => runAppleWizard(wizardOptions),
-      // eslint-disable-next-line no-console
-    ).catch(console.error);
+    // eslint-disable-next-line no-console
+    runAppleWizard(wizardOptions).catch(console.error);
     break;
   default:
     void run(argv);

--- a/lib/Steps/Integrations/Apple.ts
+++ b/lib/Steps/Integrations/Apple.ts
@@ -2,7 +2,6 @@ import { Answers } from 'inquirer';
 import type { Args } from '../../Constants';
 import { BaseIntegration } from './BaseIntegration';
 import { runAppleWizard } from '../../../src/apple/apple-wizard';
-import { withTelemetry } from '../../../src/telemetry';
 
 export class Apple extends BaseIntegration {
   argv: Args;
@@ -12,19 +11,12 @@ export class Apple extends BaseIntegration {
   }
 
   public async emit(_answers: Answers): Promise<Answers> {
-    await withTelemetry(
-      {
-        enabled: !this.argv.disableTelemetry,
-        integration: 'ios',
-      },
-      async () =>
-        await runAppleWizard({
-          promoCode: this._argv.promoCode,
-          url: this._argv.url,
-          telemetryEnabled: !this._argv.disableTelemetry,
-        }),
+    await runAppleWizard({
+      promoCode: this._argv.promoCode,
+      url: this._argv.url,
+      telemetryEnabled: !this._argv.disableTelemetry,
       // eslint-disable-next-line no-console
-    ).catch(console.error);
+    }).catch(console.error);
 
     return {};
   }

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -12,7 +12,7 @@ import * as codeTools from './code-tools';
 import * as bash from '../utils/bash';
 import { WizardOptions } from '../utils/types';
 import * as Sentry from '@sentry/node';
-import { traceStep } from '../telemetry';
+import { traceStep, withTelemetry } from '../telemetry';
 
 const xcode = require('xcode');
 /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -28,7 +28,17 @@ import {
   askForItemSelection,
 } from '../utils/clack-utils';
 
-export async function runAppleWizard(
+export async function runAppleWizard(options: WizardOptions): Promise<void> {
+  return withTelemetry(
+    {
+      enabled: options.telemetryEnabled,
+      integration: 'ios',
+    },
+    () => runAppleWizardWithTelementry(options),
+  );
+}
+
+async function runAppleWizardWithTelementry(
   options: WizardOptions,
 ): Promise<void> {
   printWelcome({
@@ -39,8 +49,12 @@ export async function runAppleWizard(
   const hasCli = bash.hasSentryCLI();
   Sentry.setTag('has-cli', hasCli);
   if (!hasCli) {
-    if (!(await traceStep("Ask for SentryCLI", () => askToInstallSentryCLI()))) {
-      clack.log.warn("Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/");
+    if (
+      !(await traceStep('Ask for SentryCLI', () => askToInstallSentryCLI()))
+    ) {
+      clack.log.warn(
+        "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+      );
       Sentry.setTag('CLI-Installed', false);
     } else {
       await bash.installSentryCLI();
@@ -49,10 +63,12 @@ export async function runAppleWizard(
   }
 
   const projectDir = process.cwd();
-  const xcodeProjFiles = findFilesWithExtension(projectDir, ".xcodeproj");
+  const xcodeProjFiles = findFilesWithExtension(projectDir, '.xcodeproj');
 
   if (!xcodeProjFiles || xcodeProjFiles.length === 0) {
-    clack.log.error('No Xcode project found. Please run this command from the root of your project.');
+    clack.log.error(
+      'No Xcode project found. Please run this command from the root of your project.',
+    );
     await abort();
     return;
   }
@@ -64,26 +80,46 @@ export async function runAppleWizard(
     Sentry.setTag('multiple-projects', false);
   } else {
     Sentry.setTag('multiple-projects', true);
-    xcodeProjFile = (await traceStep("Choose Xcode project", () => askForItemSelection(xcodeProjFiles, "Which project do you want to add Sentry to?"))).value;
+    xcodeProjFile = (
+      await traceStep('Choose Xcode project', () =>
+        askForItemSelection(
+          xcodeProjFiles,
+          'Which project do you want to add Sentry to?',
+        ),
+      )
+    ).value;
   }
 
-  const pbxproj = path.join(projectDir, xcodeProjFile, "project.pbxproj");
+  const pbxproj = path.join(projectDir, xcodeProjFile, 'project.pbxproj');
   if (!fs.existsSync(pbxproj)) {
     clack.log.error(`No pbxproj found at ${pbxproj}`);
     await abort();
     return;
   }
 
-  const { project, apiKey } = await getSentryProjectAndApiKey(options.promoCode, options.url);
+  const { project, apiKey } = await getSentryProjectAndApiKey(
+    options.promoCode,
+    options.url,
+  );
 
   traceStep('Update Xcode project', () => {
     xcManager.updateXcodeProject(pbxproj, project, apiKey, true, true);
   });
 
-  const projSource = path.join(projectDir, xcodeProjFile.replace(".xcodeproj", ""));
-  const codeAdded = traceStep("Add code snippet", () => { return codeTools.addCodeSnippetToProject(projSource, project.keys[0].dsn.public) });
+  const projSource = path.join(
+    projectDir,
+    xcodeProjFile.replace('.xcodeproj', ''),
+  );
+  const codeAdded = traceStep('Add code snippet', () => {
+    return codeTools.addCodeSnippetToProject(
+      projSource,
+      project.keys[0].dsn.public,
+    );
+  });
   if (!codeAdded) {
-    clack.log.warn('Added the Sentry dependency to your project but could not add the Sentry code snippet. Please add the code snipped manually by following the docs: https://docs.sentry.io/platforms/apple/guides/ios/#configure');
+    clack.log.warn(
+      'Added the Sentry dependency to your project but could not add the Sentry code snippet. Please add the code snipped manually by following the docs: https://docs.sentry.io/platforms/apple/guides/ios/#configure',
+    );
     return;
   }
 
@@ -91,7 +127,10 @@ export async function runAppleWizard(
 }
 
 //Prompt for Sentry project and API key
-async function getSentryProjectAndApiKey(promoCode?: string, url?: string): Promise<{ project: SentryProjectData, apiKey: { token: string } }> {
+async function getSentryProjectAndApiKey(
+  promoCode?: string,
+  url?: string,
+): Promise<{ project: SentryProjectData; apiKey: { token: string } }> {
   const { url: sentryUrl } = await askForSelfHosted(url);
 
   const { projects, apiKeys } = await askForWizardLogin({
@@ -107,5 +146,5 @@ async function getSentryProjectAndApiKey(promoCode?: string, url?: string): Prom
 //find files with the given extension
 function findFilesWithExtension(dir: string, extension: string): string[] {
   const files = fs.readdirSync(dir);
-  return files.filter(file => file.endsWith(extension));
+  return files.filter((file) => file.endsWith(extension));
 }


### PR DESCRIPTION
This aligns the apple wizard with the refactor of the source maps wizard in #348 where we moved the `withTelemetry` call into the wizard. 
The benefit is that we have the call in one place instead of two and that we can potentially check the `telemetryEnabled` flag whenever we need to within the wizard, as it's now part of the wizard options. 

(This is not strictly required but IMO it makes sense to keep things aligned). 

#skip-changelog