### PR TITLE
fix(telemetry): Only flush after the root span finished

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -27,29 +27,23 @@ export async function withTelemetry<F>(
   const sentrySession = sentryHub.startSession();
   sentryHub.captureSession();
 
-  return startSpan(
-    {
-      name: 'sentry-wizard-execution',
-      status: 'ok',
-      op: 'wizard.flow',
-    },
-    async (span) => {
-      if (!span) {
-        return runWithAsyncContext(() => callback());
-      }
-      try {
-        return await runWithAsyncContext(() => callback());
-      } catch (e) {
-        sentryHub.captureException('Error during wizard execution.');
-        span.setStatus('internal_error');
-        sentrySession.status = 'crashed';
-        throw e;
-      } finally {
-        sentryHub.endSession();
-        await sentryClient.flush(3000);
-      }
-    },
-  );
+  try {
+    return await startSpan(
+      {
+        name: 'sentry-wizard-execution',
+        status: 'ok',
+        op: 'wizard.flow',
+      },
+      async () => runWithAsyncContext(callback),
+    );
+  } catch (e) {
+    sentryHub.captureException('Error during wizard execution.');
+    sentrySession.status = 'crashed';
+    throw e;
+  } finally {
+    sentryHub.endSession();
+    await sentryClient.flush(3000);
+  }
 }
 
 function createSentryInstance(enabled: boolean, integration: string) {
@@ -92,6 +86,13 @@ function createSentryInstance(enabled: boolean, integration: string) {
   hub.setTag('integration', integration);
   hub.setTag('node', process.version);
   hub.setTag('platform', process.platform);
+
+  client.on('beforeSendEvent', (event) => {
+    console.log('beforeSendEvent', event.type ?? 'error');
+  });
+  client.on('afterSendEvent', (event) => {
+    console.log('afterSendEvent', event.type ?? 'error');
+  });
 
   return { sentryHub: hub, sentryClient: client };
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -87,13 +87,6 @@ function createSentryInstance(enabled: boolean, integration: string) {
   hub.setTag('node', process.version);
   hub.setTag('platform', process.platform);
 
-  client.on('beforeSendEvent', (event) => {
-    console.log('beforeSendEvent', event.type ?? 'error');
-  });
-  client.on('afterSendEvent', (event) => {
-    console.log('afterSendEvent', event.type ?? 'error');
-  });
-
   return { sentryHub: hub, sentryClient: client };
 }
 


### PR DESCRIPTION
This PR fixes something I missed in #459: 

When using `startSpan`, the created span won't be finished if we flush inside the startSpan callback. Hence, it's not sent to Sentry, meaning erroneous transactions might be missing. This PR fixes this by moving everything around capturing exceptions and flushing _outside_ of the `startSpan` callback. Also, there's no need to update the span status on error anymore since `startSpan` does that already internally. 

#skip-changelog