### PR TITLE
ref(telemetry): Set integration-specific `environment`

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -52,6 +52,8 @@ function createSentryInstance(enabled: boolean, integration: string) {
     dsn: 'https://8871d3ff64814ed8960c96d1fcc98a27@o1.ingest.sentry.io/4505425820712960',
     enabled: enabled,
 
+    environment: `production-${integration}`,
+
     tracesSampleRate: 1,
     sampleRate: 1,
 


### PR DESCRIPTION
This PR sets the Sentry environment to be integration specific:

Before:
`environment: "production"`

After (for example):
`environment: "produciton-sourcemaps"`

This allows us to filter for the environment in Sentry dashboards/queries.

closes #404 

internal, so:
#skip-changelog