### PR TITLE
chore: Repair changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 Work in this release contributed by @andreysam. Thank you for your contributions!
 
+## 3.12.0
+
+- feat(sourcemaps): Automatically insert Sentry Webpack plugin (#432)
+- fix(android): Add support for unusual import statements (#440)
+- fix(wizard): Sort projects in project-selection step (#441)
+- enh(android): Add more telemetry (#435)
+
 ## 3.11.0
 
 - feat(android): Add wizard support for Android (#389)


### PR DESCRIPTION
Seems like I removed the 3.12.0 entry when rebasing a PR (must have been #434). This PR brings it back.

ironically:
#skip-changelog