### PR TITLE
feat(remix): Support sourcemap uploads of Hydrogen apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(remix): Support sourcemap uploads of Hydrogen apps (#474)
 - fix(remix): Use captureRemixServerException inside handleError (#466)
 - fix(remix): Fix `request` arg in `handleError` template (#469)
 - fix(remix): Update documentation links to the new routes (#470)

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -25,6 +25,8 @@ import {
 } from './sdk-setup';
 import { debug } from '../utils/debug';
 import { traceStep, withTelemetry } from '../telemetry';
+import { isHydrogenApp } from './utils';
+import { DEFAULT_URL } from '../../lib/Constants';
 
 export async function runRemixWizard(options: WizardOptions): Promise<void> {
   return withTelemetry(
@@ -73,7 +75,8 @@ async function runRemixWizardWithTelemetry(
       await updateBuildScript({
         org: selectedProject.organization.slug,
         project: selectedProject.name,
-        url: sentryUrl,
+        url: sentryUrl === DEFAULT_URL ? undefined : sentryUrl,
+        isHydrogen: isHydrogenApp(packageJson),
       });
     } catch (e) {
       clack.log

--- a/src/remix/utils.ts
+++ b/src/remix/utils.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
+import { PackageDotJson, hasPackageInstalled } from '../utils/package-json';
 
 // Copied from sveltekit wizard
 export function hasSentryContent(
@@ -38,4 +39,8 @@ export function getInitCallInsertionIndex(
   }
 
   return 0;
+}
+
+export function isHydrogenApp(packageJson: PackageDotJson): boolean {
+  return hasPackageInstalled('@shopify/hydrogen', packageJson);
 }


### PR DESCRIPTION
Adds support for sourcemap uploads on Hydrogen apps.

With this PR and #472, the wizard will support Hydrogen's default file/build structure.