### PR TITLE
fix(remix): Fix Remix version and TS checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 feat(nextjs): Add telemetry collection to NextJS wizard (#458)
 feat(wizard): Ask for confirmation to continue if git repo is not clean (#462)
+fix(remix): Fix Remix version and TS checks (#464)
+
 
 ## 3.13.0
 
 - enh(android): Show link to issues page after setup is complete (#448)
-- feat(remix): Pass `org`, `project`, `url` to `upload-sourcemaps` script (#434) 
+- feat(remix): Pass `org`, `project`, `url` to `upload-sourcemaps` script (#434)
 - feat(sourcemaps): Automatically enable source maps generation in `tsconfig.json` (#449)
 - feat(sveltekit): Add telemetry collection (#455)
 - fix(nextjs): Add selfhosted url in `next.config.js` (#438)

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -105,7 +105,7 @@ async function runRemixWizardWithTelemetry(
 
   await traceStep('Initialize Sentry on server entry', async () => {
     try {
-      await initializeSentryOnEntryServer(dsn, isTS, isV2);
+      await initializeSentryOnEntryServer(dsn, isV2, isTS);
     } catch (e) {
       clack.log.warn(`Could not initialize Sentry on server entry.
   Please do it manually using instructions from https://docs.sentry.io/platforms/javascript/guides/remix/`);

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -12,7 +12,7 @@ import * as url from 'url';
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
-import { parse } from 'semver';
+import { gte, minVersion } from 'semver';
 
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { builders, generateCode, loadFile, writeFile } from 'magicast';
@@ -97,8 +97,17 @@ export function isRemixV2(
   packageJson: PackageDotJson,
 ): boolean {
   const remixVersion = getPackageVersion('@remix-run/react', packageJson);
-  const remixVersionMajor = remixVersion && parse(remixVersion)?.major;
-  const isV2Remix = remixVersionMajor && remixVersionMajor >= 2;
+  if (!remixVersion) {
+    return false;
+  }
+
+  const minVer = minVersion(remixVersion);
+
+  if (!minVer) {
+    return false;
+  }
+
+  const isV2Remix = gte(minVer, '2.0.0');
 
   return isV2Remix || remixConfig?.future?.v2_errorBoundary || false;
 }


### PR DESCRIPTION
There was a bug caused by wrong parameter orders of `isV2` and `isTS` on server instrumentation step. 

Also improved Remix version checks, making them similar to svelte and next wizards.