### PR TITLE
fix: Handle no projects available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ brew update
 brew install getsentry/tools/sentry-wizard
 ```
 
+- fix: Handle no projects available (#412)
 - fix: Support org auth tokens in old wizards (#409)
 
 ## 3.10.0

--- a/lib/Steps/SentryProjectSelector.ts
+++ b/lib/Steps/SentryProjectSelector.ts
@@ -21,7 +21,9 @@ export class SentryProjectSelector extends BaseStep {
       _.has(answers, 'wizard.projects') &&
       answers.wizard.projects.length === 0
     ) {
-      throw new Error('no projects');
+      throw new Error(
+        'No Projects found. Please create a new Project in Sentry and try again.',
+      );
     }
 
     let selectedProject = null;

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -20,13 +20,11 @@ const xcode = require('xcode');
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 import {
-  askForProjectSelection,
-  askForSelfHosted,
-  askForWizardLogin,
   askToInstallSentryCLI,
   printWelcome,
   abort,
   askForItemSelection,
+  getOrAskForProjectData,
 } from '../utils/clack-utils';
 
 export async function runAppleWizard(options: WizardOptions): Promise<void> {
@@ -98,10 +96,7 @@ async function runAppleWizardWithTelementry(
     return;
   }
 
-  const { project, apiKey } = await getSentryProjectAndApiKey(
-    options.promoCode,
-    options.url,
-  );
+  const { project, apiKey } = await getSentryProjectAndApiKey(options);
 
   const hasCocoa = cocoapod.usesCocoaPod(projectDir);
 
@@ -160,19 +155,10 @@ async function runAppleWizardWithTelementry(
 
 //Prompt for Sentry project and API key
 async function getSentryProjectAndApiKey(
-  promoCode?: string,
-  url?: string,
+  options: WizardOptions,
 ): Promise<{ project: SentryProjectData; apiKey: { token: string } }> {
-  const { url: sentryUrl } = await askForSelfHosted(url);
-
-  const { projects, apiKeys } = await askForWizardLogin({
-    promoCode: promoCode,
-    url: sentryUrl,
-    platform: 'apple-ios',
-  });
-
-  const selectedProject = await askForProjectSelection(projects);
-  return { project: selectedProject, apiKey: apiKeys };
+  const { selectedProject, authToken } = await getOrAskForProjectData(options);
+  return { project: selectedProject, apiKey: { token: authToken } };
 }
 
 //find files with the given extension

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -4,11 +4,9 @@ import chalk from 'chalk';
 
 import {
   addSentryCliRc,
-  askForProjectSelection,
-  askForSelfHosted,
-  askForWizardLogin,
   confirmContinueEvenThoughNoGitRepo,
   ensurePackageIsInstalled,
+  getOrAskForProjectData,
   getPackageDotJson,
   installPackage,
   isUsingTypeScript,
@@ -54,15 +52,10 @@ async function runRemixWizardWithTelemetry(
   // We expect `@remix-run/dev` to be installed for every Remix project
   await ensurePackageIsInstalled(packageJson, '@remix-run/dev', 'Remix');
 
-  const { url: sentryUrl } = await askForSelfHosted(options.url);
-
-  const { projects, apiKeys } = await askForWizardLogin({
-    promoCode: options.promoCode,
-    url: sentryUrl,
-    platform: 'javascript-remix',
-  });
-
-  const selectedProject = await askForProjectSelection(projects);
+  const { selectedProject, authToken } = await getOrAskForProjectData(
+    options,
+    'javascript-remix',
+  );
 
   await traceStep('Install Sentry SDK', () =>
     installPackage({
@@ -77,7 +70,7 @@ async function runRemixWizardWithTelemetry(
   const isV2 = isRemixV2(remixConfig, packageJson);
 
   await addSentryCliRc(
-    apiKeys.token,
+    authToken,
     selectedProject.organization.slug,
     selectedProject.name,
   );

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -5,11 +5,9 @@ import chalk from 'chalk';
 import {
   abort,
   addSentryCliRc,
-  askForProjectSelection,
-  askForSelfHosted,
-  askForWizardLogin,
   confirmContinueEvenThoughNoGitRepo,
   ensurePackageIsInstalled,
+  getOrAskForProjectData,
   getPackageDotJson,
   installPackage,
   printWelcome,
@@ -32,22 +30,15 @@ export async function runSvelteKitWizard(
   const packageJson = await getPackageDotJson();
   await ensurePackageIsInstalled(packageJson, '@sveltejs/kit', 'Sveltekit');
 
-  const { url: sentryUrl, selfHosted } = await askForSelfHosted(options.url);
-
-  const { projects, apiKeys } = await askForWizardLogin({
-    promoCode: options.promoCode,
-    url: sentryUrl,
-    platform: 'javascript-sveltekit',
-  });
-
-  const selectedProject = await askForProjectSelection(projects);
+  const { selectedProject, selfHosted, sentryUrl, authToken } =
+    await getOrAskForProjectData(options, 'javascript-sveltekit');
 
   await installPackage({
     packageName: '@sentry/sveltekit',
     alreadyInstalled: hasPackageInstalled('@sentry/sveltekit', packageJson),
   });
 
-  await addSentryCliRc(apiKeys.token);
+  await addSentryCliRc(authToken);
 
   const svelteConfig = await loadSvelteConfig();
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -134,113 +134,6 @@ export async function askToInstallSentryCLI(): Promise<boolean> {
   );
 }
 
-export async function askForWizardLogin(options: {
-  url: string;
-  promoCode?: string;
-  platform?:
-    | 'javascript-nextjs'
-    | 'javascript-remix'
-    | 'javascript-sveltekit'
-    | 'apple-ios'
-    | 'android';
-}): Promise<WizardProjectData> {
-  Sentry.setTag('has-promo-code', !!options.promoCode);
-
-  let hasSentryAccount = await clack.confirm({
-    message: 'Do you already have a Sentry account?',
-  });
-
-  hasSentryAccount = await abortIfCancelled(hasSentryAccount);
-
-  Sentry.setTag('already-has-sentry-account', hasSentryAccount);
-
-  let wizardHash: string;
-  try {
-    wizardHash = (
-      await axios.get<{ hash: string }>(`${options.url}api/0/wizard/`)
-    ).data.hash;
-  } catch {
-    if (options.url !== SAAS_URL) {
-      clack.log.error('Loading Wizard failed. Did you provide the right URL?');
-      await abort(
-        chalk.red(
-          'Please check your configuration and try again.\n\n   Let us know if you think this is an issue with the wizard or Sentry: https://github.com/getsentry/sentry-wizard/issues',
-        ),
-      );
-    } else {
-      clack.log.error('Loading Wizard failed.');
-      await abort(
-        chalk.red(
-          'Please try again in a few minutes and let us know if this issue persists: https://github.com/getsentry/sentry-wizard/issues',
-        ),
-      );
-    }
-  }
-
-  const loginUrl = new URL(
-    `${options.url}account/settings/wizard/${wizardHash!}/`,
-  );
-
-  if (!hasSentryAccount) {
-    loginUrl.searchParams.set('signup', '1');
-    if (options.platform) {
-      loginUrl.searchParams.set('project_platform', options.platform);
-    }
-  }
-
-  if (options.promoCode) {
-    loginUrl.searchParams.set('code', options.promoCode);
-  }
-
-  const urlToOpen = loginUrl.toString();
-  clack.log.info(
-    `${chalk.bold(
-      `If the browser window didn't open automatically, please open the following link to ${
-        hasSentryAccount ? 'log' : 'sign'
-      } into Sentry:`,
-    )}\n\n${chalk.cyan(urlToOpen)}`,
-  );
-
-  opn(urlToOpen).catch(() => {
-    // opn throws in environments that don't have a browser (e.g. remote shells) so we just noop here
-  });
-
-  const loginSpinner = clack.spinner();
-
-  loginSpinner.start('Waiting for you to log in using the link above');
-
-  const data = await new Promise<WizardProjectData>((resolve) => {
-    const pollingInterval = setInterval(() => {
-      axios
-        .get<WizardProjectData>(`${options.url}api/0/wizard/${wizardHash}/`)
-        .then((result) => {
-          resolve(result.data);
-          clearTimeout(timeout);
-          clearInterval(pollingInterval);
-          void axios.delete(`${options.url}api/0/wizard/${wizardHash}/`);
-        })
-        .catch(() => {
-          // noop - just try again
-        });
-    }, 500);
-
-    const timeout = setTimeout(() => {
-      clearInterval(pollingInterval);
-      loginSpinner.stop(
-        'Login timed out. No worries - it happens to the best of us.',
-      );
-
-      Sentry.setTag('opened-wizard-link', false);
-      void abort('Please restart the Wizard and log in to complete the setup.');
-    }, 180_000);
-  });
-
-  loginSpinner.stop('Login complete.');
-  Sentry.setTag('opened-wizard-link', true);
-
-  return data;
-}
-
 export async function askForItemSelection(
   items: string[],
   message: string,
@@ -258,29 +151,6 @@ export async function askForItemSelection(
         }),
       }),
     );
-
-  return selection;
-}
-
-export async function askForProjectSelection(
-  projects: SentryProjectData[],
-): Promise<SentryProjectData> {
-  const selection: SentryProjectData | symbol = await abortIfCancelled(
-    windowedSelect({
-      maxItems: 12,
-      message: 'Select your Sentry project.',
-      options: projects.map((project) => {
-        return {
-          value: project,
-          label: `${project.organization.slug}/${project.slug}`,
-        };
-      }),
-    }),
-  );
-
-  Sentry.setTag('project', selection.slug);
-  Sentry.setTag('project-platform', selection.platform);
-  Sentry.setUser({ id: selection.organization.slug });
 
   return selection;
 }
@@ -344,78 +214,6 @@ export async function installPackage({
       packageName,
     )} with ${chalk.bold(packageManager)}.`,
   );
-}
-
-/**
- * Asks users if they are using SaaS or self-hosted Sentry and returns the validated URL.
- *
- * If users started the wizard with a --url arg, that URL is used as the default and we skip
- * the self-hosted question. However, the passed url is still validated and in case it's
- * invalid, users are asked to enter a new one until it is valid.
- *
- * @param urlFromArgs the url passed via the --url arg
- */
-export async function askForSelfHosted(urlFromArgs?: string): Promise<{
-  url: string;
-  selfHosted: boolean;
-}> {
-  if (!urlFromArgs) {
-    const choice: 'saas' | 'self-hosted' | symbol = await abortIfCancelled(
-      clack.select({
-        message: 'Are you using Sentry SaaS or self-hosted Sentry?',
-        options: [
-          { value: 'saas', label: 'Sentry SaaS (sentry.io)' },
-          {
-            value: 'self-hosted',
-            label: 'Self-hosted/on-premise/single-tenant',
-          },
-        ],
-      }),
-    );
-
-    if (choice === 'saas') {
-      Sentry.setTag('url', SAAS_URL);
-      Sentry.setTag('self-hosted', false);
-      return { url: SAAS_URL, selfHosted: false };
-    }
-  }
-
-  let validUrl: string | undefined;
-  let tmpUrlFromArgs = urlFromArgs;
-
-  while (validUrl === undefined) {
-    const url =
-      tmpUrlFromArgs ||
-      (await abortIfCancelled(
-        clack.text({
-          message: `Please enter the URL of your ${
-            urlFromArgs ? '' : 'self-hosted '
-          }Sentry instance.`,
-          placeholder: 'https://sentry.io/',
-        }),
-      ));
-    tmpUrlFromArgs = undefined;
-
-    try {
-      validUrl = new URL(url).toString();
-
-      // We assume everywhere else that the URL ends in a slash
-      if (!validUrl.endsWith('/')) {
-        validUrl += '/';
-      }
-    } catch {
-      clack.log.error(
-        'Please enter a valid URL. (It should look something like "https://sentry.mydomain.com/")',
-      );
-    }
-  }
-
-  const isSelfHostedUrl = new URL(validUrl).host !== new URL(SAAS_URL).host;
-
-  Sentry.setTag('url', validUrl);
-  Sentry.setTag('self-hosted', isSelfHostedUrl);
-
-  return { url: validUrl, selfHosted: true };
 }
 
 async function addOrgAndProjectToSentryCliRc(
@@ -706,6 +504,17 @@ export function isUsingTypeScript() {
   }
 }
 
+/**
+ * Checks if we already got project data from a previous wizard invocation.
+ * If yes, this data is returned.
+ * Otherwise, we start the login flow and ask the user to select a project.
+ *
+ * Use this function to get project data for the wizard.
+ *
+ * @param options wizard options
+ * @param platform the platform of the wizard
+ * @returns project data (org, project, token, url)
+ */
 export async function getOrAskForProjectData(
   options: WizardOptions,
   platform?:
@@ -741,6 +550,14 @@ export async function getOrAskForProjectData(
     }),
   );
 
+  if (!projects || !projects.length) {
+    clack.log.error(
+      'No projects found. Please create a project in Sentry and try again.',
+    );
+    Sentry.setTag('no-projects-found', true);
+    await abort();
+  }
+
   const selectedProject = await traceStep('select-project', () =>
     askForProjectSelection(projects),
   );
@@ -751,4 +568,206 @@ export async function getOrAskForProjectData(
     authToken: apiKeys.token,
     selectedProject,
   };
+}
+
+/**
+ * Asks users if they are using SaaS or self-hosted Sentry and returns the validated URL.
+ *
+ * If users started the wizard with a --url arg, that URL is used as the default and we skip
+ * the self-hosted question. However, the passed url is still validated and in case it's
+ * invalid, users are asked to enter a new one until it is valid.
+ *
+ * @param urlFromArgs the url passed via the --url arg
+ */
+async function askForSelfHosted(urlFromArgs?: string): Promise<{
+  url: string;
+  selfHosted: boolean;
+}> {
+  if (!urlFromArgs) {
+    const choice: 'saas' | 'self-hosted' | symbol = await abortIfCancelled(
+      clack.select({
+        message: 'Are you using Sentry SaaS or self-hosted Sentry?',
+        options: [
+          { value: 'saas', label: 'Sentry SaaS (sentry.io)' },
+          {
+            value: 'self-hosted',
+            label: 'Self-hosted/on-premise/single-tenant',
+          },
+        ],
+      }),
+    );
+
+    if (choice === 'saas') {
+      Sentry.setTag('url', SAAS_URL);
+      Sentry.setTag('self-hosted', false);
+      return { url: SAAS_URL, selfHosted: false };
+    }
+  }
+
+  let validUrl: string | undefined;
+  let tmpUrlFromArgs = urlFromArgs;
+
+  while (validUrl === undefined) {
+    const url =
+      tmpUrlFromArgs ||
+      (await abortIfCancelled(
+        clack.text({
+          message: `Please enter the URL of your ${
+            urlFromArgs ? '' : 'self-hosted '
+          }Sentry instance.`,
+          placeholder: 'https://sentry.io/',
+        }),
+      ));
+    tmpUrlFromArgs = undefined;
+
+    try {
+      validUrl = new URL(url).toString();
+
+      // We assume everywhere else that the URL ends in a slash
+      if (!validUrl.endsWith('/')) {
+        validUrl += '/';
+      }
+    } catch {
+      clack.log.error(
+        'Please enter a valid URL. (It should look something like "https://sentry.mydomain.com/")',
+      );
+    }
+  }
+
+  const isSelfHostedUrl = new URL(validUrl).host !== new URL(SAAS_URL).host;
+
+  Sentry.setTag('url', validUrl);
+  Sentry.setTag('self-hosted', isSelfHostedUrl);
+
+  return { url: validUrl, selfHosted: true };
+}
+
+async function askForWizardLogin(options: {
+  url: string;
+  promoCode?: string;
+  platform?:
+    | 'javascript-nextjs'
+    | 'javascript-remix'
+    | 'javascript-sveltekit'
+    | 'apple-ios'
+    | 'android';
+}): Promise<WizardProjectData> {
+  Sentry.setTag('has-promo-code', !!options.promoCode);
+
+  let hasSentryAccount = await clack.confirm({
+    message: 'Do you already have a Sentry account?',
+  });
+
+  hasSentryAccount = await abortIfCancelled(hasSentryAccount);
+
+  Sentry.setTag('already-has-sentry-account', hasSentryAccount);
+
+  let wizardHash: string;
+  try {
+    wizardHash = (
+      await axios.get<{ hash: string }>(`${options.url}api/0/wizard/`)
+    ).data.hash;
+  } catch {
+    if (options.url !== SAAS_URL) {
+      clack.log.error('Loading Wizard failed. Did you provide the right URL?');
+      await abort(
+        chalk.red(
+          'Please check your configuration and try again.\n\n   Let us know if you think this is an issue with the wizard or Sentry: https://github.com/getsentry/sentry-wizard/issues',
+        ),
+      );
+    } else {
+      clack.log.error('Loading Wizard failed.');
+      await abort(
+        chalk.red(
+          'Please try again in a few minutes and let us know if this issue persists: https://github.com/getsentry/sentry-wizard/issues',
+        ),
+      );
+    }
+  }
+
+  const loginUrl = new URL(
+    `${options.url}account/settings/wizard/${wizardHash!}/`,
+  );
+
+  if (!hasSentryAccount) {
+    loginUrl.searchParams.set('signup', '1');
+    if (options.platform) {
+      loginUrl.searchParams.set('project_platform', options.platform);
+    }
+  }
+
+  if (options.promoCode) {
+    loginUrl.searchParams.set('code', options.promoCode);
+  }
+
+  const urlToOpen = loginUrl.toString();
+  clack.log.info(
+    `${chalk.bold(
+      `If the browser window didn't open automatically, please open the following link to ${
+        hasSentryAccount ? 'log' : 'sign'
+      } into Sentry:`,
+    )}\n\n${chalk.cyan(urlToOpen)}`,
+  );
+
+  opn(urlToOpen).catch(() => {
+    // opn throws in environments that don't have a browser (e.g. remote shells) so we just noop here
+  });
+
+  const loginSpinner = clack.spinner();
+
+  loginSpinner.start('Waiting for you to log in using the link above');
+
+  const data = await new Promise<WizardProjectData>((resolve) => {
+    const pollingInterval = setInterval(() => {
+      axios
+        .get<WizardProjectData>(`${options.url}api/0/wizard/${wizardHash}/`)
+        .then((result) => {
+          resolve(result.data);
+          clearTimeout(timeout);
+          clearInterval(pollingInterval);
+          void axios.delete(`${options.url}api/0/wizard/${wizardHash}/`);
+        })
+        .catch(() => {
+          // noop - just try again
+        });
+    }, 500);
+
+    const timeout = setTimeout(() => {
+      clearInterval(pollingInterval);
+      loginSpinner.stop(
+        'Login timed out. No worries - it happens to the best of us.',
+      );
+
+      Sentry.setTag('opened-wizard-link', false);
+      void abort('Please restart the Wizard and log in to complete the setup.');
+    }, 180_000);
+  });
+
+  loginSpinner.stop('Login complete.');
+  Sentry.setTag('opened-wizard-link', true);
+
+  return data;
+}
+
+async function askForProjectSelection(
+  projects: SentryProjectData[],
+): Promise<SentryProjectData> {
+  const selection: SentryProjectData | symbol = await abortIfCancelled(
+    windowedSelect({
+      maxItems: 12,
+      message: 'Select your Sentry project.',
+      options: projects.map((project) => {
+        return {
+          value: project,
+          label: `${project.organization.slug}/${project.slug}`,
+        };
+      }),
+    }),
+  );
+
+  Sentry.setTag('project', selection.slug);
+  Sentry.setTag('project-platform', selection.platform);
+  Sentry.setUser({ id: selection.organization.slug });
+
+  return selection;
 }


### PR DESCRIPTION
This PR handles the uncaught crash when a user chose to log in but didn't yet create a project. In this case, we now print a message instructing users to create a new project first and then try running the wizard again. 

I refactored all our clack-based wizards to use the `getOrAskForProjectData` helper so that we only have to handle this once.

For the Step-based wizards, I adjusted the error message with better instructions. 

closes #400