### PR TITLE
ref(telemetry): Add progress tag and `updateProgress` function

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -28,8 +28,6 @@ export async function withTelemetry<F>(
   const sentrySession = sentryHub.startSession();
   sentryHub.captureSession();
 
-  updateProgress('start');
-
   try {
     return await startSpan(
       {
@@ -38,8 +36,10 @@ export async function withTelemetry<F>(
         op: 'wizard.flow',
       },
       async () => {
+        updateProgress('start');
         const res = await runWithAsyncContext(callback);
         updateProgress('done');
+
         return res;
       },
     );

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,6 @@
 import {
   defaultStackParser,
+  getCurrentHub,
   Hub,
   Integrations,
   makeMain,
@@ -38,7 +39,7 @@ export async function withTelemetry<F>(
       async () => {
         updateProgress('start');
         const res = await runWithAsyncContext(callback);
-        updateProgress('done');
+        updateProgress('finished');
 
         return res;
       },
@@ -102,6 +103,7 @@ export function traceStep<T>(step: string, callback: () => T): T {
   return startSpan({ name: step, op: 'wizard.step' }, () => callback());
 }
 
+let stepCounter = -1;
 export function updateProgress(step: string) {
-  setTag('progress', step);
+  setTag('progress', `${++stepCounter}-${step}`);
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,6 +1,5 @@
 import {
   defaultStackParser,
-  getCurrentHub,
   Hub,
   Integrations,
   makeMain,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -102,7 +102,6 @@ export function traceStep<T>(step: string, callback: () => T): T {
   return startSpan({ name: step, op: 'wizard.step' }, () => callback());
 }
 
-let stepCounter = -1;
 export function updateProgress(step: string) {
-  setTag('progress', `${++stepCounter}-${step}`);
+  setTag('progress', step);
 }


### PR DESCRIPTION
This PR adds progress tracking to telemetry collection to identify, where in the respective wizard users cancel or drop off. This is done by updating the value of the `progress` tag in the following cases:

* At the very beginning, `start` is set
* At the very end of a successful run, `finished` is set
* Whenever `traceStep(step, callback)` is called, the value of `step` is set.

Additionally, this PR adds an exported `updateProgress` function that can be used manually to update the progress if it makes sense. 
(This is the result of a slack thread RE progress tracking)

#skip-changelog