### PR TITLE
fix: Treat user-entered DSN as a public DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ brew update
 brew install getsentry/tools/sentry-wizard
 ```
 
+- fix: Treat user-entered DSN as a public DSN (#410)
+
 ## 3.10.0
 
 - feat(remix): Add Remix wizard (#387)

--- a/lib/Steps/PromptForParameters.ts
+++ b/lib/Steps/PromptForParameters.ts
@@ -50,11 +50,11 @@ export class PromptForParameters extends BaseStep {
     const dsn = await prompt([
       {
         message: 'DSN:',
-        name: 'secret',
+        name: 'public',
         type: 'input',
         // eslint-disable-next-line @typescript-eslint/unbound-method
         validate: this._validateDSN,
-        when: this._shouldAsk(answers, 'config.dsn.secret', () => {
+        when: this._shouldAsk(answers, 'config.dsn.public', () => {
           dim('Please copy/paste your DSN');
           dim(`It can be found here: ${url}`);
         }),


### PR DESCRIPTION
When the old wizards (e.g. react native) fall back to user-input for org, project, dsn and auth token, they set the DSN as `config.dsn.secret`. AIFAICT, this is a legacy feature and all wizards only use `config.dsn.public`. As reported in #407, this caused the wizard to inject `dsn: null` into the `Sentry.init` code snippets although the DSN was entered correctly by users.

This PR fixes this behaviour by assigning the entered value to `config.dsn.public`.

(As with #409, this PR does not affect our newer, clack-based wizards)

I verified locally that this change fixes the issue. Therefore
closes #407