### PR TITLE
fix(reactnative): Save Sentry URL, Organization and Project to `sentry.properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ref(reactnative): Use clack prompts and share common code (dirty repo, login) (#473)
 - feat(reactnative): Add telemetry (#477)
+- fix(reactnative): Save Sentry URL, Organization and Project to `sentry.properties` (#479)
 
 ## 3.15.0
 

--- a/lib/Steps/ChooseIntegration.ts
+++ b/lib/Steps/ChooseIntegration.ts
@@ -65,7 +65,7 @@ export class ChooseIntegration extends BaseStep {
         break;
       case Integration.reactNative:
       default:
-        integration = new ReactNative(sanitizeUrl(this._argv));
+        integration = new ReactNative(this._argv);
         break;
     }
 

--- a/src/android/android-wizard.ts
+++ b/src/android/android-wizard.ts
@@ -151,7 +151,7 @@ async function runAndroidWizardWithTelemetry(
     )} file.`,
   );
 
-  await addSentryCliConfig(authToken, proguardMappingCliSetupConfig);
+  await addSentryCliConfig({ authToken }, proguardMappingCliSetupConfig);
 
   // ======== OUTRO ========
   const issuesPageLink = selfHosted

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -87,7 +87,7 @@ export async function runNextjsWizardWithTelemetry(
     createExamplePage(selfHosted, selectedProject, sentryUrl),
   );
 
-  await addSentryCliConfig(authToken);
+  await addSentryCliConfig({ authToken });
 
   const mightBeUsingVercel = fs.existsSync(
     path.join(process.cwd(), 'vercel.json'),

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -56,7 +56,10 @@ export const RN_HUMAN_NAME = 'React Native';
 
 export const SUPPORTED_RN_RANGE = '>=0.69.0';
 
-export type RNCliSetupConfigContent = Pick<Required<CliSetupConfigContent>, 'authToken' | 'org' | 'project' | 'url'>;
+export type RNCliSetupConfigContent = Pick<
+  Required<CliSetupConfigContent>,
+  'authToken' | 'org' | 'project' | 'url'
+>;
 
 export async function runReactNativeWizard(
   params: ReactNativeWizardOptions,
@@ -100,10 +103,8 @@ export async function runReactNativeWizardWithTelemetry(
     });
   }
 
-  const { selectedProject, authToken, sentryUrl } = await getOrAskForProjectData(
-    options,
-    'react-native',
-  );
+  const { selectedProject, authToken, sentryUrl } =
+    await getOrAskForProjectData(options, 'react-native');
   const orgSlug = selectedProject.organization.slug;
   const projectSlug = selectedProject.slug;
   const cliConfig: RNCliSetupConfigContent = {

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -56,6 +56,8 @@ export const RN_HUMAN_NAME = 'React Native';
 
 export const SUPPORTED_RN_RANGE = '>=0.69.0';
 
+export type RNCliSetupConfigContent = Pick<Required<CliSetupConfigContent>, 'authToken' | 'org' | 'project' | 'url'>;
+
 export async function runReactNativeWizard(
   params: ReactNativeWizardOptions,
 ): Promise<void> {
@@ -98,16 +100,17 @@ export async function runReactNativeWizardWithTelemetry(
     });
   }
 
-  const { selectedProject, authToken } = await getOrAskForProjectData(
+  const { selectedProject, authToken, sentryUrl } = await getOrAskForProjectData(
     options,
     'react-native',
   );
   const orgSlug = selectedProject.organization.slug;
   const projectSlug = selectedProject.slug;
-  const cliConfig: Required<CliSetupConfigContent> = {
+  const cliConfig: RNCliSetupConfigContent = {
     authToken,
     org: orgSlug,
     project: projectSlug,
+    url: sentryUrl,
   };
 
   await installPackage({
@@ -229,7 +232,7 @@ ${chalk.cyan(projectsIssuesUrl)}`);
   return firstErrorConfirmed;
 }
 
-async function patchXcodeFiles(config: Required<CliSetupConfigContent>) {
+async function patchXcodeFiles(config: RNCliSetupConfigContent) {
   await addSentryCliConfig(config, {
     ...propertiesCliSetupConfig,
     name: 'source maps and iOS debug files',
@@ -297,7 +300,7 @@ async function patchXcodeFiles(config: Required<CliSetupConfigContent>) {
   Sentry.setTag('xcode-project-status', 'patched');
 }
 
-async function patchAndroidFiles(config: Required<CliSetupConfigContent>) {
+async function patchAndroidFiles(config: RNCliSetupConfigContent) {
   await addSentryCliConfig(config, {
     ...propertiesCliSetupConfig,
     name: 'source maps and iOS debug files',

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -238,6 +238,7 @@ async function patchXcodeFiles(config: RNCliSetupConfigContent) {
     ...propertiesCliSetupConfig,
     name: 'source maps and iOS debug files',
     filename: 'ios/sentry.properties',
+    gitignore: false,
   });
 
   if (platform() === 'darwin') {
@@ -306,6 +307,7 @@ async function patchAndroidFiles(config: RNCliSetupConfigContent) {
     ...propertiesCliSetupConfig,
     name: 'source maps and iOS debug files',
     filename: 'android/sentry.properties',
+    gitignore: false,
   });
 
   const appBuildGradlePath = traceStep('find-app-build-gradle', () =>

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -68,7 +68,7 @@ async function runRemixWizardWithTelemetry(
   const isTS = isUsingTypeScript();
   const isV2 = isRemixV2(remixConfig, packageJson);
 
-  await addSentryCliConfig(authToken, rcCliSetupConfig);
+  await addSentryCliConfig({ authToken }, rcCliSetupConfig);
 
   await traceStep('Update build script for sourcemap uploads', async () => {
     try {

--- a/src/sourcemaps/tools/nextjs.ts
+++ b/src/sourcemaps/tools/nextjs.ts
@@ -19,14 +19,14 @@ const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
   const nextConfig = {
     // your existing next config
   };
-  
+
   ${chalk.greenBright(`const sentryWebpackPluginOptions = {
     org: "${options.orgSlug}",
     project: "${options.projectSlug}",${
     options.selfHosted ? `\n    url: "${options.url}",` : ''
   }
   };`)}
-  
+
   ${chalk.greenBright(`const sentryOptions = {
     // Upload additional client files (increases upload size)
     widenClientFileUpload: true,
@@ -34,12 +34,12 @@ const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
     // Hides source maps from generated client bundles
     hideSourceMaps: true,
   };`)}
-  
+
   ${chalk.greenBright(`module.exports = withSentryConfig(
     nextConfig,
     sentryWebpackPluginOptions,
     sentryOptions
-  );`)}  
+  );`)}
 `);
 
 export const configureNextJsSourceMapsUpload = async (
@@ -99,7 +99,7 @@ In case you already tried the wizard, we can also show you how to configure your
     );
 
     await traceStep('nextjs-manual-sentryclirc', () =>
-      addSentryCliConfig(options.authToken),
+      addSentryCliConfig({ authToken: options.authToken }),
     );
   }
 
@@ -108,7 +108,7 @@ In case you already tried the wizard, we can also show you how to configure your
 
 Uploading Source Maps:
 https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-source-maps
-  
+
 Troubleshooting Source Maps:
 https://docs.sentry.io/platforms/javascript/guides/nextjs/troubleshooting/`);
 };

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -96,7 +96,7 @@ export async function configureSentryCLI(
     );
   }
 
-  await addSentryCliConfig(options.authToken);
+  await addSentryCliConfig({ authToken: options.authToken });
 }
 
 export async function setupNpmScriptInCI(): Promise<void> {

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -95,7 +95,7 @@ export async function runSvelteKitWizardWithTelemetry(
     alreadyInstalled: sdkAlreadyInstalled,
   });
 
-  await addSentryCliConfig(authToken);
+  await addSentryCliConfig({ authToken });
 
   const svelteConfig = await traceStep('load-svelte-config', loadSvelteConfig);
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -41,6 +41,7 @@ interface WizardProjectData {
 export interface CliSetupConfig {
   filename: string;
   name: string;
+  gitignore: boolean;
 
   likelyAlreadyHasAuthToken(contents: string): boolean;
   tokenContent(authToken: string): string;
@@ -62,6 +63,7 @@ export interface CliSetupConfigContent {
 export const rcCliSetupConfig: CliSetupConfig = {
   filename: SENTRY_CLI_RC_FILE,
   name: 'source maps',
+  gitignore: true,
   likelyAlreadyHasAuthToken: function (contents: string): boolean {
     return !!(contents.includes('[auth]') && contents.match(/token=./g));
   },
@@ -82,6 +84,7 @@ export const rcCliSetupConfig: CliSetupConfig = {
 
 export const propertiesCliSetupConfig: Required<CliSetupConfig> = {
   filename: SENTRY_PROPERTIES_FILE,
+  gitignore: true,
   name: 'debug files',
   likelyAlreadyHasAuthToken(contents: string): boolean {
     return !!contents.match(/auth\.token=./g);
@@ -437,7 +440,13 @@ export async function addSentryCliConfig(
       );
     }
 
-    await addCliConfigFileToGitIgnore(setupConfig.filename);
+    if (setupConfig.gitignore) {
+      await addCliConfigFileToGitIgnore(setupConfig.filename);
+    } else {
+      clack.log.warn(
+        chalk.yellow('DO NOT commit auth token to your repository!'),
+      );
+    }
   });
 }
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -402,19 +402,28 @@ export async function addSentryCliConfig(
     const configPath = path.join(process.cwd(), setupConfig.filename);
     const configExists = fs.existsSync(configPath);
 
-    let configContents = (configExists && fs.readFileSync(configPath, 'utf8')) || '';
-    configContents = addAuthTokenToSentryConfig(configContents, authToken, setupConfig);
-    configContents = addOrgAndProjectToSentryConfig(configContents, org, project, setupConfig);
+    let configContents =
+      (configExists && fs.readFileSync(configPath, 'utf8')) || '';
+    configContents = addAuthTokenToSentryConfig(
+      configContents,
+      authToken,
+      setupConfig,
+    );
+    configContents = addOrgAndProjectToSentryConfig(
+      configContents,
+      org,
+      project,
+      setupConfig,
+    );
     configContents = addUrlToSentryConfig(configContents, url, setupConfig);
 
     try {
-      await fs.promises.writeFile(
-        configPath,
-        configContents,
-        { encoding: 'utf8', flag: 'w' },
-      );
+      await fs.promises.writeFile(configPath, configContents, {
+        encoding: 'utf8',
+        flag: 'w',
+      });
       clack.log.success(
-        `${configExists ? 'Saved' : 'Created' } ${chalk.cyan(
+        `${configExists ? 'Saved' : 'Created'} ${chalk.cyan(
           setupConfig.filename,
         )}.`,
       );
@@ -450,7 +459,9 @@ function addAuthTokenToSentryConfig(
     return configContents;
   }
 
-  const newContents = `${configContents}\n${setupConfig.tokenContent(authToken)}\n`;
+  const newContents = `${configContents}\n${setupConfig.tokenContent(
+    authToken,
+  )}\n`;
   clack.log.success(
     `Added auth token to ${chalk.cyan(
       setupConfig.filename,
@@ -478,7 +489,10 @@ function addOrgAndProjectToSentryConfig(
     return configContents;
   }
 
-  const newContents = `${configContents}\n${setupConfig.orgAndProjContent(org, project)}\n`;
+  const newContents = `${configContents}\n${setupConfig.orgAndProjContent(
+    org,
+    project,
+  )}\n`;
   clack.log.success(
     `Added default org and project to ${chalk.cyan(
       setupConfig.filename,
@@ -498,9 +512,7 @@ function addUrlToSentryConfig(
 
   if (setupConfig.likelyAlreadyHasUrl(configContents)) {
     clack.log.warn(
-      `${chalk.cyan(
-        setupConfig.filename,
-      )} already has url. Will not add one.`,
+      `${chalk.cyan(setupConfig.filename)} already has url. Will not add one.`,
     );
     return configContents;
   }

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -473,7 +473,7 @@ function addOrgAndProjectToSentryConfig(
     clack.log.warn(
       `${chalk.cyan(
         setupConfig.filename,
-      )} already has has org and project. Will not add them.`,
+      )} already has org and project. Will not add them.`,
     );
     return configContents;
   }
@@ -500,7 +500,7 @@ function addUrlToSentryConfig(
     clack.log.warn(
       `${chalk.cyan(
         setupConfig.filename,
-      )} already has has org and project. Will not add them.`,
+      )} already has url. Will not add one.`,
     );
     return configContents;
   }


### PR DESCRIPTION
Fixes missing url, org and project in RN sentry.properties

- bug introduced in https://github.com/getsentry/sentry-wizard/pull/473