### PR TITLE
enh(wizard): sort projects in project-selection step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- enh(wizard): sort projects in project-selection step #441
+
 ## 3.11.0
 
 - feat(android): Add wizard support for Android (#389)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- enh(wizard): sort projects in project-selection step #441
+- fix(wizard): Sort projects in project-selection step #441
 
 ## 3.11.0
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -778,14 +778,21 @@ async function askForWizardLogin(options: {
 async function askForProjectSelection(
   projects: SentryProjectData[],
 ): Promise<SentryProjectData> {
+  const label = (project: SentryProjectData): string => {
+    return `${project.organization.slug}/${project.slug}`;
+  };
+  const sortedProjects = [...projects];
+  sortedProjects.sort((a: SentryProjectData, b: SentryProjectData) => {
+    return label(a).localeCompare(label(b));
+  });
   const selection: SentryProjectData | symbol = await abortIfCancelled(
     clack.select({
       maxItems: 12,
       message: 'Select your Sentry project.',
-      options: projects.map((project) => {
+      options: sortedProjects.map((project) => {
         return {
           value: project,
-          label: `${project.organization.slug}/${project.slug}`,
+          label: label(project),
         };
       }),
     }),


### PR DESCRIPTION
Small enhancement to show the list of projects in alphabetical order:
<img width="438" alt="image" src="https://github.com/getsentry/sentry-wizard/assets/1411808/134e83fe-6388-4c62-bc54-1534186a73d0">

Ideally one could even type to search to filter the list, but the underlying `clack.select` doesn't seem to provide this functionality.
