### PR TITLE
fix(nextjs): Set created test route handler to always be dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Set created test route handler to always be dynamic (#486)
+
 ## 3.16.1
 
 - fix(Cordova): Skip dynamic libraries on Cordova (#481)

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -258,6 +258,8 @@ export default function handler(_req, res) {
 export function getSentryExampleAppDirApiRoute() {
   return `import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 // A faulty API route to test Sentry's error monitoring
 export function GET() {
   throw new Error("Sentry Example API Route Error");


### PR DESCRIPTION
Since Next.js tries to make api routes static, any api routes that are not marked as dynamic will be executed during build. This means if they throw, which our test route does, it will prevent the build from going through.

This PR sets the created route to always be dynamic.