### PR TITLE
ref(sourcemaps): Redirect to ReactNative wizard if RN project is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat(apple): Add Fastlane detector for iOS wizard (#356)
 - feat(sourcemaps): Add dedicated NextJS sourcemaps flow (#372)
 - fix(login): Avoid repeatedly printing loading message (#368)
+- ref(sourcemaps): Redirect to ReactNative wizard if RN project is detected (#369)
 
 ## 3.7.1
 

--- a/src/sourcemaps/utils/other-wizards.ts
+++ b/src/sourcemaps/utils/other-wizards.ts
@@ -160,11 +160,6 @@ function runReactNativeWizard(): Promise<void> {
       stdio: 'inherit',
     });
   } catch {
-    clack.log.error(
-      `Could not redirect to the react-native wizard.\nPlease re-run the wizard manually with the \`${chalk.cyan(
-        '-i reactNative',
-      )}\` argument`,
-    );
     return Promise.reject();
   }
 


### PR DESCRIPTION
This PR adds a redirection mechanism to the RN wizard if we detect an installed RN SDK and the `react-native` package in a user's `package.json`. Since for RN, we need to redirect to an old wizard flow, we can't just call `run*Wizard()` but we basically need to go through the entire wizard startup sequence again to correctly parse the CLI args. I therefore opted to just open a child process with the wizard instead. Not the prettiest solution but it seems to work well enough.  

ref https://github.com/getsentry/team-sdks/issues/16