### PR TITLE
feat(sourcemaps): Add path for users who don't use CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
+- feat(sourcemaps): Add path for users who don't use CI (#359)
 - fix(sveltekit): Call correct API endpoint in Sentry example code (#358)
 - ref(sveltekit): Create `.ts` hooks files if typescript is detected (#355)
-
 ## 3.6.0
 
 - feat(apple): Add support for iOS (#334)

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -12,7 +12,9 @@ import {
 } from '../../utils/clack-utils';
 
 import { SourceMapUploadToolConfigurationOptions } from './types';
-import { hasPackageInstalled } from '../../utils/package-json';
+import { hasPackageInstalled, PackageDotJson } from '../../utils/package-json';
+
+const NPM_SCRIPT_NAME = 'sentry:sourcemaps';
 
 export async function configureSentryCLI(
   options: SourceMapUploadToolConfigurationOptions,
@@ -72,37 +74,23 @@ export async function configureSentryCLI(
 
   await configureSourcemapGenerationFlow();
 
-  packageDotJson.scripts = packageDotJson.scripts || {};
-  packageDotJson.scripts['sentry:ci'] = `sentry-cli sourcemaps inject --org ${
-    options.orgSlug
-  } --project ${
-    options.projectSlug
-  } ${relativePosixArtifactPath} && sentry-cli${
-    options.selfHosted ? ` --url ${options.url}` : ''
-  } sourcemaps upload --org ${options.orgSlug} --project ${
-    options.projectSlug
-  } ${relativePosixArtifactPath}`;
-
-  await fs.promises.writeFile(
-    path.join(process.cwd(), 'package.json'),
-    JSON.stringify(packageDotJson, null, 2),
+  await createAndAddNpmScript(
+    packageDotJson,
+    options,
+    relativePosixArtifactPath,
   );
 
-  clack.log.info(
-    `Added a ${chalk.cyan('sentry:ci')} script to your ${chalk.cyan(
-      'package.json',
-    )}. Make sure to run this script ${chalk.bold(
-      'after',
-    )} building your application but ${chalk.bold('before')} deploying!`,
-  );
+  await addSentryCliRc(options.authToken);
+}
 
+export async function setupNpmScriptInCI(): Promise<void> {
   const addedToCI = await abortIfCancelled(
     clack.select({
-      message: `Did you add a step to your CI pipeline that runs the ${chalk.cyan(
-        'sentry:ci',
-      )} script ${chalk.bold('right after')} building your application?`,
+      message: `Add a step to your CI pipeline that runs the ${chalk.cyan(
+        NPM_SCRIPT_NAME,
+      )} script ${chalk.bold('right after')} building your application.`,
       options: [
-        { label: 'Yes, continue!', value: true },
+        { label: 'I did, continue!', value: true },
         {
           label: "I'll do it later...",
           value: false,
@@ -120,8 +108,38 @@ export async function configureSentryCLI(
   if (!addedToCI) {
     clack.log.info("Don't forget! :)");
   }
+}
 
-  await addSentryCliRc(options.authToken);
+async function createAndAddNpmScript(
+  packageDotJson: PackageDotJson,
+  options: SourceMapUploadToolConfigurationOptions,
+  relativePosixArtifactPath: string,
+): Promise<void> {
+  const sentryCliNpmScript = `sentry-cli sourcemaps inject --org ${
+    options.orgSlug
+  } --project ${
+    options.projectSlug
+  } ${relativePosixArtifactPath} && sentry-cli${
+    options.selfHosted ? ` --url ${options.url}` : ''
+  } sourcemaps upload --org ${options.orgSlug} --project ${
+    options.projectSlug
+  } ${relativePosixArtifactPath}`;
+
+  packageDotJson.scripts = packageDotJson.scripts || {};
+  packageDotJson.scripts[NPM_SCRIPT_NAME] = sentryCliNpmScript;
+
+  await fs.promises.writeFile(
+    path.join(process.cwd(), 'package.json'),
+    JSON.stringify(packageDotJson, null, 2),
+  );
+
+  clack.log.info(
+    `Added a ${chalk.cyan(NPM_SCRIPT_NAME)} script to your ${chalk.cyan(
+      'package.json',
+    )}. Make sure to run this script ${chalk.bold(
+      'after',
+    )} building your application but ${chalk.bold('before')} deploying!`,
+  );
 }
 
 async function defaultConfigureSourcemapGenerationFlow(): Promise<void> {


### PR DESCRIPTION
Previously, our wizard implicitly assumed that users would have a CI/CD setup that builds and deploys their application. While this might be true for a lot of users, it's not always the case, so we should provide a path for users through the respective build tool flows who don't use CI. 

Therefore, this PR makes the following user-facing changes to provide a path through the wizard for non-CI users:
- Ask users if they use CI
  - if yes, show CI configuration for selected tool. In the plugin case, they only need to add the auth token to their CI env. In the CLI case, they additionally need to ensure that the npm script is called.
  - otherwise, no CI configuration steps are displayed and the users are just reminded that the auth token needs to be available when-/where ever they build and deploy their app.

This change required some internal refactoring, especially of the CLI flow.
Also adjusted telemetry to collect CI usage
 
ref getsentry/team-sdks#16