### PR TITLE
fix(telemetry): Re-enable telemetry collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased 
+
+fix(telemetry): Re-enable telemetry collection (#361)
+
 ## 3.7.0
 
 - feat(sourcemaps): Add path for users who don't use CI (#359)

--- a/lib/Helper/Wizard.ts
+++ b/lib/Helper/Wizard.ts
@@ -21,9 +21,6 @@ function sanitizeAndValidateArgs(argv: Args): void {
   }
   // @ts-ignore skip-connect does not exist on args
   argv.promoCode = argv['promo-code'];
-
-  // @ts-ignore skip-connect does not exist on args
-  argv.disableTelemetry = argv['disable-telemetry'] != undefined;
 }
 
 export function getCurrentIntegration(answers: Answers): BaseIntegration {

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -48,8 +48,15 @@ async function runSourcemapsWizardWithTelemetry(
 ): Promise<void> {
   printWelcome({
     wizardName: 'Sentry Source Maps Upload Configuration Wizard',
-    message:
-      'This wizard will help you upload source maps to Sentry as part of your build.\nThank you for using Sentry :)\n\n(This setup wizard sends telemetry data and crash reports to Sentry.\nYou can turn this off by running the wizard with the `--disable-telemetry` flag.)',
+    message: `This wizard will help you upload source maps to Sentry as part of your build.
+Thank you for using Sentry :)${
+      options.telemetryEnabled
+        ? `
+
+(This setup wizard sends telemetry data and crash reports to Sentry.
+You can turn this off by running the wizard with the '--disable-telemetry' flag.)`
+        : ''
+    }`,
     promoCode: options.promoCode,
   });
 


### PR DESCRIPTION
Seems like a check in #334 unintentionally disabled telemetry collection by default. I missed this when reviewing the PR. As a consequence of this and merging in #360, we didn't collect any telemetry data in the last 3.7.0 release. This patch removes the unnecessary check and restores telemetry collection.

Furthermore, this patch also adjusts the welcome message to no longer show the telemetry collection note in the welcome message if it is disabled.