### PR TITLE
fix(sveltekit): Abort the wizard when encountering an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat(apple): Add Fastlane detector for iOS wizard (#356)
 - feat(sourcemaps): Add dedicated NextJS sourcemaps flow (#372)
 - fix(login): Avoid repeatedly printing loading message (#368)
+- fix(sveltekit): Abort the wizard when encountering an error (#376)
 - ref(sourcemaps): Redirect to ReactNative wizard if RN project is detected (#369)
 
 ## 3.7.1

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -3,6 +3,7 @@ import clack from '@clack/prompts';
 import chalk from 'chalk';
 
 import {
+  abort,
   askForProjectSelection,
   askForSelfHosted,
   askForWizardLogin,
@@ -66,6 +67,7 @@ export async function runSvelteKitWizard(
           : 'Unknown error',
       ),
     );
+    await abort('Exiting Wizard');
     return;
   }
 
@@ -87,6 +89,7 @@ export async function runSvelteKitWizard(
           : 'Unknown error',
       ),
     );
+    await abort('Exiting Wizard');
     return;
   }
 


### PR DESCRIPTION
This ensures we flush out the error once we add telemetry to sentry. Also it'll fix showing a success message when in fact we crashed.
Closes #337