### PR TITLE
fix(sveltekit): Call correct API endpoint in Example code

### DIFF
--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -72,7 +72,7 @@ Feel free to delete this file and the entire sentry route.
     });
 
     try {
-      const res = await fetch('/test-sentry');
+      const res = await fetch('/sentry-example');
       if (!res.ok) {
         throw new Error('Sentry Example Frontend Error');
       }


### PR DESCRIPTION
While working on an issue reproduction, I noticed that our example route we add to the users' project once the wizard configured the SDK, calls the wrong API route and hence an incorrect error is thrown.
