### PR TITLE
fix(android): Add support for unusual import statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(android): Add support for unusual import statements (#440)
+
 ## 3.11.0
 
 - feat(android): Add wizard support for Android (#389)

--- a/src/android/code-tools.ts
+++ b/src/android/code-tools.ts
@@ -103,13 +103,8 @@ export function patchMainActivity(activityFile: string | undefined): boolean {
     return true;
   }
 
-  const importRegex = /import\s+[\w.]+;?/gim;
-  let importsMatch = importRegex.exec(activityContent);
-  let importIndex = 0;
-  while (importsMatch) {
-    importIndex = importsMatch.index + importsMatch[0].length + 1;
-    importsMatch = importRegex.exec(activityContent);
-  }
+  const importIndex = getLastImportLineLocation(activityContent);
+
   let newActivityContent;
   if (activityFile.endsWith('.kt')) {
     newActivityContent =
@@ -153,4 +148,23 @@ export function patchMainActivity(activityFile: string | undefined): boolean {
   );
 
   return true;
+}
+
+/**
+ * Returns the string index of the last import statement in the given code file.
+ * Works for both Java and Kotlin import statements.
+ *
+ * @param sourceCode
+ * @returns the insert index, or 0 if none found.
+ */
+export function getLastImportLineLocation(sourceCode: string): number {
+  const importRegex = /import(?:\sstatic)?\s+[\w.*]+(?: as [\w.]+)?;?/gim;
+
+  let importsMatch = importRegex.exec(sourceCode);
+  let importIndex = 0;
+  while (importsMatch) {
+    importIndex = importsMatch.index + importsMatch[0].length + 1;
+    importsMatch = importRegex.exec(sourceCode);
+  }
+  return importIndex;
 }

--- a/test/android/code-tools.test.ts
+++ b/test/android/code-tools.test.ts
@@ -1,0 +1,49 @@
+//@ts-ignore
+import { getLastImportLineLocation } from '../../src/android/code-tools';
+
+describe('code-tools', () => {
+  describe('getLastImportLineLocation', () => {
+    it('returns proper line index', () => {
+      const code = `import a.b.c;\n` + `//<insert-location>\n` + `class X {}`;
+      expect(getLastImportLineLocation(code)).toBe(
+        code.indexOf('//<insert-location>'),
+      );
+    });
+
+    it('returns proper line index when static import is used', () => {
+      const code =
+        `import static a.b.c;\n` + `//<insert-location>\n` + `class X {}`;
+      expect(getLastImportLineLocation(code)).toBe(
+        code.indexOf('//<insert-location>'),
+      );
+    });
+
+    it('returns proper line index when wildcard import is used', () => {
+      const code = `import a.b.*\n` + `//<insert-location>\n` + `class X {}`;
+      expect(getLastImportLineLocation(code)).toBe(
+        code.indexOf('//<insert-location>'),
+      );
+    });
+
+    it('returns proper line index when alias import is used', () => {
+      const code =
+        `import static a.b.c as d\n` + `//<insert-location>\n` + `class X {}`;
+      expect(getLastImportLineLocation(code)).toBe(
+        code.indexOf('//<insert-location>'),
+      );
+    });
+
+    it('returns proper line index when multiple imports are present', () => {
+      const code =
+        `import static a.b.c as d\n` +
+        `import a.b.*\n` +
+        `import static a.b.c;\n` +
+        `import a.b.c;\n` +
+        `//<insert-location>\n` +
+        `class X {}`;
+      expect(getLastImportLineLocation(code)).toBe(
+        code.indexOf('//<insert-location>'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Sometimes injecting the sentry import statements fails due to imports like

````java
import static a.b.c;
import x.y.z as D;
import a.b.*;
````

This PR adds support for that and some basic unit tests.