### PR TITLE
feat: Autodetect more wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Autodetect more wizards (#370)
 - feat(apple): iOS wizard has support for cocoapods (#350)
 - feat(apple): Add Fastlane detector for iOS wizard (#356)
 

--- a/lib/Steps/ChooseIntegration.ts
+++ b/lib/Steps/ChooseIntegration.ts
@@ -1,6 +1,5 @@
 import type { Answers } from 'inquirer';
 import { prompt } from 'inquirer';
-import * as _ from 'lodash';
 import { dim } from 'picocolors';
 
 import {
@@ -17,6 +16,7 @@ import { ReactNative } from './Integrations/ReactNative';
 import { SourceMapsShim } from './Integrations/SourceMapsShim';
 import { Apple } from './Integrations/Apple';
 import { SvelteKitShim } from './Integrations/SvelteKitShim';
+import { hasPackageInstalled } from '../../src/utils/package-json';
 
 let projectPackage: any = {};
 
@@ -65,12 +65,22 @@ export class ChooseIntegration extends BaseStep {
   }
 
   public tryDetectingIntegration(): Integration | undefined {
-    if (_.has(projectPackage, 'dependencies.react-native')) {
+    if (hasPackageInstalled('react-native', projectPackage)) {
       return Integration.reactNative;
     }
-    if (_.has(projectPackage, 'dependencies.cordova')) {
+    if (hasPackageInstalled('cordova', projectPackage)) {
       return Integration.cordova;
     }
+    if (hasPackageInstalled('electron', projectPackage)) {
+      return Integration.electron;
+    }
+    if (hasPackageInstalled('next', projectPackage)) {
+      return Integration.nextjs;
+    }
+    if (hasPackageInstalled('@sveltejs/kit', projectPackage)) {
+      return Integration.sveltekit;
+    }
+
     return;
   }
 


### PR DESCRIPTION
Improve the wizard selection menu when starting the wizard without the `-i/--integration` arg:

Add additional checks as we have already for RN and Cordova for to pre-select other wizards if we detect a corresponding framework package:
* Electron
* NextJS
* SvelteKit

This leaves us with source maps and Apple that don't have auto-detection. Both is fine but we can probably check for apple and default to source maps(?) in the future. 

cc @brustolin if you have a free minute, how can we check for apple here?