### PR TITLE
feat(sourcemaps): Automatically enable source maps generation in `tsconfig.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - enh(android): Show link to issues page after setup is complete (#448)
 - feat(remix): Pass `org`, `project`, `url` to `upload-sourcemaps` script (#434) 
+- feat(sourcemaps): Automatically enable source maps generation in `tsconfig.json` (#449)
 - fix(nextjs): Add selfhosted url in `next.config.js` (#438)
 - fix(nextjs): Create necessary directories in app router (#439)
 - fix(sourcemaps): Write package manager command instead of object to package.json (#453)

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -1,15 +1,20 @@
+import * as fs from 'fs';
+
+import * as recast from 'recast';
+
 import {
   makeCodeSnippet,
   showCopyPasteInstructions,
 } from '../../utils/clack-utils';
+import {
+  getObjectProperty,
+  parseJsonC,
+  printJsonC,
+  setOrUpdateObjectProperty,
+} from '../../utils/ast-utils';
+import { debug } from '../../utils/debug';
 
-export async function configureTscSourcemapGenerationFlow(): Promise<void> {
-  await showCopyPasteInstructions(
-    'tsconfig.json',
-    getCodeSnippet(true),
-    'This ensures that source maps are generated correctly',
-  );
-}
+const b = recast.types.builders;
 
 const getCodeSnippet = (colors: boolean) =>
   makeCodeSnippet(colors, (unchanged, plus, _) =>
@@ -26,3 +31,74 @@ const getCodeSnippet = (colors: boolean) =>
 }`,
     ),
   );
+
+export async function configureTscSourcemapGenerationFlow(): Promise<void> {
+  await showCopyPasteInstructions(
+    'tsconfig.json',
+    getCodeSnippet(true),
+    'This ensures that source maps are generated correctly',
+  );
+}
+
+export async function enableSourcemaps(tsConfigPath: string): Promise<boolean> {
+  try {
+    const tsConfig = await fs.promises.readFile(tsConfigPath, 'utf-8');
+
+    const { ast, jsonObject } = parseJsonC(tsConfig.toString());
+
+    if (!jsonObject || !ast) {
+      // this will only happen if the input file isn't valid JSON-C
+      return false;
+    }
+
+    const compilerOptionsProp = getObjectProperty(
+      jsonObject,
+      'compilerOptions',
+    );
+
+    if (!compilerOptionsProp) {
+      setOrUpdateObjectProperty(
+        jsonObject,
+        'compilerOptions',
+        b.objectExpression([]),
+      );
+    }
+
+    const compilerOptionsObj = compilerOptionsProp
+      ? compilerOptionsProp.value
+      : getObjectProperty(jsonObject, 'compilerOptions')?.value;
+
+    if (!compilerOptionsObj || compilerOptionsObj.type !== 'ObjectExpression') {
+      // a valid compilerOptions prop should always be an object expression
+      return false;
+    }
+
+    setOrUpdateObjectProperty(
+      compilerOptionsObj,
+      'sourceMap',
+      b.booleanLiteral(true),
+    );
+
+    setOrUpdateObjectProperty(
+      compilerOptionsObj,
+      'inlineSources',
+      b.booleanLiteral(true),
+    );
+
+    setOrUpdateObjectProperty(
+      compilerOptionsObj,
+      'sourceRoot',
+      b.stringLiteral('/'),
+      'Set `sourceRoot` to  "/" to strip the build path prefix\nfrom generated source code references.\nThis improves issue grouping in Sentry.',
+    );
+
+    const code = printJsonC(ast);
+
+    await fs.promises.writeFile(tsConfigPath, code);
+    return true;
+  } catch (e) {
+    console.log(e);
+    debug(e);
+    return false;
+  }
+}

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -7,7 +7,7 @@ import {
   showCopyPasteInstructions,
 } from '../../utils/clack-utils';
 import {
-  getObjectProperty,
+  getOrSetObjectProperty,
   parseJsonC,
   printJsonC,
   setOrUpdateObjectProperty,
@@ -51,22 +51,13 @@ export async function enableSourcemaps(tsConfigPath: string): Promise<boolean> {
       return false;
     }
 
-    const compilerOptionsProp = getObjectProperty(
+    const compilerOptionsProp = getOrSetObjectProperty(
       jsonObject,
       'compilerOptions',
+      b.objectExpression([]),
     );
 
-    if (!compilerOptionsProp) {
-      setOrUpdateObjectProperty(
-        jsonObject,
-        'compilerOptions',
-        b.objectExpression([]),
-      );
-    }
-
-    const compilerOptionsObj = compilerOptionsProp
-      ? compilerOptionsProp.value
-      : getObjectProperty(jsonObject, 'compilerOptions')?.value;
+    const compilerOptionsObj = compilerOptionsProp.value;
 
     if (!compilerOptionsObj || compilerOptionsObj.type !== 'ObjectExpression') {
       // a valid compilerOptions prop should always be an object expression
@@ -97,7 +88,6 @@ export async function enableSourcemaps(tsConfigPath: string): Promise<boolean> {
     await fs.promises.writeFile(tsConfigPath, code);
     return true;
   } catch (e) {
-    console.log(e);
     debug(e);
     return false;
   }

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/node';
 
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
+import chalk from 'chalk';
 
 import {
   askForToolConfigPath,
@@ -127,6 +128,13 @@ export async function enableSourcemaps(tsConfigPath: string): Promise<boolean> {
     const code = printJsonC(ast);
 
     await fs.promises.writeFile(tsConfigPath, code);
+
+    clack.log.success(
+      `Enabled source maps generation in ${chalk.cyan(
+        path.basename(tsConfigPath || 'tsconfig.json'),
+      )}.`,
+    );
+
     return true;
   } catch (e) {
     debug(e);

--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -73,6 +73,42 @@ export function getObjectProperty(
 }
 
 /**
+ * Attempts to find a property of an ObjectExpression by name. If it doesn't exist,
+ * the property will be added to the ObjectExpression with the provided default value.
+ *
+ * @param object the parent object expression to search in
+ * @param name the name of the property to search for
+ * @param defaultValue the default value to set if the property doesn't exist
+ *
+ * @returns the
+ */
+export function getOrSetObjectProperty(
+  object: t.ObjectExpression,
+  name: string,
+  defaultValue:
+    | t.Literal
+    | t.BooleanLiteral
+    | t.StringLiteral
+    | t.ObjectExpression,
+): t.Property {
+  const existingProperty = getObjectProperty(object, name);
+
+  if (existingProperty) {
+    return existingProperty;
+  }
+
+  const newProperty = b.property.from({
+    kind: 'init',
+    key: b.stringLiteral(name),
+    value: defaultValue,
+  });
+
+  object.properties.push(newProperty);
+
+  return newProperty;
+}
+
+/**
  * Sets a property of an ObjectExpression if it exists, otherwise adds it
  * to the ObjectExpression. Optionally, a comment can be added to the
  * property.

--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -4,6 +4,8 @@ import * as recast from 'recast';
 import x = recast.types;
 import t = x.namedTypes;
 
+const b = recast.types.builders;
+
 /**
  * Checks if a file where we don't know its concrete file type yet exists
  * and returns the full path to the file with the correct file type.
@@ -35,4 +37,146 @@ export function hasSentryContent(program: t.Program): boolean {
   });
 
   return !!foundSentry;
+}
+
+/**
+ * Searches for a property of an ObjectExpression by name
+ *
+ * @param object the ObjectExpression to search in
+ * @param name the name of the property to search for
+ *
+ * @returns the property if it exists
+ */
+export function getObjectProperty(
+  object: t.ObjectExpression,
+  name: string,
+): t.Property | undefined {
+  return object.properties.find((p): p is t.Property => {
+    const isObjectProp = p.type === 'Property' || p.type === 'ObjectProperty';
+
+    if (!isObjectProp) {
+      return false;
+    }
+
+    const hasMatchingLiteralKey =
+      isObjectProp &&
+      (p.key.type === 'Literal' || p.key.type === 'StringLiteral') &&
+      p.key.value === name;
+
+    if (hasMatchingLiteralKey) {
+      return true;
+    }
+
+    // has matching identifier key
+    return isObjectProp && p.key.type === 'Identifier' && p.key.name === name;
+  });
+}
+
+/**
+ * Sets a property of an ObjectExpression if it exists, otherwise adds it
+ * to the ObjectExpression. Optionally, a comment can be added to the
+ * property.
+ *
+ * @param object the ObjectExpression to set the property on
+ * @param name the name of the property to set
+ * @param value  the value of the property to set
+ * @param comment (optional) a comment to add to the property
+ */
+export function setOrUpdateObjectProperty(
+  object: t.ObjectExpression,
+  name: string,
+  value: t.Literal | t.BooleanLiteral | t.StringLiteral | t.ObjectExpression,
+  comment?: string,
+) {
+  const newComments =
+    comment &&
+    comment.split('\n').map((c) => b.commentLine(` ${c}`, true, false));
+
+  const existingProperty = getObjectProperty(object, name);
+
+  if (existingProperty) {
+    existingProperty.value = value;
+    if (newComments) {
+      existingProperty.comments = [
+        ...(existingProperty?.comments || []),
+        ...newComments,
+      ];
+    }
+  } else {
+    object.properties.push(
+      b.objectProperty.from({
+        key: b.stringLiteral(name),
+        value,
+        ...(newComments && {
+          comments: newComments,
+        }),
+      }),
+    );
+  }
+}
+
+type JsonCParseResult =
+  | {
+      jsonObject: t.ObjectExpression;
+      ast: t.Program;
+    }
+  | {
+      jsonObject: undefined;
+      ast: undefined;
+    };
+
+/**
+ * Parses a JSON string with (potential) comments (JSON-C) and returns the JS AST
+ * that can be walked and modified with recast like a normal JS AST.
+ *
+ * This is done by wrapping the JSON-C string in parentheses, thereby making it
+ * a JS `Program` with an `ExpressionStatement` as its body. The expression is then
+ * extracted from the AST and returned alongside the AST.
+ *
+ * To preserve as much original formatting as possible, the returned `ast`
+ * property should be passed to {@link `printJsonC`} to get the JSON-C string back.
+ *
+ * If the input is not valid JSON-C, the result will be undefined.
+ *
+ * @see {@link JsonCParseResult}
+ *
+ * @param jsonString a JSON-C string
+ *
+ * @returns a {@link JsonCParseResult}, containing either the JSON-C object and the AST or undefined in both cases
+ */
+export function parseJsonC(jsonString: string): JsonCParseResult {
+  try {
+    const jsTsConfig = `(${jsonString})`;
+    // no idea why recast returns any here, this is dumb :/
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const ast = recast.parse(jsTsConfig.toString()).program as t.Program;
+
+    const jsonObject =
+      (ast.body[0].type === 'ExpressionStatement' &&
+        ast.body[0].expression.type === 'ObjectExpression' &&
+        ast.body[0].expression) ||
+      undefined;
+
+    if (jsonObject) {
+      return { jsonObject, ast };
+    }
+  } catch {
+    /* empty */
+  }
+  return { jsonObject: undefined, ast: undefined };
+}
+
+/**
+ * Takes the AST of a parsed JSON-C "program" and returns the JSON-C string without
+ * any of the temporary JS wrapper code that was previously applied.
+ *
+ * Only use this in conjunction with {@link `parseJsonC`}
+ *
+ * @param ast the `ast` returned from {@link `parseJsonC`}
+ *
+ * @returns the JSON-C string
+ */
+export function printJsonC(ast: t.Program): string {
+  const js = recast.print(ast).code;
+  return js.substring(1, js.length - 1);
 }

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -788,7 +788,7 @@ export async function askForToolConfigPath(
     clack.confirm({
       message: `Do you have a ${toolName} config file (e.g. ${chalk.cyan(
         configFileName,
-      )}?`,
+      )})?`,
       initialValue: true,
     }),
   );

--- a/test/sourcemaps/tools/tsc.test.ts
+++ b/test/sourcemaps/tools/tsc.test.ts
@@ -1,0 +1,181 @@
+import * as fs from 'fs';
+import { enableSourcemaps } from '../../../src/sourcemaps/tools/tsc';
+
+function updateFileContent(content: string): void {
+  fileContent = content;
+}
+
+let fileContent = '';
+
+jest.mock('@clack/prompts', () => {
+  return {
+    log: {
+      info: jest.fn(),
+      success: jest.fn(),
+    },
+  };
+});
+
+jest
+  .spyOn(fs.promises, 'readFile')
+  .mockImplementation(() => Promise.resolve(fileContent));
+
+const writeFileSpy = jest
+  .spyOn(fs.promises, 'writeFile')
+  .mockImplementation(() => Promise.resolve(void 0));
+
+describe('enableSourcemaps', () => {
+  afterEach(() => {
+    fileContent = '';
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [
+      'no sourcemaps options',
+      `
+/**
+ * My TS config with comments
+ */
+{
+  "extends": "./tsconfig.build.json",
+
+  "compilerOptions": {
+    // line comment which should stay
+    "moduleResolution": "node16",
+    "outDir": "dist" // another inline comment
+  },
+
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}
+`,
+      `
+/**
+ * My TS config with comments
+ */
+{
+  "extends": "./tsconfig.build.json",
+
+  "compilerOptions": {
+    // line comment which should stay
+    "moduleResolution": "node16",
+
+    // another inline comment
+    "outDir": "dist",
+
+    "sourceMap": true,
+    "inlineSources": true,
+
+    // Set \`sourceRoot\` to  "/" to strip the build path prefix
+    // from generated source code references.
+    // This improves issue grouping in Sentry.
+    "sourceRoot": "/"
+  },
+
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}
+`,
+    ],
+    [
+      'a few sourcemaps options',
+      `
+/**
+ * My TS config with comments
+ */
+{
+  "extends": "./tsconfig.build.json",
+
+  "compilerOptions": {
+    // line comment which should stay
+    "moduleResolution": "node16",
+    "outDir": "dist", // another inline comment
+    "sourceMap": false,
+    "sourceRoot": "/src"
+  },
+
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}
+`,
+      `
+/**
+ * My TS config with comments
+ */
+{
+  "extends": "./tsconfig.build.json",
+
+  "compilerOptions": {
+    // line comment which should stay
+    "moduleResolution": "node16",
+
+    // another inline comment
+    "outDir": "dist",
+
+    "sourceMap": true,
+
+    // Set \`sourceRoot\` to  "/" to strip the build path prefix
+    // from generated source code references.
+    // This improves issue grouping in Sentry.
+    "sourceRoot": "/",
+
+    "inlineSources": true
+  },
+
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}
+`,
+    ],
+    [
+      'no compiler options',
+      `
+{
+    "include": [
+        "src/**/*",
+        "test/**/*"
+    ]
+}
+`,
+      `
+{
+    "include": [
+        "src/**/*",
+        "test/**/*"
+    ],
+
+    "compilerOptions": {
+        "sourceMap": true,
+        "inlineSources": true,
+
+        // Set \`sourceRoot\` to  "/" to strip the build path prefix
+        // from generated source code references.
+        // This improves issue grouping in Sentry.
+        "sourceRoot": "/"
+    }
+}
+`,
+    ],
+  ])(
+    'adds the plugin and enables source maps generation (%s)',
+    async (_, originalCode, expectedCode) => {
+      updateFileContent(originalCode);
+
+      const addedCode = await enableSourcemaps('');
+
+      expect(writeFileSpy).toHaveBeenCalledTimes(1);
+      const [[, fileContent]] = writeFileSpy.mock.calls;
+      expect(fileContent).toBe(expectedCode);
+      expect(addedCode).toBe(true);
+    },
+  );
+});

--- a/test/utils/ast-utils.test.ts
+++ b/test/utils/ast-utils.test.ts
@@ -1,15 +1,21 @@
-import { hasSentryContent } from '../../src/utils/ast-utils';
+import {
+  getObjectProperty,
+  hasSentryContent,
+  parseJsonC,
+  printJsonC,
+  setOrUpdateObjectProperty,
+} from '../../src/utils/ast-utils';
 
 import * as recast from 'recast';
+const b = recast.types.builders;
 
-describe('AST utils', () => {
-  describe('hasSentryContent', () => {
-    it.each([
-      `
+describe('hasSentryContent', () => {
+  it.each([
+    `
       const { sentryVitePlugin } = require("@sentry/vite-plugin");
       const somethingelse = require('gs');
     `,
-      `
+    `
         import { sentryVitePlugin } from "@sentry/vite-plugin";
         import * as somethingelse from 'gs';
 
@@ -17,47 +23,201 @@ describe('AST utils', () => {
             plugins: [sentryVitePlugin()]
         }
       `,
-    ])(
-      "returns true if a require('@sentry/') call was found in the parsed module",
-      (code) => {
-        // recast.parse returns a Program node (or fails) but it's badly typed as any
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const program = recast.parse(code)
-          .program as recast.types.namedTypes.Program;
-        expect(hasSentryContent(program)).toBe(true);
-      },
-    );
+  ])(
+    "returns true if a require('@sentry/') call was found in the parsed module",
+    (code) => {
+      // recast.parse returns a Program node (or fails) but it's badly typed as any
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const program = recast.parse(code)
+        .program as recast.types.namedTypes.Program;
+      expect(hasSentryContent(program)).toBe(true);
+    },
+  );
 
-    it.each([
-      `const whatever = require('something')`,
-      `// const {sentryWebpackPlugin} = require('@sentry/webpack-plugin')`,
-      `const {sAntryWebpackPlugin} = require('webpack-plugin-@sentry')`,
-      `
+  it.each([
+    `const whatever = require('something')`,
+    `// const {sentryWebpackPlugin} = require('@sentry/webpack-plugin')`,
+    `const {sAntryWebpackPlugin} = require('webpack-plugin-@sentry')`,
+    `
       import * as somethingelse from 'gs';
       export default {
           plugins: []
       }
       `,
-      `import * as somethingelse from 'gs';
+    `import * as somethingelse from 'gs';
        // import { sentryVitePlugin } from "@sentry/vite-plugin"
       export default {
           plugins: []
       }
       `,
-      `import * as thirdPartyVitePlugin from "vite-plugin-@sentry"
+    `import * as thirdPartyVitePlugin from "vite-plugin-@sentry"
       export default {
         plugins: [thirdPartyVitePlugin()]
       }
       `,
-    ])(
-      "returns false if the file doesn't contain any require('@sentry/') calls",
-      (code) => {
-        // recast.parse returns a Program node (or fails) but it's badly typed as any
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const program = recast.parse(code)
-          .program as recast.types.namedTypes.Program;
-        expect(hasSentryContent(program)).toBe(false);
-      },
+  ])(
+    "returns false if the file doesn't contain any require('@sentry/') calls",
+    (code) => {
+      // recast.parse returns a Program node (or fails) but it's badly typed as any
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const program = recast.parse(code)
+        .program as recast.types.namedTypes.Program;
+      expect(hasSentryContent(program)).toBe(false);
+    },
+  );
+});
+
+describe('getObjectProperty', () => {
+  it.each([
+    [
+      'literal',
+      b.objectExpression([
+        b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+        b.objectProperty(
+          b.stringLiteral('needle'),
+          b.stringLiteral('haystack'),
+        ),
+      ]),
+    ],
+    [
+      'stringLiteral',
+      b.objectExpression([
+        b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+        b.objectProperty(b.literal('needle'), b.stringLiteral('haystack')),
+      ]),
+    ],
+    [
+      'identifier',
+      b.objectExpression([
+        b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+        b.objectProperty(b.identifier('needle'), b.stringLiteral('haystack')),
+      ]),
+    ],
+  ])('returns the poperty (%s) if it exists', (_, object) => {
+    const property = getObjectProperty(object, 'needle');
+    expect(property).toBeDefined();
+    // @ts-expect-error we know it's defined due to the expect above
+    expect(recast.print(property).code).toEqual(
+      expect.stringContaining('needle'),
     );
+  });
+
+  it('returns undefined if the property does not exist', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+    ]);
+    const property = getObjectProperty(object, 'needle');
+    expect(property).toBeUndefined();
+  });
+
+  it('handles objects without simple properties', () => {
+    const object = b.objectExpression([b.spreadElement(b.identifier('foo'))]);
+    const property = getObjectProperty(object, 'needle');
+    expect(property).toBeUndefined();
+  });
+});
+
+describe('setOrUpdateObjectProperty', () => {
+  it('sets a new property if it does not exist yet', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+    ]);
+
+    setOrUpdateObjectProperty(object, 'needle', b.stringLiteral('haystack'));
+
+    expect(getObjectProperty(object, 'needle')).toBeDefined();
+  });
+
+  it('updates an existing property if it exists', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+      b.objectProperty(b.identifier('needle'), b.stringLiteral('haystack')),
+    ]);
+
+    setOrUpdateObjectProperty(object, 'needle', b.stringLiteral('haystack2'));
+
+    const property = getObjectProperty(object, 'needle');
+    // @ts-expect-error it must be defiend, otherwise we fail anyway
+    expect(property?.value.value).toBe('haystack2');
+  });
+
+  it('adds a comment to the existing property if provided', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+    ]);
+
+    setOrUpdateObjectProperty(
+      object,
+      'needle',
+      b.stringLiteral('haystack'),
+      'This is a comment',
+    );
+
+    const property = getObjectProperty(object, 'needle');
+    expect(property?.comments).toHaveLength(1);
+    // @ts-expect-error it must be defiend, otherwise we fail anyway
+    expect(property?.comments[0].value).toBe(' This is a comment');
+  });
+
+  it('adds a comment to the new property if provided', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+    ]);
+
+    setOrUpdateObjectProperty(
+      object,
+      'needle',
+      b.stringLiteral('haystack'),
+      'This is a comment',
+    );
+
+    const property = getObjectProperty(object, 'needle');
+    expect(property?.comments).toHaveLength(1);
+    // @ts-expect-error it must be defiend, otherwise we fail anyway
+    expect(property?.comments[0].value).toBe(' This is a comment');
+  });
+});
+
+describe('parse and print JSON-C', () => {
+  it.each([
+    ['simple JSON', "{'foo': 'bar'}"],
+    [
+      'JSON-C with inline comment',
+      `
+    {
+      "foo": "bar" // with an inline comment
+    }
+    `,
+    ],
+    [
+      'JSON-C with multiple comments',
+      `
+    /*
+     * let's throw in a block comment for good measure
+     */  
+    {
+      // one line comment
+      "foo": "bar", // another inline comment
+      /* one more here */
+      "dogs": /* and here */ "awesome",
+    }
+    /* and here */
+    `,
+    ],
+  ])(`parses and prints JSON-C (%s)`, (_, json) => {
+    const { ast, jsonObject } = parseJsonC(json);
+    expect(ast?.type).toBe('Program');
+    expect(jsonObject).toBeDefined();
+    expect(jsonObject?.type).toBe('ObjectExpression');
+    // @ts-expect-error we know it's defined due to the expect above
+    expect(printJsonC(ast)).toEqual(json);
+  });
+
+  it('returns undefined if the input is not valid JSON-C', () => {
+    const { ast, jsonObject } = parseJsonC(`{
+      "invalid": // "json"
+    }`);
+    expect(ast).toBeUndefined();
+    expect(jsonObject).toBeUndefined();
   });
 });

--- a/test/utils/ast-utils.test.ts
+++ b/test/utils/ast-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   getObjectProperty,
+  getOrSetObjectProperty,
   hasSentryContent,
   parseJsonC,
   printJsonC,
@@ -114,6 +115,46 @@ describe('getObjectProperty', () => {
     const object = b.objectExpression([b.spreadElement(b.identifier('foo'))]);
     const property = getObjectProperty(object, 'needle');
     expect(property).toBeUndefined();
+  });
+});
+
+describe('getOrSetObjectProperty', () => {
+  it('returns the property if it exists', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('needle'), b.stringLiteral('haystack')),
+    ]);
+
+    const property = getOrSetObjectProperty(
+      object,
+      'needle',
+      b.stringLiteral('nope'),
+    );
+
+    expect(property).toBeDefined();
+    expect(property.type).toBe('ObjectProperty');
+    // @ts-expect-error we know its type
+    expect(property.key.name).toBe('needle');
+    // @ts-expect-error we know its type
+    expect(property.value.value).toBe('haystack');
+  });
+
+  it('adds the property if it does not exist', () => {
+    const object = b.objectExpression([
+      b.objectProperty(b.identifier('foo'), b.stringLiteral('bar')),
+    ]);
+
+    const property = getOrSetObjectProperty(
+      object,
+      'needle',
+      b.stringLiteral('haystack'),
+    );
+
+    expect(property).toBeDefined();
+    expect(property.type).toBe('Property');
+    // @ts-expect-error we know its type
+    expect(property.key.value).toBe('needle');
+    // @ts-expect-error we know its type
+    expect(property.value.value).toBe('haystack');
   });
 });
 


### PR DESCRIPTION
This PR adds automatic adjustment of properties in `tsconfig.json` to emit source maps in the TypeScript/TSC flow of the source maps wizard. More specifically, it modifies the current source map generation flow for TSC from always printing copy/paste instructions to:

* Looking up (or asking users for) an existing tsconfig
* If it exists, automatically setting the necessariy source map properties
* If it doesn't exist, creating a new tsconfig with the options if nothing exists yet
* Showing copy/paste instructions as a fallback if something goes wrong.

`tsconfigs.json` files are not simple JSON but they can contain comments (JSON-C). To preserve as much of the original formatting as possible, I decided to parse the JSON-C file as a JS file and modifiy it with recast. 

A pure JSON object expression is unfortunately not a valid JS program, meaning we have to apply a little hack to be able to parse this with any JS parser: We simple throw the JSON object into parentheses:
`{"foo": "bar"}` becomes `({"foo": "bar"})`. This we can parse and extract the actual JSON object from. After printing the entire program again, we can simply remove the parentheses and we're done. 

I created two helpers, `parseJsonC` and `printJsonC` to make this reusable (#402 👀). We can reuse them even if we parse normal JSON because the nice thing about recast is that it always tries to preserve original formatting. Meaning it's better than `JSON.stringify(obj, null, 2)`. 

Also added a few helpers to get, set and update object properties of object expressions. Plus tests for all AST operations.

closes #403