### PR TITLE
ref(sourcemaps): Handle no vite config found case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased:
 
+- ref(sourcemaps): Handle no vite config found case (#391)
 - ref(sourcemaps): Improve handling of vite config already having Sentry code (#392)
 
 ## 3.9.0

--- a/src/sourcemaps/tools/vite.ts
+++ b/src/sourcemaps/tools/vite.ts
@@ -25,10 +25,12 @@ import { findScriptFile, hasSentryContent } from '../../utils/ast-utils';
 import * as path from 'path';
 import * as fs from 'fs';
 import { debug } from '../../utils/debug';
+import { stripAnsii } from '../../utils/string';
 
-const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
-  chalk.gray(`
-import { defineConfig } from "vite";
+const getCopyPasteCodeSnippet = (
+  options: SourceMapUploadToolConfigurationOptions,
+) =>
+  chalk.gray(`import { defineConfig } from "vite";
 ${chalk.greenBright('import { sentryVitePlugin } from "@sentry/vite-plugin"')};
 
 export default defineConfig({
@@ -50,6 +52,10 @@ export default defineConfig({
 });
 `);
 
+const getNewViteConfigContent = (
+  options: SourceMapUploadToolConfigurationOptions,
+) => stripAnsii(getCopyPasteCodeSnippet(options));
+
 export const configureVitePlugin: SourceMapUploadToolConfigurationFunction =
   async (options) => {
     await installPackage({
@@ -60,15 +66,15 @@ export const configureVitePlugin: SourceMapUploadToolConfigurationFunction =
       ),
     });
 
-    const viteConfigPath = findScriptFile(
-      path.resolve(process.cwd(), 'vite.config'),
-    );
+    const viteConfigPath =
+      findScriptFile(path.resolve(process.cwd(), 'vite.config')) ||
+      (await askForViteConfigPath());
 
     let successfullyAdded = false;
     if (viteConfigPath) {
       successfullyAdded = await addVitePluginToConfig(viteConfigPath, options);
     } else {
-      Sentry.setTag('ast-mod-fail-reason', 'config-not-found');
+      successfullyAdded = await createNewViteConfig(options);
     }
 
     if (successfullyAdded) {
@@ -83,6 +89,35 @@ export const configureVitePlugin: SourceMapUploadToolConfigurationFunction =
 
     await addDotEnvSentryBuildPluginFile(options.authToken);
   };
+
+async function createNewViteConfig(
+  options: SourceMapUploadToolConfigurationOptions,
+): Promise<boolean> {
+  try {
+    await fs.promises.writeFile(
+      'vite.config.js',
+      getNewViteConfigContent(options),
+    );
+    Sentry.setTag('created-new-config', 'success');
+    return true;
+  } catch (e) {
+    debug(e);
+    Sentry.setTag('created-new-config', 'fail');
+    clack.log.warn(
+      `Could not create a new ${chalk.cyan(
+        'vite.config.js',
+      )} file. Please create one manually and follow the instructions below.`,
+    );
+
+    clack.log.info(
+      chalk.gray(
+        'More information about vite configs: https://vitejs.dev/config/',
+      ),
+    );
+
+    return false;
+  }
+}
 
 async function addVitePluginToConfig(
   viteConfigPath: string,
@@ -161,13 +196,46 @@ async function showCopyPasteInstructions(
 
   // Intentionally logging directly to console here so that the code can be copied/pasted directly
   // eslint-disable-next-line no-console
-  console.log(getCodeSnippet(options));
+  console.log('\n', getCopyPasteCodeSnippet(options));
 
   await abortIfCancelled(
     select({
       message: 'Did you copy the snippet above?',
       options: [{ label: 'Yes, continue!', value: true }],
       initialValue: true,
+    }),
+  );
+}
+
+async function askForViteConfigPath(): Promise<string | undefined> {
+  const hasViteConfig = await abortIfCancelled(
+    clack.confirm({
+      message: `Do you have a vite config file (e.g. ${chalk.cyan(
+        'vite.config.js',
+      )}?`,
+      initialValue: true,
+    }),
+  );
+
+  if (!hasViteConfig) {
+    return undefined;
+  }
+
+  return await abortIfCancelled(
+    clack.text({
+      message: 'Please enter the path to your vite config file:',
+      placeholder: `.${path.sep}vite.config.js`,
+      validate: (value) => {
+        if (!value) {
+          return 'Please enter a path.';
+        }
+
+        try {
+          fs.accessSync(value);
+        } catch {
+          return 'Could not access the file at this path.';
+        }
+      },
     }),
   );
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,7 @@
+export function stripAnsii(str: string): string {
+  return str.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+    '',
+  );
+}


### PR DESCRIPTION
This PR improves one of the main reasons why our plugin injection approach currently fails. Previously, if we couldn't find a `vite.config.(js|ts|cjs|mjs)` file, we just bailed and fell back to copy paste instructions. This PR adds the following improvements:

* If we can find a vite.config file, inject the plugin (no changes here). Otherwise:
* Ask users if they have a config file. 
  * If not, create a new file with a standard vite config that contains our plugin and enables source map generation.
    * If this fails (i/o problems), we fall back to telling users to add a config and copy/paste code
  * If yes, ask for the path to the file, validate that we can access it and inject the plugin
* Whenever we attempt plugin injection and we fail, we continue to fall back to copy/paste. I thought about also creating a new file in this case but I think merging a new file into an existing config is not much better than copy/pasting code into an existing one. Happy to change this if reviewers have different opinions. 

ref #390 