### PR TITLE
fix: Ensure wizard exits after setup is completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(sourcemaps): Add path for users who don't use CI (#359)
+- fix: Ensure wizard exits after setup is completed (#360)
 - fix(sveltekit): Call correct API endpoint in Sentry example code (#358)
 - ref(sveltekit): Create `.ts` hooks files if typescript is detected (#355)
 ## 3.6.0

--- a/bin.ts
+++ b/bin.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
 import { Integration, Platform } from './lib/Constants';
 import { run } from './lib/Setup';
-import { runNextjsWizard } from './src/nextjs/nextjs-wizard';
-import { runSourcemapsWizard } from './src/sourcemaps/sourcemaps-wizard';
-import { runSvelteKitWizard } from './src/sveltekit/sveltekit-wizard';
-import { runAppleWizard } from './src/apple/apple-wizard';
-import { WizardOptions } from './src/utils/types';
 export * from './lib/Setup';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -63,31 +58,4 @@ const argv = require('yargs')
     describe: 'A promo code that will be applied during signup',
   }).argv;
 
-// Collect argv options that are relevant for the new wizard
-// flows based on `clack`
-const wizardOptions: WizardOptions = {
-  url: argv.url as string | undefined,
-  promoCode: argv['promo-code'] as string | undefined,
-  telemetryEnabled: !argv['disable-telemetry'],
-};
-
-switch (argv.i) {
-  case 'nextjs':
-    // eslint-disable-next-line no-console
-    runNextjsWizard(wizardOptions).catch(console.error);
-    break;
-  case 'sveltekit':
-    // eslint-disable-next-line no-console
-    runSvelteKitWizard(wizardOptions).catch(console.error);
-    break;
-  case 'sourcemaps':
-    // eslint-disable-next-line no-console
-    runSourcemapsWizard(wizardOptions).catch(console.error);
-    break;
-  case 'ios':
-    // eslint-disable-next-line no-console
-    runAppleWizard(wizardOptions).catch(console.error);
-    break;
-  default:
-    void run(argv);
-}
+void run(argv);

--- a/lib/Steps/Integrations/SourceMapsShim.ts
+++ b/lib/Steps/Integrations/SourceMapsShim.ts
@@ -6,7 +6,7 @@ import { BaseIntegration } from './BaseIntegration';
 
 /**
  * This class just redirects to the `sourcemaps-wizard.ts` flow
- * for anyone calling the wizard without the '-i sveltekit' flag.
+ * for anyone calling the wizard without the '-i sourcemaps' flag.
  */
 export class SourceMapsShim extends BaseIntegration {
   public constructor(protected _argv: Args) {


### PR DESCRIPTION
When the wizard was started with the `-i` flag, it would sometimes just keep on awaiting a promise after the `run[integration]Wizard` function returned. Seems like we broke the promise chain in #348 or sometime before that. This caused the application to appear hanging and users needing to cancel the wizard manually. 

Affected wizards.
* NextJs
* Sveltekit
* Sourcemaps
* Apple (not tested but I'm fairly certain)

This patch makes sure that the wizard exits by removing our duplicated invokation logic for the `clack`-based wizard. For the moment, we always go through the Shim classes. I'd like to refactor this eventually and get rid of the shims but for now we should fix this to unblock users.