### PR TITLE
fix(sourcemaps): Write package manager command instead of object to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat(remix): Pass `org`, `project`, `url` to `upload-sourcemaps` script (#434) 
 - fix(nextjs): Add selfhosted url in `next.config.js` (#438)
 - fix(nextjs): Create necessary directories in app router (#439)
+- fix(sourcemaps): Write package manager command instead of object to package.json (#453)
 
 Work in this release contributed by @andreysam. Thank you for your contributions!
 

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -10,38 +10,44 @@ export interface PackageManager {
   lockFile: string;
   installCommand: string;
   buildCommand: string;
+  /* The command that the package manager uses to run a script from package.json */
+  runScriptCommand: string;
 }
 
-const bun: PackageManager = {
+export const BUN: PackageManager = {
   name: 'bun',
   label: 'Bun',
   lockFile: 'bun.lockb',
   installCommand: 'bun add',
-  buildCommand: 'bun build',
+  buildCommand: 'bun run build',
+  runScriptCommand: 'bun run',
 };
-const yarn: PackageManager = {
+export const YARN: PackageManager = {
   name: 'yarn',
   label: 'Yarn',
   lockFile: 'yarn.lock',
   installCommand: 'yarn add',
   buildCommand: 'yarn build',
+  runScriptCommand: 'yarn',
 };
-const pnpm: PackageManager = {
+export const PNPM: PackageManager = {
   name: 'pnpm',
   label: 'PNPM',
   lockFile: 'pnpm-lock.yaml',
   installCommand: 'pnpm add',
   buildCommand: 'pnpm build',
+  runScriptCommand: 'pnpm',
 };
-const npm: PackageManager = {
+export const NPM: PackageManager = {
   name: 'npm',
   label: 'NPM',
   lockFile: 'package-lock.json',
   installCommand: 'npm add',
   buildCommand: 'npm run build',
+  runScriptCommand: 'npm run',
 };
 
-export const packageManagers = [bun, yarn, pnpm, npm];
+export const packageManagers = [BUN, YARN, PNPM, NPM];
 
 export function detectPackageManger(): PackageManager | null {
   for (const packageManager of packageManagers) {

--- a/test/sourcemaps/tools/sentry-cli.test.ts
+++ b/test/sourcemaps/tools/sentry-cli.test.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+
+import { addSentryCommandToBuildCommand } from '../../../src/sourcemaps/tools/sentry-cli';
+
+import * as packageManagerHelpers from '../../../src/utils/package-manager';
+
+const writeFileSpy = jest
+  .spyOn(fs.promises, 'writeFile')
+  .mockImplementation(() => Promise.resolve());
+
+jest.mock('@clack/prompts', () => {
+  return {
+    log: {
+      info: jest.fn(),
+      success: jest.fn(),
+    },
+    confirm: jest.fn().mockResolvedValue(true),
+    isCancel: jest.fn().mockReturnValue(false),
+  };
+});
+
+describe('addSentryCommandToBuildCommand', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it.each([
+    [
+      packageManagerHelpers.NPM,
+      packageManagerHelpers.PNPM,
+      packageManagerHelpers.YARN,
+      packageManagerHelpers.BUN,
+    ],
+  ])('adds the cli command to the script command (%s)', async (_, pacMan) => {
+    jest
+      .spyOn(packageManagerHelpers, 'detectPackageManger')
+      .mockReturnValue(pacMan);
+    const packageJson = {
+      scripts: {
+        build: 'tsc',
+      },
+      version: '1.0.0',
+    };
+    await addSentryCommandToBuildCommand(packageJson);
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      expect.stringContaining('package.json'),
+      expect.stringContaining(
+        `tsc && ${pacMan.runScriptCommand} sentry:sourcemaps`,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
This PR fixes a bug in our Sentry-CLI flow when we printed the package manager object (introduced in #417) to the package.json instead of the package manager's run command. 

A contributing factor to this bug was that we had an eslint-ignore comment in the erroneous line that suppressed an actually correct warning. This PR removes the ignore comment and resolves both of the warnings.

Added a couple of tests to ensure this is fixed.