### PR TITLE
feat(sourcemaps): Pre-select auto-detected build tool option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(apple): Add support for iOS (#334)
 - feat(sourcemaps): Add CLI-based flow for Angular (#349)
 - feat(sourcemaps): Detect SvelteKit and NextJS projects and redirect to dedicated wizards (#341)
+- feat(sourcemaps): Pre-select auto-detected build tool option (#354)
 - ref(sourcemaps): Improve Outro message (#344) 
 
 ## 3.5.0

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -27,16 +27,7 @@ import { traceStep } from '../telemetry';
 import { URL } from 'url';
 import { checkIfMoreSuitableWizardExistsAndAskForRedirect } from './utils/other-wizards';
 import { configureAngularSourcemapGenerationFlow } from './tools/angular';
-
-type SupportedTools =
-  | 'webpack'
-  | 'vite'
-  | 'rollup'
-  | 'esbuild'
-  | 'tsc'
-  | 'sentry-cli'
-  | 'create-react-app'
-  | 'angular';
+import { detectUsedTool, SupportedTools } from './utils/detect-tool';
 
 export async function runSourcemapsWizard(
   options: WizardOptions,
@@ -148,6 +139,7 @@ async function askForUsedBundlerTool(): Promise<SupportedTools> {
           hint: 'This will configure source maps upload for you using sentry-cli',
         },
       ],
+      initialValue: await detectUsedTool(),
     }),
   );
 

--- a/src/sourcemaps/utils/detect-tool.ts
+++ b/src/sourcemaps/utils/detect-tool.ts
@@ -1,0 +1,41 @@
+import { getPackageDotJson } from '../../utils/clack-utils';
+import { findInstalledPackageFromList } from '../../utils/package-json';
+
+export type SupportedTools =
+  | 'webpack'
+  | 'vite'
+  | 'rollup'
+  | 'esbuild'
+  | 'tsc'
+  | 'sentry-cli'
+  | 'create-react-app'
+  | 'angular';
+
+// A map of package names pointing to the tool slug.
+// The order is important, because we want to detect the most specific tool first.
+// For instance, webpack needs to come before tsc because typescript c
+// Similarly
+export const TOOL_PACKAGE_MAP: Record<string, SupportedTools> = {
+  '@angular/core': 'angular',
+  'create-react-app': 'create-react-app',
+  webpack: 'webpack',
+  vite: 'vite',
+  esbuild: 'esbuild',
+  rollup: 'rollup',
+  typescript: 'tsc',
+};
+
+export async function detectUsedTool(): Promise<SupportedTools> {
+  const packageJson = await getPackageDotJson();
+
+  const foundToolPackage = findInstalledPackageFromList(
+    Object.keys(TOOL_PACKAGE_MAP),
+    packageJson,
+  );
+
+  if (foundToolPackage) {
+    return TOOL_PACKAGE_MAP[foundToolPackage.name];
+  }
+
+  return 'sentry-cli';
+}

--- a/src/sourcemaps/utils/other-wizards.ts
+++ b/src/sourcemaps/utils/other-wizards.ts
@@ -10,7 +10,7 @@ import {
   getPackageDotJson,
 } from '../../utils/clack-utils';
 import {
-  findPackageFromList,
+  findInstalledPackageFromList,
   hasPackageInstalled,
 } from '../../utils/package-json';
 
@@ -63,7 +63,7 @@ async function checkIfMoreSuitableWizardExists(): Promise<string | undefined> {
 
   const packageJson = await getPackageDotJson();
 
-  const installedSdkPackage = findPackageFromList(
+  const installedSdkPackage = findInstalledPackageFromList(
     Object.keys(sdkMap),
     packageJson,
   );

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -9,7 +9,7 @@ import {
 } from '../../utils/clack-utils';
 
 import * as Sentry from '@sentry/node';
-import { findPackageFromList } from '../../utils/package-json';
+import { findInstalledPackageFromList } from '../../utils/package-json';
 
 const MINIMUM_DEBUG_ID_SDK_VERSION = '7.47.0';
 
@@ -52,7 +52,7 @@ const SENTRY_SDK_PACKAGE_NAMES = [
  *    -> We tell users to manually upgrade (migrate between majors)
  */
 export async function ensureMinimumSdkVersionIsInstalled(): Promise<void> {
-  const installedSdkPackage = findPackageFromList(
+  const installedSdkPackage = findInstalledPackageFromList(
     SENTRY_SDK_PACKAGE_NAMES,
     await getPackageDotJson(),
   );

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -15,7 +15,7 @@ type NpmPackage = {
  * If so, it returns the first package name that is found, including the
  * version (range) specified in the package.json.
  */
-export function findPackageFromList(
+export function findInstalledPackageFromList(
   packageNamesList: string[],
   packageJson: PackageDotJson,
 ): NpmPackage | undefined {


### PR DESCRIPTION
This PR adds a simple auto-detection of installed build tool packages to preselect a tool selection option in the source maps wizard. Detection is performed by checking the users' `package.json` for specific packages. Either the packages of the build tool/bundler or the framework/library (Angular/CRA). If nothing is found, we fall back to the catch-all "None of the above" option which starts the Sentry CLI flow. 

ref #290  