### PR TITLE
ref(sourcemaps): Improve handling of vite config already having Sentry code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased:
+
+- ref(sourcemaps): Improve handling of vite config already having Sentry code (#392)
+
 ## 3.9.0
 
 - ref: Add debug logging to clack-based wizards (#381)

--- a/src/sourcemaps/tools/vite.ts
+++ b/src/sourcemaps/tools/vite.ts
@@ -98,12 +98,28 @@ async function addVitePluginToConfig(
     const mod = parseModule(viteConfigContent);
 
     if (hasSentryContent(mod)) {
-      clack.log.warn(
-        `File ${prettyViteConfigFilename} already contains Sentry code. 
-Please follow the instruction below`,
+      clack.log.info(``);
+      const shouldContinue = await abortIfCancelled(
+        clack.select({
+          message: `${prettyViteConfigFilename} already contains Sentry-related code. Should the wizard modify it anyway?`,
+          options: [
+            {
+              label: 'Yes, add the Sentry Vite plugin',
+              value: true,
+            },
+            {
+              label: 'No, show me instructions to manually add the plugin',
+              value: false,
+            },
+          ],
+          initialValue: true,
+        }),
       );
-      Sentry.setTag('ast-mod-fail-reason', 'has-sentry-content');
-      return false;
+
+      if (!shouldContinue) {
+        Sentry.setTag('ast-mod-fail-reason', 'has-sentry-content');
+        return false;
+      }
     }
 
     const { orgSlug: org, projectSlug: project, selfHosted, url } = options;


### PR DESCRIPTION
Previously, if we detected that a vite config file already contained Sentry code, we just bailed. This PR improves the handling here by asking users if they want to attempt the plugin insertion anyway. If yes, we try to insert the plugin and fall back to copy/paste if we fail. If no, we directly fall back to copy/paste instructions.

closes #390