### PR TITLE
fix(cordova)  iOS fails to build when sentry.cli not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(cordova): Fallback to the default Sentry CLI path if not defined. (#???)
+- fix(cordova): Fallback to the default Sentry CLI path if not defined. (#401)
 
 ## 3.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(cordova): Fallback to the default Sentry CLI path if not defined. (#???)
+
 ## 3.9.2
 
 - fix(sentry-cli-sourcemaps): Fix writing of build command (#398)

--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -201,7 +201,11 @@ export class Cordova extends BaseIntegration {
           'function getProperty {\\n' +
           '    PROP_KEY=$1\\n' +
           '    PROP_VALUE=`cat $SENTRY_PROPERTIES | grep "$PROP_KEY" | cut -d\'=\' -f2`\\n' +
-          '    echo $PROP_VALUE\\n' +
+          '    if [ -z "$PROP_VALUE" ]; then\\n' +
+          '        echo "plugins/sentry-cordova/node_modules/@sentry/cli/bin/sentry-cli"\\n' +
+          '    else\\n' +
+          '        echo $PROP_VALUE\\n' +
+          '    fi\\n' +
           '}\\n' +
           'if [ ! -f $SENTRY_PROPERTIES ]; then\\n' +
           '  echo "warning: SENTRY: sentry.properties file not found! Skipping symbol upload."\\n' +


### PR DESCRIPTION
By default, Sentry.CLI is bundled with Sentry Cordova and can be accessed on the following path: `plugins/sentry-cordova/node_modules/@sentry/cli/bin/sentry-cli`

The current code breaks the build if `cli.executable` is not defined on sentry.properties, so this fix sets the default value when not defined to `plugins/sentry-cordova/node_modules/@sentry/cli/bin/sentry-cli`.

EDIT:

code build with and without cli.executable:

![image](https://github.com/getsentry/sentry-wizard/assets/8229322/1bf67333-4d6a-4148-b72e-d73e9b7c8491)
![image](https://github.com/getsentry/sentry-wizard/assets/8229322/e24ea92c-b903-4f05-82b2-5d371fbc33b7)
