### PR TITLE
ref(sveltekit): Add log for successful Vite plugin insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+ref(sveltekit): Add log for successful Vite plugin insertion (#465)
+
 ## 3.14.0
 
 feat(nextjs): Add telemetry collection to NextJS wizard (#458)

--- a/src/sveltekit/sdk-setup.ts
+++ b/src/sveltekit/sdk-setup.ts
@@ -440,14 +440,14 @@ async function modifyViteConfig(
 
   const { org, project, url, selfHosted } = projectInfo;
 
+  const prettyViteConfigFilename = chalk.cyan(path.basename(viteConfigPath));
+
   try {
     const viteModule = parseModule(viteConfigContent);
 
     if (hasSentryContent(viteModule.$ast as t.Program)) {
       clack.log.warn(
-        `File ${chalk.cyan(
-          path.basename(viteConfigPath),
-        )} already contains Sentry code.
+        `File ${prettyViteConfigFilename} already contains Sentry code.
 Skipping adding Sentry functionality to.`,
       );
       Sentry.setTag(`modified-vite-cfg`, 'fail');
@@ -490,6 +490,9 @@ Skipping adding Sentry functionality to.`,
     );
     Sentry.captureException('Sveltekit Vite Config Modification Fail');
   }
+
+  clack.log.success(`Added Sentry code to ${prettyViteConfigFilename}`);
+  Sentry.setTag(`modified-vite-cfg`, 'success');
 }
 
 async function showFallbackViteCopyPasteSnippet(


### PR DESCRIPTION
Realized that we didn't log anything about modifying users' Vite config in the SvelteKit wizard. This PR fixes that. 
Also, I forgot to add the success tag - that explains why our SvelteKit dashboard only shows Vite plugin insertion fails 😅 