### PR TITLE
feat(nextjs): Add telemetry collection to NextJS wizard

### DIFF
--- a/src/android/android-wizard.ts
+++ b/src/android/android-wizard.ts
@@ -165,9 +165,8 @@ async function runAndroidWizardWithTelemetry(
       'sentry.properties',
     )} file.`,
   );
-  await traceStep('Add SentryCli Config', () =>
-    addSentryCliConfig(authToken, proguardMappingCliSetupConfig),
-  );
+
+  await addSentryCliConfig(authToken, proguardMappingCliSetupConfig);
 
   // ======== OUTRO ========
   const issuesPageLink = selfHosted

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -7,6 +7,8 @@ import * as fs from 'fs';
 import { builders, generateCode, parseModule } from 'magicast';
 import * as path from 'path';
 
+import * as Sentry from '@sentry/node';
+
 import {
   abort,
   abortIfCancelled,
@@ -19,7 +21,7 @@ import {
   isUsingTypeScript,
   printWelcome,
 } from '../utils/clack-utils';
-import { WizardOptions } from '../utils/types';
+import { SentryProjectData, WizardOptions } from '../utils/types';
 import {
   getNextjsConfigCjsAppendix,
   getNextjsConfigCjsTemplate,
@@ -31,88 +33,158 @@ import {
   getSentryExampleAppDirApiRoute,
   getSentryExamplePageContents,
 } from './templates';
+import { traceStep, withTelemetry } from '../telemetry';
+import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
+import { getNextJsVersionBucket } from './utils';
 
-// eslint-disable-next-line complexity
-export async function runNextjsWizard(options: WizardOptions): Promise<void> {
+export function runNextjsWizard(options: WizardOptions) {
+  return withTelemetry(
+    {
+      enabled: options.telemetryEnabled,
+      integration: 'nextjs',
+    },
+    () => runNextjsWizardWithTelemetry(options),
+  );
+}
+
+export async function runNextjsWizardWithTelemetry(
+  options: WizardOptions,
+): Promise<void> {
   printWelcome({
     wizardName: 'Sentry Next.js Wizard',
     promoCode: options.promoCode,
+    telemetryEnabled: options.telemetryEnabled,
   });
 
   await confirmContinueEvenThoughNoGitRepo();
 
   const packageJson = await getPackageDotJson();
+
   await ensurePackageIsInstalled(packageJson, 'next', 'Next.js');
+
+  const nextVersion = getPackageVersion('next', packageJson);
+  Sentry.setTag('nextjs-version', getNextJsVersionBucket(nextVersion));
 
   const { selectedProject, authToken, selfHosted, sentryUrl } =
     await getOrAskForProjectData(options, 'javascript-nextjs');
+
+  const sdkAlreadyInstalled = hasPackageInstalled(
+    '@sentry/nextjs',
+    packageJson,
+  );
+  Sentry.setTag('sdk-already-installed', sdkAlreadyInstalled);
 
   await installPackage({
     packageName: '@sentry/nextjs',
     alreadyInstalled: !!packageJson?.dependencies?.['@sentry/nextjs'],
   });
 
+  await traceStep('configure-sdk', async () =>
+    createOrMergeNextJsFiles(selectedProject, selfHosted, sentryUrl),
+  );
+
+  await traceStep('create-example-page', async () =>
+    createExamplePage(selfHosted, selectedProject, sentryUrl),
+  );
+
+  await addSentryCliConfig(authToken);
+
+  const mightBeUsingVercel = fs.existsSync(
+    path.join(process.cwd(), 'vercel.json'),
+  );
+
+  clack.outro(
+    `${chalk.green('Everything is set up!')}
+
+   ${chalk.cyan(
+     'You can validate your setup by starting your dev environment (`next dev`) and visiting "/sentry-example-page".',
+   )}
+${
+  mightBeUsingVercel
+    ? `
+   ▲ It seems like you're using Vercel. We recommend using the Sentry Vercel integration: https://vercel.com/integrations/sentry
+`
+    : ''
+}
+   ${chalk.dim(
+     'If you encounter any issues, let us know here: https://github.com/getsentry/sentry-javascript/issues',
+   )}`,
+  );
+}
+
+async function createOrMergeNextJsFiles(
+  selectedProject: SentryProjectData,
+  selfHosted: boolean,
+  sentryUrl: string,
+) {
   const typeScriptDetected = isUsingTypeScript();
 
   const configVariants = ['server', 'client', 'edge'] as const;
 
   for (const configVariant of configVariants) {
-    const jsConfig = `sentry.${configVariant}.config.js`;
-    const tsConfig = `sentry.${configVariant}.config.ts`;
+    await traceStep(`create-sentry-${configVariant}-config`, async () => {
+      const jsConfig = `sentry.${configVariant}.config.js`;
+      const tsConfig = `sentry.${configVariant}.config.ts`;
 
-    const jsConfigExists = fs.existsSync(path.join(process.cwd(), jsConfig));
-    const tsConfigExists = fs.existsSync(path.join(process.cwd(), tsConfig));
+      const jsConfigExists = fs.existsSync(path.join(process.cwd(), jsConfig));
+      const tsConfigExists = fs.existsSync(path.join(process.cwd(), tsConfig));
 
-    let shouldWriteFile = true;
+      let shouldWriteFile = true;
 
-    if (jsConfigExists || tsConfigExists) {
-      const existingConfigs = [];
+      if (jsConfigExists || tsConfigExists) {
+        const existingConfigs = [];
 
-      if (jsConfigExists) {
-        existingConfigs.push(jsConfig);
-      }
-
-      if (tsConfigExists) {
-        existingConfigs.push(tsConfig);
-      }
-
-      const overwriteExistingConfigs = await abortIfCancelled(
-        clack.confirm({
-          message: `Found existing Sentry ${configVariant} config (${existingConfigs.join(
-            ', ',
-          )}). Overwrite ${existingConfigs.length > 1 ? 'them' : 'it'}?`,
-        }),
-      );
-
-      shouldWriteFile = overwriteExistingConfigs;
-
-      if (overwriteExistingConfigs) {
         if (jsConfigExists) {
-          fs.unlinkSync(path.join(process.cwd(), jsConfig));
-          clack.log.warn(`Removed existing ${chalk.bold(jsConfig)}.`);
+          existingConfigs.push(jsConfig);
         }
+
         if (tsConfigExists) {
-          fs.unlinkSync(path.join(process.cwd(), tsConfig));
-          clack.log.warn(`Removed existing ${chalk.bold(tsConfig)}.`);
+          existingConfigs.push(tsConfig);
+        }
+
+        const overwriteExistingConfigs = await abortIfCancelled(
+          clack.confirm({
+            message: `Found existing Sentry ${configVariant} config (${existingConfigs.join(
+              ', ',
+            )}). Overwrite ${existingConfigs.length > 1 ? 'them' : 'it'}?`,
+          }),
+        );
+        Sentry.setTag(
+          `overwrite-${configVariant}-config`,
+          overwriteExistingConfigs,
+        );
+
+        shouldWriteFile = overwriteExistingConfigs;
+
+        if (overwriteExistingConfigs) {
+          if (jsConfigExists) {
+            fs.unlinkSync(path.join(process.cwd(), jsConfig));
+            clack.log.warn(`Removed existing ${chalk.bold(jsConfig)}.`);
+          }
+          if (tsConfigExists) {
+            fs.unlinkSync(path.join(process.cwd(), tsConfig));
+            clack.log.warn(`Removed existing ${chalk.bold(tsConfig)}.`);
+          }
         }
       }
-    }
 
-    if (shouldWriteFile) {
-      await fs.promises.writeFile(
-        path.join(process.cwd(), typeScriptDetected ? tsConfig : jsConfig),
-        getSentryConfigContents(
-          selectedProject.keys[0].dsn.public,
-          configVariant,
-        ),
-        { encoding: 'utf8', flag: 'w' },
-      );
-      clack.log.success(
-        `Created fresh ${chalk.bold(
-          typeScriptDetected ? tsConfig : jsConfig,
-        )}.`,
-      );
-    }
+      if (shouldWriteFile) {
+        await fs.promises.writeFile(
+          path.join(process.cwd(), typeScriptDetected ? tsConfig : jsConfig),
+          getSentryConfigContents(
+            selectedProject.keys[0].dsn.public,
+            configVariant,
+          ),
+          { encoding: 'utf8', flag: 'w' },
+        );
+        clack.log.success(
+          `Created fresh ${chalk.bold(
+            typeScriptDetected ? tsConfig : jsConfig,
+          )}.`,
+        );
+        Sentry.setTag(`created-${configVariant}-config`, true);
+      }
+    });
   }
 
   const sentryWebpackOptionsTemplate = getNextjsWebpackPluginOptionsTemplate(
@@ -126,162 +198,179 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
   const nextConfigJs = 'next.config.js';
   const nextConfigMjs = 'next.config.mjs';
 
-  const nextConfigJsExists = fs.existsSync(
-    path.join(process.cwd(), nextConfigJs),
-  );
-  const nextConfigMjsExists = fs.existsSync(
-    path.join(process.cwd(), nextConfigMjs),
-  );
-
-  if (!nextConfigJsExists && !nextConfigMjsExists) {
-    await fs.promises.writeFile(
+  await traceStep('setup-next-config', async () => {
+    const nextConfigJsExists = fs.existsSync(
       path.join(process.cwd(), nextConfigJs),
-      getNextjsConfigCjsTemplate(
-        sentryWebpackOptionsTemplate,
-        sentryBuildOptionsTemplate,
-      ),
-      { encoding: 'utf8', flag: 'w' },
+    );
+    const nextConfigMjsExists = fs.existsSync(
+      path.join(process.cwd(), nextConfigMjs),
     );
 
-    clack.log.success(
-      `Created ${chalk.bold('next.config.js')} with Sentry configuration.`,
-    );
-  }
+    if (!nextConfigJsExists && !nextConfigMjsExists) {
+      Sentry.setTag('next-config-strategy', 'create');
 
-  if (nextConfigJsExists) {
-    const nextConfgiJsContent = fs.readFileSync(
-      path.join(process.cwd(), nextConfigJs),
-      'utf8',
-    );
-
-    const probablyIncludesSdk =
-      nextConfgiJsContent.includes('@sentry/nextjs') &&
-      nextConfgiJsContent.includes('withSentryConfig');
-
-    let shouldInject = true;
-
-    if (probablyIncludesSdk) {
-      const injectAnyhow = await abortIfCancelled(
-        clack.confirm({
-          message: `${chalk.bold(
-            nextConfigJs,
-          )} already contains Sentry SDK configuration. Should the wizard modify it anyways?`,
-        }),
-      );
-
-      shouldInject = injectAnyhow;
-    }
-
-    if (shouldInject) {
-      await fs.promises.appendFile(
+      await fs.promises.writeFile(
         path.join(process.cwd(), nextConfigJs),
-        getNextjsConfigCjsAppendix(
+        getNextjsConfigCjsTemplate(
           sentryWebpackOptionsTemplate,
           sentryBuildOptionsTemplate,
         ),
-        'utf8',
+        { encoding: 'utf8', flag: 'w' },
       );
 
       clack.log.success(
-        `Added Sentry configuration to ${chalk.bold(nextConfigJs)}. ${chalk.dim(
-          '(you probably want to clean this up a bit!)',
-        )}`,
+        `Created ${chalk.bold('next.config.js')} with Sentry configuration.`,
       );
     }
-  }
 
-  if (nextConfigMjsExists) {
-    const nextConfgiMjsContent = fs.readFileSync(
-      path.join(process.cwd(), nextConfigMjs),
-      'utf8',
-    );
+    if (nextConfigJsExists) {
+      Sentry.setTag('next-config-strategy', 'modify');
 
-    const probablyIncludesSdk =
-      nextConfgiMjsContent.includes('@sentry/nextjs') &&
-      nextConfgiMjsContent.includes('withSentryConfig');
-
-    let shouldInject = true;
-
-    if (probablyIncludesSdk) {
-      const injectAnyhow = await abortIfCancelled(
-        clack.confirm({
-          message: `${chalk.bold(
-            nextConfigMjs,
-          )} already contains Sentry SDK configuration. Should the wizard modify it anyways?`,
-        }),
+      const nextConfgiJsContent = fs.readFileSync(
+        path.join(process.cwd(), nextConfigJs),
+        'utf8',
       );
 
-      shouldInject = injectAnyhow;
-    }
+      const probablyIncludesSdk =
+        nextConfgiJsContent.includes('@sentry/nextjs') &&
+        nextConfgiJsContent.includes('withSentryConfig');
 
-    try {
+      let shouldInject = true;
+
+      if (probablyIncludesSdk) {
+        const injectAnyhow = await abortIfCancelled(
+          clack.confirm({
+            message: `${chalk.bold(
+              nextConfigJs,
+            )} already contains Sentry SDK configuration. Should the wizard modify it anyways?`,
+          }),
+        );
+
+        shouldInject = injectAnyhow;
+      }
+
       if (shouldInject) {
-        const mod = parseModule(nextConfgiMjsContent);
-        mod.imports.$add({
-          from: '@sentry/nextjs',
-          imported: 'withSentryConfig',
-          local: 'withSentryConfig',
-        });
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-        const expressionToWrap = generateCode(mod.exports.default.$ast).code;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        mod.exports.default = builders.raw(`withSentryConfig(
+        await fs.promises.appendFile(
+          path.join(process.cwd(), nextConfigJs),
+          getNextjsConfigCjsAppendix(
+            sentryWebpackOptionsTemplate,
+            sentryBuildOptionsTemplate,
+          ),
+          'utf8',
+        );
+
+        clack.log.success(
+          `Added Sentry configuration to ${chalk.bold(
+            nextConfigJs,
+          )}. ${chalk.dim('(you probably want to clean this up a bit!)')}`,
+        );
+      }
+
+      Sentry.setTag('next-config-mod-result', 'success');
+    }
+
+    if (nextConfigMjsExists) {
+      const nextConfgiMjsContent = fs.readFileSync(
+        path.join(process.cwd(), nextConfigMjs),
+        'utf8',
+      );
+
+      const probablyIncludesSdk =
+        nextConfgiMjsContent.includes('@sentry/nextjs') &&
+        nextConfgiMjsContent.includes('withSentryConfig');
+
+      let shouldInject = true;
+
+      if (probablyIncludesSdk) {
+        const injectAnyhow = await abortIfCancelled(
+          clack.confirm({
+            message: `${chalk.bold(
+              nextConfigMjs,
+            )} already contains Sentry SDK configuration. Should the wizard modify it anyways?`,
+          }),
+        );
+
+        shouldInject = injectAnyhow;
+      }
+
+      try {
+        if (shouldInject) {
+          const mod = parseModule(nextConfgiMjsContent);
+          mod.imports.$add({
+            from: '@sentry/nextjs',
+            imported: 'withSentryConfig',
+            local: 'withSentryConfig',
+          });
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+          const expressionToWrap = generateCode(mod.exports.default.$ast).code;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          mod.exports.default = builders.raw(`withSentryConfig(
       ${expressionToWrap},
       ${sentryWebpackOptionsTemplate},
       ${sentryBuildOptionsTemplate}
 )`);
-        const newCode = mod.generate().code;
+          const newCode = mod.generate().code;
 
-        await fs.promises.writeFile(
-          path.join(process.cwd(), nextConfigMjs),
-          newCode,
-          {
-            encoding: 'utf8',
-            flag: 'w',
-          },
+          await fs.promises.writeFile(
+            path.join(process.cwd(), nextConfigMjs),
+            newCode,
+            {
+              encoding: 'utf8',
+              flag: 'w',
+            },
+          );
+          clack.log.success(
+            `Added Sentry configuration to ${chalk.bold(
+              nextConfigMjs,
+            )}. ${chalk.dim('(you probably want to clean this up a bit!)')}`,
+          );
+
+          Sentry.setTag('next-config-mod-result', 'success');
+        }
+      } catch {
+        Sentry.setTag('next-config-mod-result', 'fail');
+        clack.log.warn(
+          chalk.yellow(
+            `Something went wrong writing to ${chalk.bold(nextConfigMjs)}`,
+          ),
         );
-        clack.log.success(
-          `Added Sentry configuration to ${chalk.bold(
+        clack.log.info(
+          `Please put the following code snippet into ${chalk.bold(
             nextConfigMjs,
-          )}. ${chalk.dim('(you probably want to clean this up a bit!)')}`,
+          )}: ${chalk.dim('You probably have to clean it up a bit.')}\n`,
         );
-      }
-    } catch {
-      clack.log.warn(
-        chalk.yellow(
-          `Something went wrong writing to ${chalk.bold(nextConfigMjs)}`,
-        ),
-      );
-      clack.log.info(
-        `Please put the following code snippet into ${chalk.bold(
-          nextConfigMjs,
-        )}: ${chalk.dim('You probably have to clean it up a bit.')}\n`,
-      );
 
-      // eslint-disable-next-line no-console
-      console.log(
-        getNextjsConfigEsmCopyPasteSnippet(
-          sentryWebpackOptionsTemplate,
-          sentryBuildOptionsTemplate,
-        ),
-      );
+        // eslint-disable-next-line no-console
+        console.log(
+          getNextjsConfigEsmCopyPasteSnippet(
+            sentryWebpackOptionsTemplate,
+            sentryBuildOptionsTemplate,
+          ),
+        );
 
-      const shouldContinue = await abortIfCancelled(
-        clack.confirm({
-          message: `Are you done putting the snippet above into ${chalk.bold(
-            nextConfigMjs,
-          )}?`,
-          active: 'Yes',
-          inactive: 'No, get me out of here',
-        }),
-      );
+        const shouldContinue = await abortIfCancelled(
+          clack.confirm({
+            message: `Are you done putting the snippet above into ${chalk.bold(
+              nextConfigMjs,
+            )}?`,
+            active: 'Yes',
+            inactive: 'No, get me out of here',
+          }),
+        );
 
-      if (!shouldContinue) {
-        await abort();
+        if (!shouldContinue) {
+          await abort();
+        }
       }
     }
-  }
+  });
+}
 
+async function createExamplePage(
+  selfHosted: boolean,
+  selectedProject: SentryProjectData,
+  sentryUrl: string,
+): Promise<void> {
   const srcDir = path.join(process.cwd(), 'src');
   const maybePagesDirPath = path.join(process.cwd(), 'pages');
   const maybeSrcPagesDirPath = path.join(srcDir, 'pages');
@@ -315,6 +404,8 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
       recursive: true,
     });
   }
+
+  Sentry.setTag('nextjs-app-dir', !!appLocation);
 
   if (appLocation) {
     const examplePageContents = getSentryExamplePageContents({
@@ -415,28 +506,4 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
       )}.`,
     );
   }
-
-  await addSentryCliConfig(authToken);
-
-  const mightBeUsingVercel = fs.existsSync(
-    path.join(process.cwd(), 'vercel.json'),
-  );
-
-  clack.outro(
-    `${chalk.green('Everything is set up!')}
-
-   ${chalk.cyan(
-     'You can validate your setup by starting your dev environment (`next dev`) and visiting "/sentry-example-page".',
-   )}
-${
-  mightBeUsingVercel
-    ? `
-   ▲ It seems like you're using Vercel. We recommend using the Sentry Vercel integration: https://vercel.com/integrations/sentry
-`
-    : ''
-}
-   ${chalk.dim(
-     'If you encounter any issues, let us know here: https://github.com/getsentry/sentry-javascript/issues',
-   )}`,
-  );
 }

--- a/src/nextjs/utils.ts
+++ b/src/nextjs/utils.ts
@@ -1,0 +1,21 @@
+import { major, minVersion } from 'semver';
+
+export function getNextJsVersionBucket(version: string | undefined) {
+  if (!version) {
+    return 'none';
+  }
+
+  try {
+    const minVer = minVersion(version);
+    if (!minVer) {
+      return 'invalid';
+    }
+    const majorVersion = major(minVer);
+    if (majorVersion >= 11) {
+      return `${majorVersion}.x`;
+    }
+    return '<11.0.0';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -56,12 +56,10 @@ async function runRemixWizardWithTelemetry(
   const { selectedProject, authToken, sentryUrl } =
     await getOrAskForProjectData(options, 'javascript-remix');
 
-  await traceStep('Install Sentry SDK', () =>
-    installPackage({
-      packageName: '@sentry/remix',
-      alreadyInstalled: hasPackageInstalled('@sentry/remix', packageJson),
-    }),
-  );
+  await installPackage({
+    packageName: '@sentry/remix',
+    alreadyInstalled: hasPackageInstalled('@sentry/remix', packageJson),
+  });
 
   const dsn = selectedProject.keys[0].dsn.public;
 

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -70,7 +70,7 @@ You can turn this off by running the wizard with the '--disable-telemetry' flag.
     return;
   }
 
-  await traceStep('detect-git', confirmContinueEvenThoughNoGitRepo);
+  await confirmContinueEvenThoughNoGitRepo();
 
   await traceStep('check-sdk-version', ensureMinimumSdkVersionIsInstalled);
 

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -43,12 +43,11 @@ export async function runSvelteKitWizardWithTelemetry(
     telemetryEnabled: options.telemetryEnabled,
   });
 
-  await traceStep('detect-git', confirmContinueEvenThoughNoGitRepo);
+  await confirmContinueEvenThoughNoGitRepo();
 
   const packageJson = await getPackageDotJson();
-  await traceStep('detect-framework-version', () =>
-    ensurePackageIsInstalled(packageJson, '@sveltejs/kit', 'Sveltekit'),
-  );
+
+  await ensurePackageIsInstalled(packageJson, '@sveltejs/kit', 'Sveltekit');
 
   const kitVersion = getPackageVersion('@sveltejs/kit', packageJson);
   const kitVersionBucket = getKitVersionBucket(kitVersion);
@@ -91,14 +90,12 @@ export async function runSvelteKitWizardWithTelemetry(
   );
   Sentry.setTag('sdk-already-installed', sdkAlreadyInstalled);
 
-  await traceStep('install-sdk', () =>
-    installPackage({
-      packageName: '@sentry/sveltekit',
-      alreadyInstalled: sdkAlreadyInstalled,
-    }),
-  );
+  await installPackage({
+    packageName: '@sentry/sveltekit',
+    alreadyInstalled: sdkAlreadyInstalled,
+  });
 
-  await traceStep('add-cli-config', () => addSentryCliConfig(authToken));
+  await addSentryCliConfig(authToken);
 
   const svelteConfig = await traceStep('load-svelte-config', loadSvelteConfig);
 


### PR DESCRIPTION
This PR adds telemetry data collection to the NextJS wizard. Specifically:

- Transaction and spans:
![image](https://github.com/getsentry/sentry-wizard/assets/8420481/8613b91e-15b5-4005-af5c-72dc9326cc9c)
- tags around 
  - Next JS major versions
  - SDK already installed
  - SDK configuration methods and results
  - Detected package manager (this tag will be added to all wizards with telemetry)

This PR is unfortunately a little messy because I decided to pull a lot of the `traceStep` calls into the helper functions rather than wrapping the individual calls to the helpers. IMO this is better as we can reuse already existing manual instrumentation when we use these helpers. Also, if telemetry is disabled or the helper is used in a wizard that doesn't support telemetry, the `traceStep` wrapper will no-op anyway. 

closes #450  