### PR TITLE
ref(wizard): Improve code snippet creation and copy paste helpers

### DIFF
--- a/lib/Steps/ChooseIntegration.ts
+++ b/lib/Steps/ChooseIntegration.ts
@@ -113,6 +113,7 @@ export class ChooseIntegration extends BaseStep {
           message: 'What platform do you want to set up?',
           name: 'integration',
           type: 'list',
+          pageSize: 10,
         },
       ]);
     }

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -1,39 +1,28 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
-import clack, { select } from '@clack/prompts';
-import chalk from 'chalk';
-import { abortIfCancelled } from '../../utils/clack-utils';
+import {
+  makeCodeSnippet,
+  showCopyPasteInstructions,
+} from '../../utils/clack-utils';
 
 export async function configureTscSourcemapGenerationFlow(): Promise<void> {
-  clack.log.step(
-    `Add the following code to your ${chalk.bold(
-      'tsconfig.json',
-    )} file: ${chalk.dim(
-      '(This ensures that source maps are generated correctly)',
-    )}`,
-  );
-
-  // Intentially logging directly to console here so that the code can be copied/pasted directly
-  // eslint-disable-next-line no-console
-  console.log(codeSnippet);
-
-  await abortIfCancelled(
-    select({
-      message: 'Did you update your config as shown in the snippet above?',
-      options: [{ label: 'Yes, continue!', value: true }],
-      initialValue: true,
-    }),
+  await showCopyPasteInstructions(
+    'tsconfig.json',
+    getCodeSnippet(true),
+    'This ensures that source maps are generated correctly',
   );
 }
 
-const codeSnippet = chalk.gray(`
-{
+const getCodeSnippet = (colors: boolean) =>
+  makeCodeSnippet(colors, (unchanged, plus, _) =>
+    unchanged(
+      `{
   "compilerOptions": {
-    ${chalk.greenBright('"sourceMap": true,')}
-    ${chalk.greenBright('"inlineSources": true,')}
+    ${plus('"sourceMap": true,')}
+    ${plus('"inlineSources": true,')}
 
     // Set \`sourceRoot\` to  "/" to strip the build path prefix from
     // generated source code references. This will improve issue grouping in Sentry.
-    ${chalk.greenBright('"sourceRoot": "/"')}
+    ${plus('"sourceRoot": "/"')}
   }
-}
-`);
+}`,
+    ),
+  );

--- a/src/sourcemaps/tools/vite.ts
+++ b/src/sourcemaps/tools/vite.ts
@@ -19,6 +19,7 @@ import {
   createNewConfigFile,
   getPackageDotJson,
   installPackage,
+  makeCodeSnippet,
   showCopyPasteInstructions,
 } from '../../utils/clack-utils';
 import { hasPackageInstalled } from '../../utils/package-json';
@@ -36,52 +37,27 @@ import { debug } from '../../utils/debug';
 const getViteConfigSnippet = (
   options: SourceMapUploadToolConfigurationOptions,
   colors: boolean,
-) => {
-  const rawImportStmt =
-    'import { sentryVitePlugin } from "@sentry/vite-plugin";';
-  const rawGenerateSourceMapsOption =
-    'sourcemap: true, // Source map generation must be turned on';
-  const rawSentryVitePluginFunction = `sentryVitePlugin({
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: "${options.orgSlug}",
-      project: "${options.projectSlug}",${
-    options.selfHosted ? `\n      url: "${options.url}",` : ''
-  }
-    }),`;
-
-  const importStmt = colors ? chalk.greenBright(rawImportStmt) : rawImportStmt;
-  const generateSourceMapsOption = colors
-    ? chalk.greenBright(rawGenerateSourceMapsOption)
-    : rawGenerateSourceMapsOption;
-  const sentryVitePluginFunction = colors
-    ? chalk.greenBright(rawSentryVitePluginFunction)
-    : rawSentryVitePluginFunction;
-
-  const code = getViteConfigContent(
-    importStmt,
-    generateSourceMapsOption,
-    sentryVitePluginFunction,
-  );
-  return colors ? chalk.gray(code) : code;
-};
-
-const getViteConfigContent = (
-  importStmt: string,
-  generateSourceMapsOption: string,
-  sentryVitePluginFunction: string,
-) => `import { defineConfig } from "vite";
-${importStmt}
+) =>
+  makeCodeSnippet(colors, (unchanged, plus, _) =>
+    unchanged(`import { defineConfig } from "vite";
+${plus('import { sentryVitePlugin } from "@sentry/vite-plugin";')}
 
 export default defineConfig({
   build: {
-    ${generateSourceMapsOption}
+    ${plus('sourcemap: true, // Source map generation must be turned on')}
   },
   plugins: [
     // Put the Sentry vite plugin after all other plugins
-    ${sentryVitePluginFunction}
+    ${plus(`sentryVitePlugin({
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "${options.orgSlug}",
+      project: "${options.projectSlug}",${
+      options.selfHosted ? `\n      url: "${options.url}",` : ''
+    }
+    }),`)}
   ],
-});
-`;
+});`),
+  );
 
 export const configureVitePlugin: SourceMapUploadToolConfigurationFunction =
   async (options) => {

--- a/src/sourcemaps/tools/webpack.ts
+++ b/src/sourcemaps/tools/webpack.ts
@@ -18,6 +18,7 @@ import {
   createNewConfigFile,
   getPackageDotJson,
   installPackage,
+  makeCodeSnippet,
   showCopyPasteInstructions,
 } from '../../utils/clack-utils';
 import { hasPackageInstalled } from '../../utils/package-json';
@@ -33,51 +34,27 @@ import { debug } from '../../utils/debug';
 const getCodeSnippet = (
   options: SourceMapUploadToolConfigurationOptions,
   colors: boolean,
-) => {
-  const rawImportStmt =
-    'const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");';
-  const rawGenerateSourceMapsOption =
-    'devtool: "source-map", // Source map generation must be turned on';
-  const rawSentryWebpackPluginFunction = `sentryWebpackPlugin({
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: "${options.orgSlug}",
-      project: "${options.projectSlug}",${
-    options.selfHosted ? `\n      url: "${options.url}",` : ''
-  }
-    })`;
-
-  const importStmt = colors ? chalk.greenBright(rawImportStmt) : rawImportStmt;
-  const generateSourceMapsOption = colors
-    ? chalk.greenBright(rawGenerateSourceMapsOption)
-    : rawGenerateSourceMapsOption;
-  const sentryWebpackPluginFunction = colors
-    ? chalk.greenBright(rawSentryWebpackPluginFunction)
-    : rawSentryWebpackPluginFunction;
-
-  const code = getWebpackConfigContent(
-    importStmt,
-    generateSourceMapsOption,
-    sentryWebpackPluginFunction,
-  );
-
-  return colors ? chalk.gray(code) : code;
-};
-
-const getWebpackConfigContent = (
-  importStmt: string,
-  generateSourceMapsOption: string,
-  sentryWebpackPluginFunction: string,
-) => `${importStmt}
+) =>
+  makeCodeSnippet(colors, (unchanged, plus) =>
+    unchanged(`${plus(
+      'const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");',
+    )}
 
 module.exports = {
   // ... other options
-  ${generateSourceMapsOption},
+  ${plus('devtool: "source-map", // Source map generation must be turned on')}
   plugins: [
     // Put the Sentry Webpack plugin after all other plugins
-    ${sentryWebpackPluginFunction},
+    ${plus(`sentryWebpackPlugin({
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      org: "${options.orgSlug}",
+      project: "${options.projectSlug}",${
+      options.selfHosted ? `\n      url: "${options.url}",` : ''
+    }
+    }),`)}
   ],
-}
-`;
+}`),
+  );
 
 export const configureWebPackPlugin: SourceMapUploadToolConfigurationFunction =
   async (options) => {


### PR DESCRIPTION
This PR improves how we can create multi-functional code snippets that

* can be printed to the console in which case they should appear colorized (diff-like)
* can be written to a file (for example when we create a new config file)

I believe, the new `makeCodeSnippet` helper, with its formatting functions, helps us achieve still readable code snippets that can be reused with and without formatting/colorization. 

Additionally, the PR slightly adjusts the `showCopyPasteInstructions` helper to take a hint argument.

#skip-changelog

prework to #403 