### PR TITLE
feat(craft): Add brew target on craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -12,7 +12,7 @@ targets:
         desc "The Sentry Wizard helps you set up your projects with Sentry"
         homepage "https://github.com/getsentry/sentry-wizard"
         url "https://registry.npmjs.org/@sentry/wizard/-/wizard-{{version}}.tgz"
-        sha256 "{{checksums.sentry-wizard-v{{version}}.tgz}}"
+        sha256 "{{checksums.sentry-wizard-vlatest__tgz}}"
         version "{{version}}"
         license "MIT"
 

--- a/.craft.yml
+++ b/.craft.yml
@@ -12,7 +12,7 @@ targets:
         desc "The Sentry Wizard helps you set up your projects with Sentry"
         homepage "https://github.com/getsentry/sentry-wizard"
         url "https://registry.npmjs.org/@sentry/wizard/-/wizard-{{version}}.tgz"
-        sha256 "{{checksums.sentry-wizard-vlatest__tgz}}"
+        sha256 "{{checksums.sentry-wizard-v__VERSION____tgz}}"
         version "{{version}}"
         license "MIT"
 

--- a/.craft.yml
+++ b/.craft.yml
@@ -3,6 +3,29 @@ changelogPolicy: auto
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm
+  - name: brew
+    tap: getsentry/tools
+    template: >
+      require 'language/node'
+
+      class SentryWizard < Formula
+        desc "The Sentry Wizard helps you set up your projects with Sentry"
+        homepage "https://github.com/getsentry/sentry-wizard"
+        url "https://registry.npmjs.org/@sentry/wizard/-/wizard-{{version}}.tgz"
+        sha256 "{{checksums.sentry-wizard-v{{version}}.tgz}}"
+        version "{{version}}"
+        license "MIT"
+
+        depends_on "node"
+
+        def install
+          system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+          bin.install_symlink Dir["#{libexec}/bin/*"]
+        end
+        test do
+          assert_match version.to_s, shell_output("#{bin}/sentry-wizard --version").chomp
+        end
+      end
   - name: registry
     apps:
       app:sentry-wizard:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(craft): Add `brew` target for automatically publishing `sentry-wizard` to Sentry's custom Homebrew tap
+
 ## 3.10.0
 
 - feat(remix): Add Remix wizard (#387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat(craft): Add `brew` target for automatically publishing `sentry-wizard` to Sentry's custom Homebrew tap
+- feat(craft): Add `brew` target for automatically publishing `sentry-wizard` to Sentry's custom Homebrew tap (#406)
 
 ## 3.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - feat(craft): Add `brew` target for automatically publishing `sentry-wizard` to Sentry's custom Homebrew tap (#406)
 
+You can now install `sentry-wizard` via Homebrew:
+
+```sh
+brew update
+brew install getsentry/tools/sentry-wizard
+```
+
 ## 3.10.0
 
 - feat(remix): Add Remix wizard (#387)


### PR DESCRIPTION
Adds `brew` target to automate publishing of sentry-wizard to our custom brew tap. 

There's a change on craft needs to land before this one, to make it possible accessing checksums for sentry-wizard https://github.com/getsentry/craft/pull/488

Closes #346