### PR TITLE
feat(android): Fetch latest gradle plugin version from release registry

### DIFF
--- a/src/android/gradle.ts
+++ b/src/android/gradle.ts
@@ -97,7 +97,9 @@ export async function addGradlePlugin(appFile: string): Promise<boolean> {
     return true;
   }
 
-  const pluginVersion = await fetchSdkVersion('sentry.java.android.gradle-plugin');
+  const pluginVersion = await fetchSdkVersion(
+    'sentry.java.android.gradle-plugin',
+  );
   const pluginsBlockMatch = /plugins\s*{[^{}]*}/.exec(gradleScript);
   let newGradleScript;
   if (!pluginsBlockMatch) {

--- a/src/android/gradle.ts
+++ b/src/android/gradle.ts
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/node';
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
+import { fetchSdkVersion } from '../utils/release-registry';
 
 /**
  * A Gradle project may contain multiple modules, some of them may be applications, some of them may be libraries.
@@ -96,6 +97,7 @@ export async function addGradlePlugin(appFile: string): Promise<boolean> {
     return true;
   }
 
+  const pluginVersion = await fetchSdkVersion('sentry.java.android.gradle-plugin');
   const pluginsBlockMatch = /plugins\s*{[^{}]*}/.exec(gradleScript);
   let newGradleScript;
   if (!pluginsBlockMatch) {
@@ -111,12 +113,12 @@ export async function addGradlePlugin(appFile: string): Promise<boolean> {
     if (appFile.endsWith('.kts')) {
       newGradleScript =
         gradleScript.slice(0, insertIndex) +
-        pluginsBlockKts +
+        pluginsBlockKts(pluginVersion) +
         gradleScript.slice(insertIndex);
     } else {
       newGradleScript =
         gradleScript.slice(0, insertIndex) +
-        pluginsBlock +
+        pluginsBlock(pluginVersion) +
         gradleScript.slice(insertIndex);
     }
   } else {
@@ -125,12 +127,12 @@ export async function addGradlePlugin(appFile: string): Promise<boolean> {
     if (appFile.endsWith('.kts')) {
       newGradleScript =
         gradleScript.slice(0, insertIndex) +
-        pluginKts +
+        pluginKts(pluginVersion) +
         gradleScript.slice(insertIndex);
     } else {
       newGradleScript =
         gradleScript.slice(0, insertIndex) +
-        plugin +
+        plugin(pluginVersion) +
         gradleScript.slice(insertIndex);
     }
   }

--- a/src/android/templates.ts
+++ b/src/android/templates.ts
@@ -1,23 +1,23 @@
-export const pluginsBlock = `
+export const pluginsBlock = (version = '3.12.0') => `
 plugins {
-    id 'io.sentry.android.gradle' version '3.12.0'
+    id 'io.sentry.android.gradle' version '${version}}'
 }
 
 `;
 
-export const pluginsBlockKts = `
+export const pluginsBlockKts = (version = '3.12.0') => `
 plugins {
-    id("io.sentry.android.gradle") version "3.12.0"
+    id("io.sentry.android.gradle") version "${version}"
 }
 
 `;
 
-export const plugin = `
-    id 'io.sentry.android.gradle' version '3.12.0'
+export const plugin = (version = '3.12.0') => `
+    id 'io.sentry.android.gradle' version '${version}'
 `;
 
-export const pluginKts = `
-    id("io.sentry.android.gradle") version "3.12.0"
+export const pluginKts = (version = '3.12.0') => `
+    id("io.sentry.android.gradle") version "${version}"
 `;
 
 export const manifest = (dsn: string) => `

--- a/src/utils/release-registry.ts
+++ b/src/utils/release-registry.ts
@@ -5,13 +5,15 @@ const registryUrl = 'https://release-registry.services.sentry.io/';
 export async function fetchSdkVersion(
   sdk: string,
 ): Promise<string | undefined> {
-    try {
-        const data = (
-          await axios.get<Record<string, { version: string }>>(`${registryUrl}/sdks`)
-        ).data;
-        return data[sdk]?.version;
-    } catch {
-        debug('Failed to fetch latest version from release registry.');
-    }
-    return undefined;
+  try {
+    const data = (
+      await axios.get<Record<string, { version: string }>>(
+        `${registryUrl}/sdks`,
+      )
+    ).data;
+    return data[sdk]?.version;
+  } catch {
+    debug('Failed to fetch latest version from release registry.');
+  }
+  return undefined;
 }

--- a/src/utils/release-registry.ts
+++ b/src/utils/release-registry.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { debug } from './debug';
+const registryUrl = 'https://release-registry.services.sentry.io/';
+
+export async function fetchSdkVersion(
+  sdk: string,
+): Promise<string | undefined> {
+    try {
+        const data = (
+          await axios.get<Record<string, { version: string }>>(`${registryUrl}/sdks`)
+        ).data;
+        return data[sdk]?.version;
+    } catch {
+        debug('Failed to fetch latest version from release registry.');
+    }
+    return undefined;
+}


### PR DESCRIPTION
_#skip-changelog_

Fetches latest sdk version (gradle plugin in our case) from the release registry.

Skipping changelog since it goes as part of #389 which is not yet released.