### PR TITLE
fix(Cordova)  skip dynamic libraries on Cordova

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(Cordova): Skip dynamic libraries on Cordova (#481)
+
 ## 3.16.0
 
 - ref(reactnative): Use clack prompts and share common code (dirty repo, login) (#473)

--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -252,6 +252,13 @@ export class Cordova extends BaseIntegration {
           'EXTRACTED_ARCHS=()\\n' +
           'for ARCH in $ARCHS\\n' +
           'do\\n' +
+          'echo "Checking if $FRAMEWORK_EXECUTABLE_PATH needs to be stripped."\\n' +
+          '# Do not skip if "Architectures in the fat file".\\n' +
+          '# Skip if "Non-fat file' or if file not found". \\n' +
+          'if lipo -info "$FRAMEWORK_EXECUTABLE_PATH" | grep -v " fat "; then\\n' +
+          '    echo "Strip not required, skipping the strip script."\\n' +
+          '    exit 0\\n' +
+          'fi\\n' +
           'echo "Extracting $ARCH from $FRAMEWORK_EXECUTABLE_NAME"\\n' +
           'lipo -extract "$ARCH" "$FRAMEWORK_EXECUTABLE_PATH" -o "$FRAMEWORK_EXECUTABLE_PATH-$ARCH"\\n' +
           'EXTRACTED_ARCHS+=("$FRAMEWORK_EXECUTABLE_PATH-$ARCH")\\n' +

--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -254,7 +254,7 @@ export class Cordova extends BaseIntegration {
           'do\\n' +
           'echo "Checking if $FRAMEWORK_EXECUTABLE_PATH needs to be stripped."\\n' +
           '# Do not skip if "Architectures in the fat file".\\n' +
-          '# Skip if "Non-fat file' or if file not found". \\n' +
+          '# Skip if Non-fat file or if file not found. \\n' +
           'if lipo -info "$FRAMEWORK_EXECUTABLE_PATH" | grep -v " fat "; then\\n' +
           '    echo "Strip not required, skipping the strip script."\\n' +
           '    exit 0\\n' +


### PR DESCRIPTION
 The current script is only required when debugging on simulators, when building/deploying to real devices, the Library becomes dynamic and it's no longer required to strip the SDK.

I chose to check the `fat` library because it seems to be the safest field to be used that is language agnostic. When the file is not `fat` this strip code isn't required and so it's skipped.

Tests were done manually on a Local Sample, tested with Simulators, plugged to a real device and also deployed to the AppStore.