### PR TITLE
fix(remix): Use `captureRemixServerException` inside `handleError`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+fix(remix): Use captureRemixServerException inside handleError. (#466)
+
 ## 3.14.1
 
 ref(sveltekit): Add log for successful Vite plugin insertion (#465)

--- a/src/remix/codemods/handle-error.ts
+++ b/src/remix/codemods/handle-error.ts
@@ -55,12 +55,41 @@ export function instrumentHandleError(
   ) {
     return false;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const implementation = recast.parse(HANDLE_ERROR_TEMPLATE_V2).program
+      .body[0];
+
     // @ts-expect-error - string works here because the AST is proxified by magicast
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     handleErrorFunction.declaration.body.body.unshift(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       recast.parse(HANDLE_ERROR_TEMPLATE_V2).program.body[0].body.body[0],
     );
+
+    // First parameter is the error
+    //
+    // @ts-expect-error - string works here because the AST is proxified by magicast
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    handleErrorFunction.declaration.params[0] = implementation.params[0];
+
+    // Second parameter is the request inside an object
+    // Merging the object properties to make sure it includes request
+    //
+    // @ts-expect-error - string works here because the AST is proxified by magicast
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (handleErrorFunction.declaration.params?.[1]?.parametes) {
+      // @ts-expect-error - string works here because the AST is proxified by magicast
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      handleErrorFunction.declaration.params[1].parametes.push(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        implementation.params[1].parametes[0],
+      );
+    }
+
+    // Update parameters
+    // @ts-expect-error - string works here because the AST is proxified by magicast
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    handleErrorFunction.declaration.params = implementation.params;
   }
 
   return true;

--- a/src/remix/codemods/handle-error.ts
+++ b/src/remix/codemods/handle-error.ts
@@ -77,19 +77,20 @@ export function instrumentHandleError(
     //
     // @ts-expect-error - string works here because the AST is proxified by magicast
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (handleErrorFunction.declaration.params?.[1]?.parametes) {
+    if (handleErrorFunction.declaration.params?.[1]?.properties) {
       // @ts-expect-error - string works here because the AST is proxified by magicast
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      handleErrorFunction.declaration.params[1].parametes.push(
+      handleErrorFunction.declaration.params[1].properties.push(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        implementation.params[1].parametes[0],
+        implementation.params[1].properties[0],
       );
+    } else {
+      // Create second parameter if it doesn't exist
+      //
+      // @ts-expect-error - string works here because the AST is proxified by magicast
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      handleErrorFunction.declaration.params[1] = implementation.params[1];
     }
-
-    // Update parameters
-    // @ts-expect-error - string works here because the AST is proxified by magicast
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    handleErrorFunction.declaration.params = implementation.params;
   }
 
   return true;

--- a/src/remix/templates.ts
+++ b/src/remix/templates.ts
@@ -5,11 +5,7 @@ export const ERROR_BOUNDARY_TEMPLATE_V2 = `const ErrorBoundary = () => {
 };
 `;
 
-export const HANDLE_ERROR_TEMPLATE_V2 = `function handleError(error) {
-  if (error instanceof Error) {
-    Sentry.captureRemixErrorBoundaryError(error);
-  } else {
-    Sentry.captureException(error);
-  }
+export const HANDLE_ERROR_TEMPLATE_V2 = `function handleError(error, { request }) {
+  Sentry.captureRemixServerException(error, 'remix.server', { request });
 }
 `;


### PR DESCRIPTION
Fixed Remix v2's `handleError` template, that was mistakenly invoking `Sentry.captureRemixErrorBoundaryError`

Replaced it with `Sentry.captureRemixServerException`

And as it's optional, removed manual handling of non-error capturing from the template.