### PR TITLE
fix(login): Avoid repeatedly printing waiting message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(apple): iOS wizard has support for cocoapods (#350)
 - feat(apple): Add Fastlane detector for iOS wizard (#356)
+- fix(login): Avoid repeatedly printing loading message (#368)
 
 ## 3.7.1
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -206,9 +206,7 @@ export async function askForWizardLogin(options: {
 
   const loginSpinner = clack.spinner();
 
-  loginSpinner.start(
-    "Waiting for you to log in using the link above. Once you're logged in, return to this wizard.",
-  );
+  loginSpinner.start('Waiting for you to log in using the link above');
 
   const data = await new Promise<WizardProjectData>((resolve) => {
     const pollingInterval = setInterval(() => {


### PR DESCRIPTION
We received a few internal reports about the 

```
◐  Waiting for you to log in using the link above. Once you're logged in, return to this wizard...
```

message being repeatedly printed to console while users are logging into Sentry in the browser:
![image](https://github.com/getsentry/sentry-wizard/assets/8420481/768ab77e-dbd6-415a-b4b7-ebda22a55423)

This happens when the terminal window width in which the wizard is run, is smaller than the length of the message. In this case, clack seems to fail to update (turn the spinning wheel) the line and instead prints a new one. I reproduced this in a simple app and opened an [issue](https://github.com/natemoo-re/clack/issues/132) in the clack repo. Given that the repo doesn't seem too active, it's questionable though if this will be fixed.

For the meantime though, this PR reduces the message length so that our users are less likely to run into this bug.

ref https://github.com/getsentry/team-sdks/issues/16 

