### PR TITLE
ref(sveltekit): Check for minimum supported SvelteKit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix(nextjs): Add selfhosted url in `next.config.js` (#438)
 - fix(nextjs): Create necessary directories in app router (#439)
 - fix(sourcemaps): Write package manager command instead of object to package.json (#453)
+- ref(sveltekit): Check for minimum supported SvelteKit version (#456)
 
 Work in this release contributed by @andreysam. Thank you for your contributions!
 

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -21,7 +21,6 @@ import { createExamplePage } from './sdk-example';
 import { createOrMergeSvelteKitFiles, loadSvelteConfig } from './sdk-setup';
 import { traceStep, withTelemetry } from '../telemetry';
 import { getKitVersionBucket, getSvelteVersionBucket } from './utils';
-import { lt } from 'lodash';
 
 export async function runSvelteKitWizard(
   options: WizardOptions,

--- a/src/sveltekit/utils.ts
+++ b/src/sveltekit/utils.ts
@@ -1,6 +1,8 @@
 import { lt, minVersion } from 'semver';
 
-export function getKitVersionBucket(version: string | undefined): string {
+export function getKitVersionBucket(
+  version: string | undefined,
+): 'none' | 'invalid' | '0.x' | '>=1.0.0 <1.24.0' | '>=1.24.0' {
   if (!version) {
     return 'none';
   }
@@ -22,7 +24,9 @@ export function getKitVersionBucket(version: string | undefined): string {
   }
 }
 
-export function getSvelteVersionBucket(version: string | undefined): string {
+export function getSvelteVersionBucket(
+  version: string | undefined,
+): 'none' | 'invalid' | '<3.0.0' | '3.x' | '4.x' | '>4.x' {
   if (!version) {
     return 'none';
   }
@@ -42,5 +46,5 @@ export function getSvelteVersionBucket(version: string | undefined): string {
     return '4.x';
   }
   // Svelte 5 isn't released yet but it's being worked on
-  return '>=5.0.0';
+  return '>4.x';
 }


### PR DESCRIPTION
Adds a precondition check if the minimum supported sveltekit version (1.0.0) is installed. 

Note: I'd like to recommend folks to use >=1.24.0, given that it contains a fix we need in our SDK but to not make it too specific I opted for latest 1.x (also, more Kit improvements might be merged in the future). 

based on #455 until that's merged