### PR TITLE
feat(sveltekit): Add telemetry collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - enh(android): Show link to issues page after setup is complete (#448)
 - feat(remix): Pass `org`, `project`, `url` to `upload-sourcemaps` script (#434) 
 - feat(sourcemaps): Automatically enable source maps generation in `tsconfig.json` (#449)
+- feat(sveltekit): Add telemetry collection (#455)
 - fix(nextjs): Add selfhosted url in `next.config.js` (#438)
 - fix(nextjs): Create necessary directories in app router (#439)
 - fix(sourcemaps): Write package manager command instead of object to package.json (#453)

--- a/src/sveltekit/sdk-setup.ts
+++ b/src/sveltekit/sdk-setup.ts
@@ -63,7 +63,7 @@ export async function createOrMergeSvelteKitFiles(
   const { dsn } = projectInfo;
 
   Sentry.setTag(
-    'server-hooks-file-strategy',
+    'client-hooks-file-strategy',
     originalClientHooksFile ? 'merge' : 'create',
   );
   if (!originalClientHooksFile) {
@@ -74,7 +74,7 @@ export async function createOrMergeSvelteKitFiles(
   }
 
   Sentry.setTag(
-    'client-hooks-file-strategy',
+    'server-hooks-file-strategy',
     originalServerHooksFile ? 'merge' : 'create',
   );
   if (!originalServerHooksFile) {

--- a/src/sveltekit/sdk-setup.ts
+++ b/src/sveltekit/sdk-setup.ts
@@ -22,6 +22,7 @@ import { findFile, hasSentryContent } from '../utils/ast-utils';
 import * as recast from 'recast';
 import x = recast.types;
 import t = x.namedTypes;
+import { traceStep } from '../telemetry';
 
 const SVELTE_CONFIG_FILE = 'svelte.config.js';
 
@@ -132,6 +133,7 @@ async function createNewHooksFile(
   await fs.promises.writeFile(hooksFileDest, filledTemplate);
 
   clack.log.success(`Created ${hooksFileDest}`);
+  Sentry.setTag(`created-${hooktype}-hooks`, 'success');
 }
 
 /**
@@ -151,6 +153,9 @@ async function mergeHooksFile(
   dsn: string,
 ): Promise<void> {
   const originalHooksMod = await loadFile(hooksFile);
+
+  const file: 'server-hooks' | 'client-hooks' = `${hookType}-hooks`;
+
   if (hasSentryContent(originalHooksMod.$ast as t.Program)) {
     // We don't want to mess with files that already have Sentry content.
     // Let's just bail out at this point.
@@ -160,32 +165,59 @@ async function mergeHooksFile(
       )} already contains Sentry code.
 Skipping adding Sentry functionality to.`,
     );
+    Sentry.setTag(`modified-${file}`, 'fail');
+    Sentry.setTag(`${file}-fail-reason`, 'has-sentry-content');
     return;
   }
 
-  originalHooksMod.imports.$add({
-    from: '@sentry/sveltekit',
-    imported: '*',
-    local: 'Sentry',
-  });
+  await modifyAndRecordFail(
+    () =>
+      originalHooksMod.imports.$add({
+        from: '@sentry/sveltekit',
+        imported: '*',
+        local: 'Sentry',
+      }),
+    'import-injection',
+    file,
+  );
 
-  if (hookType === 'client') {
-    insertClientInitCall(dsn, originalHooksMod);
-  } else {
-    insertServerInitCall(dsn, originalHooksMod);
-  }
+  await modifyAndRecordFail(
+    () => {
+      if (hookType === 'client') {
+        insertClientInitCall(dsn, originalHooksMod);
+      } else {
+        insertServerInitCall(dsn, originalHooksMod);
+      }
+    },
+    'init-call-injection',
+    file,
+  );
 
-  wrapHandleError(originalHooksMod);
+  await modifyAndRecordFail(
+    () => wrapHandleError(originalHooksMod),
+    'wrap-handle-error',
+    file,
+  );
 
   if (hookType === 'server') {
-    wrapHandle(originalHooksMod);
+    await modifyAndRecordFail(
+      () => wrapHandle(originalHooksMod),
+      'wrap-handle',
+      'server-hooks',
+    );
   }
 
-  const modifiedCode = originalHooksMod.generate().code;
-
-  await fs.promises.writeFile(hooksFile, modifiedCode);
+  await modifyAndRecordFail(
+    async () => {
+      const modifiedCode = originalHooksMod.generate().code;
+      await fs.promises.writeFile(hooksFile, modifiedCode);
+    },
+    'write-file',
+    file,
+  );
 
   clack.log.success(`Added Sentry code to ${hooksFile}`);
+  Sentry.setTag(`modified-${hookType}-hooks`, 'success');
 }
 
 function insertClientInitCall(
@@ -418,26 +450,38 @@ async function modifyViteConfig(
         )} already contains Sentry code.
 Skipping adding Sentry functionality to.`,
       );
+      Sentry.setTag(`modified-vite-cfg`, 'fail');
+      Sentry.setTag(`vite-cfg-fail-reason`, 'has-sentry-content');
       return;
     }
 
-    addVitePlugin(viteModule, {
-      imported: 'sentrySvelteKit',
-      from: '@sentry/sveltekit',
-      constructor: 'sentrySvelteKit',
-      options: {
-        sourceMapsUploadOptions: {
-          org,
-          project,
-          ...(selfHosted && { url }),
-        },
+    await modifyAndRecordFail(
+      () =>
+        addVitePlugin(viteModule, {
+          imported: 'sentrySvelteKit',
+          from: '@sentry/sveltekit',
+          constructor: 'sentrySvelteKit',
+          options: {
+            sourceMapsUploadOptions: {
+              org,
+              project,
+              ...(selfHosted && { url }),
+            },
+          },
+          index: 0,
+        }),
+      'add-vite-plugin',
+      'vite-cfg',
+    );
+
+    await modifyAndRecordFail(
+      async () => {
+        const code = generateCode(viteModule.$ast).code;
+        await fs.promises.writeFile(viteConfigPath, code);
       },
-      index: 0,
-    });
-
-    const code = generateCode(viteModule.$ast).code;
-
-    await fs.promises.writeFile(viteConfigPath, code);
+      'write-file',
+      'vite-cfg',
+    );
   } catch (e) {
     debug(e);
     await showFallbackViteCopyPasteSnippet(
@@ -520,4 +564,23 @@ function getInitCallInsertionIndex(originalHooksModAST: Program): number {
     ? originalHooksModAST.body.indexOf(lastImportDeclaration) + 1
     : 0;
   return initCallInsertionIndex;
+}
+
+/**
+ * Applies the @param modifyCallback and records Sentry tags if the call failed.
+ * In case of a failure, a tag is set with @param reason as a fail reason
+ * and the error is rethrown.
+ */
+async function modifyAndRecordFail<T>(
+  modifyCallback: () => T | Promise<T>,
+  reason: string,
+  fileType: 'server-hooks' | 'client-hooks' | 'vite-cfg',
+): Promise<void> {
+  try {
+    await traceStep(`${fileType}-${reason}`, modifyCallback);
+  } catch (e) {
+    Sentry.setTag(`modified-${fileType}`, 'fail');
+    Sentry.setTag(`${fileType}-mod-fail-reason`, reason);
+    throw e;
+  }
 }

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -1,6 +1,8 @@
 // @ts-ignore - clack is ESM and TS complains about that. It works though
-import clack from '@clack/prompts';
+import * as clack from '@clack/prompts';
 import chalk from 'chalk';
+
+import * as Sentry from '@sentry/node';
 
 import {
   abort,
@@ -12,46 +14,82 @@ import {
   installPackage,
   printWelcome,
 } from '../utils/clack-utils';
-import { hasPackageInstalled } from '../utils/package-json';
+import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import { WizardOptions } from '../utils/types';
 import { createExamplePage } from './sdk-example';
 import { createOrMergeSvelteKitFiles, loadSvelteConfig } from './sdk-setup';
+import { traceStep, withTelemetry } from '../telemetry';
+import { getKitVersionBucket, getSvelteVersionBucket } from './utils';
 
 export async function runSvelteKitWizard(
+  options: WizardOptions,
+): Promise<void> {
+  return withTelemetry(
+    {
+      enabled: options.telemetryEnabled,
+      integration: 'sveltekit',
+    },
+    () => runSvelteKitWizardWithTelemetry(options),
+  );
+}
+
+export async function runSvelteKitWizardWithTelemetry(
   options: WizardOptions,
 ): Promise<void> {
   printWelcome({
     wizardName: 'Sentry SvelteKit Wizard',
     promoCode: options.promoCode,
+    telemetryEnabled: options.telemetryEnabled,
   });
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await traceStep('detect-git', confirmContinueEvenThoughNoGitRepo);
 
   const packageJson = await getPackageDotJson();
-  await ensurePackageIsInstalled(packageJson, '@sveltejs/kit', 'Sveltekit');
+  await traceStep('detect-framework-version', () =>
+    ensurePackageIsInstalled(packageJson, '@sveltejs/kit', 'Sveltekit'),
+  );
+
+  Sentry.setTag(
+    'sveltekit-version',
+    getKitVersionBucket(getPackageVersion('@sveltejs/kit', packageJson)),
+  );
+  Sentry.setTag(
+    'svelte-version',
+    getSvelteVersionBucket(getPackageVersion('svelte', packageJson)),
+  );
 
   const { selectedProject, selfHosted, sentryUrl, authToken } =
     await getOrAskForProjectData(options, 'javascript-sveltekit');
 
-  await installPackage({
-    packageName: '@sentry/sveltekit',
-    alreadyInstalled: hasPackageInstalled('@sentry/sveltekit', packageJson),
-  });
+  const sdkAlreadyInstalled = hasPackageInstalled(
+    '@sentry/sveltekit',
+    packageJson,
+  );
+  Sentry.setTag('sdk-already-installed', sdkAlreadyInstalled);
 
-  await addSentryCliConfig(authToken);
+  await traceStep('install-sdk', () =>
+    installPackage({
+      packageName: '@sentry/sveltekit',
+      alreadyInstalled: sdkAlreadyInstalled,
+    }),
+  );
 
-  const svelteConfig = await loadSvelteConfig();
+  await traceStep('add-cli-config', () => addSentryCliConfig(authToken));
+
+  const svelteConfig = await traceStep('load-svelte-config', loadSvelteConfig);
 
   try {
-    await createOrMergeSvelteKitFiles(
-      {
-        dsn: selectedProject.keys[0].dsn.public,
-        org: selectedProject.organization.slug,
-        project: selectedProject.slug,
-        selfHosted,
-        url: sentryUrl,
-      },
-      svelteConfig,
+    await traceStep('configure-sdk', () =>
+      createOrMergeSvelteKitFiles(
+        {
+          dsn: selectedProject.keys[0].dsn.public,
+          org: selectedProject.organization.slug,
+          project: selectedProject.slug,
+          selfHosted,
+          url: sentryUrl,
+        },
+        svelteConfig,
+      ),
     );
   } catch (e: unknown) {
     clack.log.error('Error while setting up the SvelteKit SDK:');
@@ -64,17 +102,20 @@ export async function runSvelteKitWizard(
           : 'Unknown error',
       ),
     );
+    Sentry.captureException('Error while setting up the SvelteKit SDK');
     await abort('Exiting Wizard');
     return;
   }
 
   try {
-    await createExamplePage(svelteConfig, {
-      selfHosted,
-      url: sentryUrl,
-      orgSlug: selectedProject.organization.slug,
-      projectId: selectedProject.id,
-    });
+    await traceStep('create-example-page', () =>
+      createExamplePage(svelteConfig, {
+        selfHosted,
+        url: sentryUrl,
+        orgSlug: selectedProject.organization.slug,
+        projectId: selectedProject.id,
+      }),
+    );
   } catch (e: unknown) {
     clack.log.error('Error while creating an example page to test Sentry:');
     clack.log.info(
@@ -85,6 +126,9 @@ export async function runSvelteKitWizard(
           ? e
           : 'Unknown error',
       ),
+    );
+    Sentry.captureException(
+      'Error while creating an example Svelte page to test Sentry',
     );
     await abort('Exiting Wizard');
     return;

--- a/src/sveltekit/utils.ts
+++ b/src/sveltekit/utils.ts
@@ -1,0 +1,34 @@
+import { lt } from 'semver';
+
+export function getKitVersionBucket(version: string | undefined): string {
+  if (!version) {
+    return 'none';
+  }
+  if (lt(version, '1.0.0')) {
+    return '0.x';
+  } else if (lt(version, '1.24.0')) {
+    return '>=1.0.0 <1.24.0';
+  } else {
+    // This is the version when the client-side invalidation fix was released
+    // https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fkit%401.24.0
+    // https://github.com/sveltejs/kit/pull/10576
+    return '>=1.24.0';
+  }
+}
+
+export function getSvelteVersionBucket(version: string | undefined): string {
+  if (!version) {
+    return 'none';
+  }
+  if (lt(version, '3.0.0')) {
+    return '<3.0.0';
+  }
+  if (lt(version, '4.0.0')) {
+    return '3.x';
+  }
+  if (lt(version, '5.0.0')) {
+    return '4.x';
+  }
+  // Svelte 5 isn't released yet but it's being worked on
+  return '>=5.0.0';
+}

--- a/src/sveltekit/utils.ts
+++ b/src/sveltekit/utils.ts
@@ -1,12 +1,18 @@
-import { lt } from 'semver';
+import { lt, minVersion } from 'semver';
 
 export function getKitVersionBucket(version: string | undefined): string {
   if (!version) {
     return 'none';
   }
-  if (lt(version, '1.0.0')) {
+
+  const minVer = minVersion(version);
+  if (!minVer) {
+    return 'invalid';
+  }
+
+  if (lt(minVer, '1.0.0')) {
     return '0.x';
-  } else if (lt(version, '1.24.0')) {
+  } else if (lt(minVer, '1.24.0')) {
     return '>=1.0.0 <1.24.0';
   } else {
     // This is the version when the client-side invalidation fix was released
@@ -20,13 +26,19 @@ export function getSvelteVersionBucket(version: string | undefined): string {
   if (!version) {
     return 'none';
   }
-  if (lt(version, '3.0.0')) {
+
+  const minVer = minVersion(version);
+  if (!minVer) {
+    return 'invalid';
+  }
+
+  if (lt(minVer, '3.0.0')) {
     return '<3.0.0';
   }
-  if (lt(version, '4.0.0')) {
+  if (lt(minVer, '4.0.0')) {
     return '3.x';
   }
-  if (lt(version, '5.0.0')) {
+  if (lt(minVer, '5.0.0')) {
     return '4.x';
   }
   // Svelte 5 isn't released yet but it's being worked on

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -125,18 +125,23 @@ export function printWelcome(options: {
 
   let welcomeText =
     options.message ||
-    'This Wizard will help you set up Sentry for your application.\nThank you for using Sentry :)';
+    `The ${options.wizardName} will help you set up Sentry for your application.\nThank you for using Sentry :)`;
 
   if (options.promoCode) {
-    welcomeText += `\n\nUsing promo-code: ${options.promoCode}`;
+    welcomeText = `${welcomeText}\n\nUsing promo-code: ${options.promoCode}`;
   }
 
   if (wizardPackage.version) {
-    welcomeText += `\n\nVersion: ${wizardPackage.version}`;
+    welcomeText = `${welcomeText}\n\nVersion: ${wizardPackage.version}`;
   }
 
   if (options.telemetryEnabled) {
-    welcomeText += `\n\nYou are using the Sentry Wizard with telemetry enabled. This helps us improve the Wizard.\nYou can disable it at any time by running \`sentry-wizard --disable-telemetry\`.`;
+    welcomeText = `${welcomeText}
+
+This wizard sends telemetry data and crash reports to Sentry. This helps us improve the Wizard.
+You can turn this off at any time by running ${chalk.cyanBright(
+      'sentry-wizard --disable-telemetry',
+    )}.`;
   }
 
   clack.note(welcomeText);
@@ -419,6 +424,7 @@ export async function ensurePackageIsInstalled(
   packageName: string,
 ) {
   if (!hasPackageInstalled(packageId, packageJson)) {
+    Sentry.setTag('package-installed', false);
     const continueWithoutPackage = await abortIfCancelled(
       clack.confirm({
         message: `${packageName} does not seem to be installed. Do you still want to continue?`,
@@ -429,6 +435,8 @@ export async function ensurePackageIsInstalled(
     if (!continueWithoutPackage) {
       await abort(undefined, 0);
     }
+  } else {
+    Sentry.setTag('package-installed', true);
   }
 }
 


### PR DESCRIPTION
This PR adds telemetry collection to the SvelteKit wizard. Concretely:

* Transaction and steps via `withTelemetry` and `traceStep`:
![image](https://github.com/getsentry/sentry-wizard/assets/8420481/59463bfe-68aa-497f-99ac-f019a28a11d2)
* capture minimal exceptions around known failure points
* set tags around
  * Svelte and Kit versions
  * Decisions to continue if precondition checks fail
  * Whether files were merged (AST mods) or newly created
  * Whether file modifications were successful

closes #451 