### PR TITLE
fix(remix): Fix `request` arg in `handleError` template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 fix(remix): Use captureRemixServerException inside handleError. (#466)
-
+fix(remix): Fix `request` arg in `handleError` template. (#469)
 ## 3.14.1
 
 ref(sveltekit): Add log for successful Vite plugin insertion (#465)

--- a/src/remix/templates.ts
+++ b/src/remix/templates.ts
@@ -6,6 +6,6 @@ export const ERROR_BOUNDARY_TEMPLATE_V2 = `const ErrorBoundary = () => {
 `;
 
 export const HANDLE_ERROR_TEMPLATE_V2 = `function handleError(error, { request }) {
-  Sentry.captureRemixServerException(error, 'remix.server', { request });
+  Sentry.captureRemixServerException(error, 'remix.server', request);
 }
 `;


### PR DESCRIPTION
Fixed `captureRemixServerException`'s `request` parameter.
Mentioned in: https://github.com/getsentry/sentry-wizard/pull/466#discussion_r1338209336