### PR TITLE
fix(sourcemaps): Enable source map generation when modifying vite config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ brew install getsentry/tools/sentry-wizard
 - fix: Handle no projects available (#412)
 - fix: Support org auth tokens in old wizards (#409)
 - fix: Treat user-entered DSN as a public DSN (#410)
+- fix(sourcemaps): Enable source map generation when modifying Vite config (#421)
 
 
 ## 3.10.0

--- a/test/sourcemaps/tools/vite.test.ts
+++ b/test/sourcemaps/tools/vite.test.ts
@@ -1,0 +1,149 @@
+import * as fs from 'fs';
+import { addVitePluginToConfig } from '../../../src/sourcemaps/tools/vite';
+
+function updateFileContent(content: string): void {
+  fileContent = content;
+}
+
+let fileContent = '';
+
+jest.mock('@clack/prompts', () => {
+  return {
+    log: {
+      info: jest.fn(),
+      success: jest.fn(),
+    },
+  };
+});
+
+jest
+  .spyOn(fs.promises, 'readFile')
+  .mockImplementation(() => Promise.resolve(fileContent));
+
+const writeFileSpy = jest
+  .spyOn(fs.promises, 'writeFile')
+  .mockImplementation(() => Promise.resolve(void 0));
+
+describe('addVitePluginToConfig', () => {
+  afterEach(() => {
+    fileContent = '';
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [
+      'no build options',
+      `
+export default defineConfig({
+  plugins: [
+    vue(),
+  ],
+})
+`,
+      `import { sentryVitePlugin } from "@sentry/vite-plugin";
+export default defineConfig({
+  plugins: [vue(), sentryVitePlugin({
+    org: "my-org",
+    project: "my-project"
+  })],
+
+  build: {
+    sourcemap: true
+  }
+})`,
+    ],
+    [
+      'no build.sourcemap options',
+      `
+export default defineConfig({
+  plugins: [
+    vue(),
+  ],
+  build: {
+    test: 1,  
+  }
+})
+  `,
+      `import { sentryVitePlugin } from "@sentry/vite-plugin";
+export default defineConfig({
+  plugins: [vue(), sentryVitePlugin({
+    org: "my-org",
+    project: "my-project"
+  })],
+  build: {
+    test: 1,
+    sourcemap: true
+  }
+})`,
+    ],
+    [
+      'keep sourcemap: "hidden"',
+      `
+export default {
+  plugins: [
+    vue(),
+  ],
+  build: {
+    sourcemap: "hidden",
+  }
+}
+    `,
+      `import { sentryVitePlugin } from "@sentry/vite-plugin";
+export default {
+  plugins: [vue(), sentryVitePlugin({
+    org: "my-org",
+    project: "my-project"
+  })],
+  build: {
+    sourcemap: "hidden",
+  }
+}`,
+    ],
+    [
+      'rewrite sourcemap: false to true',
+      `
+const cfg = {
+  plugins: [
+    vue(),
+  ],
+  build: {
+    sourcemap: false,
+  }
+}
+
+export default cfg;
+      `,
+      `import { sentryVitePlugin } from "@sentry/vite-plugin";
+const cfg = {
+  plugins: [vue(), sentryVitePlugin({
+    org: "my-org",
+    project: "my-project"
+  })],
+
+  build: {
+    sourcemap: true,
+  }
+}
+
+export default cfg;`,
+    ],
+  ])(
+    'adds the plugin and enables source maps generation (%s)',
+    async (_, originalCode, expectedCode) => {
+      updateFileContent(originalCode);
+
+      const addedCode = await addVitePluginToConfig('', {
+        authToken: '',
+        orgSlug: 'my-org',
+        projectSlug: 'my-project',
+        selfHosted: false,
+        url: 'https://sentry.io/',
+      });
+
+      expect(writeFileSpy).toHaveBeenCalledTimes(1);
+      const [[, fileContent]] = writeFileSpy.mock.calls;
+      expect(fileContent).toBe(expectedCode);
+      expect(addedCode).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
This PR fixes an oversight from #382: While we successfully added plugin insertion, we didn't enable source map generation via `build.sourcemap: true` (or `"hidden"`). This PR fixes that.

Prework to #418 since we need this there as well (albeit in a different form). 

Decided to use `recast` directly for this as `magicast` doesn't expose proper helpers. In fact, I gave up trying to work with magicast types which are super opaque due to their `ProxyfiedModule` typing. Recast gives us more freedom here and it works very well when using `recast.types.builders` to create new AST nodes. 