### PR TITLE
feat(sourcemaps): Add option to add cli npm script to build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
 - fix(login): Avoid repeatedly printing loading message (#368)
 - fix(sveltekit): Abort the wizard when encountering an error (#376)
 - ref(sourcemaps): Redirect to ReactNative wizard if RN project is detected (#369)
-- fix(login): Avoid repeatedly printing loading message (#368)
-  
+
 ## 3.7.1
 
 fix(telemetry): Re-enable telemetry collection (#361)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - feat(apple): iOS wizard has support for cocoapods (#350)
 - feat(apple): Add Fastlane detector for iOS wizard (#356)
 - feat(sourcemaps): Add dedicated NextJS sourcemaps flow (#372)
+- feat(sourcemaps): Add option to add cli npm script to build command (#374)
 - fix(login): Avoid repeatedly printing loading message (#368)
 - fix(sveltekit): Abort the wizard when encountering an error (#376)
 - ref(sourcemaps): Redirect to ReactNative wizard if RN project is detected (#369)
-
+- fix(login): Avoid repeatedly printing loading message (#368)
+  
 ## 3.7.1
 
 fix(telemetry): Re-enable telemetry collection (#361)

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -15,7 +15,11 @@ import {
 import { isUnicodeSupported } from '../utils/vendor/is-unicorn-supported';
 import { SourceMapUploadToolConfigurationOptions } from './tools/types';
 import { configureVitePlugin } from './tools/vite';
-import { setupNpmScriptInCI, configureSentryCLI } from './tools/sentry-cli';
+import {
+  setupNpmScriptInCI,
+  configureSentryCLI,
+  addedToBuildCommand,
+} from './tools/sentry-cli';
 import { configureWebPackPlugin } from './tools/webpack';
 import { configureTscSourcemapGenerationFlow } from './tools/tsc';
 import { configureRollupPlugin } from './tools/rollup';
@@ -259,7 +263,7 @@ async function configureCI(
     return;
   }
 
-  if (isCliBasedFlowTool) {
+  if (isCliBasedFlowTool && !addedToBuildCommand) {
     await traceStep('ci-npm-script-setup', setupNpmScriptInCI);
   }
 

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -15,11 +15,7 @@ import {
 import { isUnicodeSupported } from '../utils/vendor/is-unicorn-supported';
 import { SourceMapUploadToolConfigurationOptions } from './tools/types';
 import { configureVitePlugin } from './tools/vite';
-import {
-  setupNpmScriptInCI,
-  configureSentryCLI,
-  addedToBuildCommand,
-} from './tools/sentry-cli';
+import { setupNpmScriptInCI, configureSentryCLI } from './tools/sentry-cli';
 import { configureWebPackPlugin } from './tools/webpack';
 import { configureTscSourcemapGenerationFlow } from './tools/tsc';
 import { configureRollupPlugin } from './tools/rollup';
@@ -263,7 +259,7 @@ async function configureCI(
     return;
   }
 
-  if (isCliBasedFlowTool && !addedToBuildCommand) {
+  if (isCliBasedFlowTool) {
     await traceStep('ci-npm-script-setup', setupNpmScriptInCI);
   }
 

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -1,5 +1,5 @@
 export type PackageDotJson = {
-  scripts?: Record<string, string>;
+  scripts?: Record<string, string | undefined>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
 };


### PR DESCRIPTION
Our CLI-based flows currently expect users to manually call the `sentry:sourcemaps` NPM script after building and before deploying and to adjust their CI steps to acommodate for this step. This leaves room for churn/error and sometimes it's not even possibly to easily add another step (see case in #366). 

Therefore, this PR introduces an optional step in the wizard to add the `sentry:sourcemaps` script to the users' build command:
- After the `sentry:sourcemaps` script is added to users' `package.json`, the wizard will ask if the automatically want to run the script after their prod build
- The wizard then ask if the detected script is the users' prod build script and fall back to letting them choose from a list of all of their npm scripts.
- Once selected, the wizard appends the script: `"build": "whateverWasHereBefore && [packageManager] run sentry:sourcemaps"`

![image](https://github.com/getsentry/sentry-wizard/assets/8420481/31725723-835a-4cf2-b990-2d0b11c41c11)

closes #366 