### PR TITLE
feat(wizard): Ask for confirmation to continue if git repo is not clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 feat(nextjs): Add telemetry collection to NextJS wizard (#458)
+feat(wizard): Ask for confirmation to continue if git repo is not clean (#462)
 
 ## 3.13.0
 

--- a/src/android/android-wizard.ts
+++ b/src/android/android-wizard.ts
@@ -12,7 +12,7 @@ import {
   SENTRY_PROPERTIES_FILE,
   abort,
   addSentryCliConfig,
-  confirmContinueEvenThoughNoGitRepo,
+  confirmContinueIfNoOrDirtyGitRepo,
   getOrAskForProjectData,
   printWelcome,
 } from '../utils/clack-utils';
@@ -58,7 +58,7 @@ async function runAndroidWizardWithTelemetry(
     promoCode: options.promoCode,
   });
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await confirmContinueIfNoOrDirtyGitRepo();
 
   const projectDir = process.cwd();
   const buildGradleFiles = findFilesWithExtensions(projectDir, [

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -25,7 +25,7 @@ import {
   printWelcome,
   abort,
   askForItemSelection,
-  confirmContinueEvenThoughNoGitRepo,
+  confirmContinueIfNoOrDirtyGitRepo,
   getOrAskForProjectData,
 } from '../utils/clack-utils';
 
@@ -47,7 +47,7 @@ async function runAppleWizardWithTelementry(
     promoCode: options.promoCode,
   });
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await confirmContinueIfNoOrDirtyGitRepo();
 
   const hasCli = bash.hasSentryCLI();
   Sentry.setTag('has-cli', hasCli);

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -13,7 +13,7 @@ import {
   abort,
   abortIfCancelled,
   addSentryCliConfig,
-  confirmContinueEvenThoughNoGitRepo,
+  confirmContinueIfNoOrDirtyGitRepo,
   ensurePackageIsInstalled,
   getOrAskForProjectData,
   getPackageDotJson,
@@ -56,7 +56,7 @@ export async function runNextjsWizardWithTelemetry(
     telemetryEnabled: options.telemetryEnabled,
   });
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await confirmContinueIfNoOrDirtyGitRepo();
 
   const packageJson = await getPackageDotJson();
 

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 
 import {
   addSentryCliConfig,
-  confirmContinueEvenThoughNoGitRepo,
+  confirmContinueIfNoOrDirtyGitRepo,
   ensurePackageIsInstalled,
   getOrAskForProjectData,
   getPackageDotJson,
@@ -45,7 +45,7 @@ async function runRemixWizardWithTelemetry(
     telemetryEnabled: options.telemetryEnabled,
   });
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await confirmContinueIfNoOrDirtyGitRepo();
 
   const remixConfig = await loadRemixConfig();
   const packageJson = await getPackageDotJson();

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/node';
 import {
   abort,
   abortIfCancelled,
-  confirmContinueEvenThoughNoGitRepo,
+  confirmContinueIfNoOrDirtyGitRepo,
   SENTRY_DOT_ENV_FILE,
   printWelcome,
   SENTRY_CLI_RC_FILE,
@@ -70,7 +70,7 @@ You can turn this off by running the wizard with the '--disable-telemetry' flag.
     return;
   }
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await confirmContinueIfNoOrDirtyGitRepo();
 
   await traceStep('check-sdk-version', ensureMinimumSdkVersionIsInstalled);
 

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -8,7 +8,7 @@ import {
   abort,
   abortIfCancelled,
   addSentryCliConfig,
-  confirmContinueEvenThoughNoGitRepo,
+  confirmContinueIfNoOrDirtyGitRepo,
   ensurePackageIsInstalled,
   getOrAskForProjectData,
   getPackageDotJson,
@@ -43,7 +43,7 @@ export async function runSvelteKitWizardWithTelemetry(
     telemetryEnabled: options.telemetryEnabled,
   });
 
-  await confirmContinueEvenThoughNoGitRepo();
+  await confirmContinueIfNoOrDirtyGitRepo();
 
   const packageJson = await getPackageDotJson();
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -168,7 +168,7 @@ export async function confirmContinueIfNoOrDirtyGitRepo(): Promise<void> {
     const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles();
     if (uncommittedOrUntrackedFiles.length) {
       clack.log.warn(
-        `You have uncommited or untracked files in your repo:
+        `You have uncommitted or untracked files in your repo:
 
 ${uncommittedOrUntrackedFiles.join('\n')}
 


### PR DESCRIPTION
This PR adds a git status check to the already existing git repo existence check. If any untracked or uncommitted files are found, the wizard will ask users if they want to continue anyway. 

![image](https://github.com/getsentry/sentry-wizard/assets/8420481/014a46dd-2bed-4592-83ab-0da36b5a96bc)


The git status check is performed with the [`--porcellain=v1` option](https://git-scm.com/docs/git-status#_porcelain_format_version_1), which is recommended in the git docs to be used for parsing the status. The advantage over other ways of checking for uncommitted or untracked files is that we only need one `exec` call to check for both, untracked as well as uncommitted files. 

This came up in https://github.com/getsentry/develop/pull/1030#issuecomment-1707995784 and aligns our (clack-based) wizards with the [specifications](https://develop.sentry.dev/sdk/setup-wizards/#1-check-preconditions)