### PR TITLE
fix(sentry-cli-sourcemaps): Fix writing of build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(sentry-cli-sourcemaps): Fix writing of build command (#398)
+
 ## 3.9.1
 
 - ref(sourcemaps): Handle no vite config found case (#391)

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -211,8 +211,9 @@ async function addSentryCommandToBuildCommand(
   // Often, 'build' is the prod build command, so we favour it.
   // If it's not there, commands that include 'build' might be the prod build command.
   let buildCommand =
-    packageDotJson.scripts.build ||
-    allNpmScripts.find((s) => s.toLocaleLowerCase().includes('build'));
+    typeof packageDotJson.scripts.build === 'string'
+      ? 'build'
+      : allNpmScripts.find((s) => s.toLocaleLowerCase().includes('build'));
 
   const isProdBuildCommand =
     !!buildCommand &&
@@ -252,7 +253,8 @@ Please add it manually to your prod build command.`,
 
   packageDotJson.scripts[
     buildCommand
-  ] = `${buildCommand} && ${pacMan} run ${SENTRY_NPM_SCRIPT_NAME}`;
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  ] = `${packageDotJson.scripts[buildCommand]} && ${pacMan} run ${SENTRY_NPM_SCRIPT_NAME}`;
 
   await fs.promises.writeFile(
     path.join(process.cwd(), 'package.json'),


### PR DESCRIPTION
In the case when the user has a script called `build` we would take its value instead of its key as the name of the build command - which is, as you would have guessed it, not right.