### PR TITLE
fix(sourcemaps): Re-read package.json after CLI install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(sourcemaps): Re-read package.json after CLI install (#489)
+
 ## 3.16.1
 
 - fix(Cordova): Skip dynamic libraries on Cordova (#481)

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -21,6 +21,7 @@ import { getInitCallInsertionIndex, hasSentryContent } from './utils';
 import { instrumentRootRouteV1 } from './codemods/root-v1';
 import { instrumentRootRouteV2 } from './codemods/root-v2';
 import { instrumentHandleError } from './codemods/handle-error';
+import { getPackageDotJson } from '../utils/clack-utils';
 
 export type PartialRemixConfig = {
   unstable_dev?: boolean;
@@ -166,13 +167,7 @@ export async function updateBuildScript(args: {
   url?: string;
   isHydrogen: boolean;
 }): Promise<void> {
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  // Add sourcemaps option to build script
-  const packageJsonPath = path.join(process.cwd(), 'package.json');
-  const packageJsonString = (
-    await fs.promises.readFile(packageJsonPath)
-  ).toString();
-  const packageJson = JSON.parse(packageJsonString);
+  const packageJson = await getPackageDotJson();
 
   if (!packageJson.scripts) {
     packageJson.scripts = {};
@@ -200,7 +195,7 @@ export async function updateBuildScript(args: {
   }
 
   await fs.promises.writeFile(
-    packageJsonPath,
+    path.join(process.cwd(), 'package.json'),
     JSON.stringify(packageJson, null, 2),
   );
 

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -78,11 +78,7 @@ export async function configureSentryCLI(
 
   await configureSourcemapGenerationFlow();
 
-  await createAndAddNpmScript(
-    packageDotJson,
-    options,
-    relativePosixArtifactPath,
-  );
+  await createAndAddNpmScript(options, relativePosixArtifactPath);
 
   if (await askShouldAddToBuildCommand()) {
     await traceStep('sentry-cli-add-to-build-cmd', () =>
@@ -135,7 +131,6 @@ export async function setupNpmScriptInCI(): Promise<void> {
 }
 
 async function createAndAddNpmScript(
-  packageDotJson: PackageDotJson,
   options: SourceMapUploadToolConfigurationOptions,
   relativePosixArtifactPath: string,
 ): Promise<void> {
@@ -148,6 +143,8 @@ async function createAndAddNpmScript(
   } sourcemaps upload --org ${options.orgSlug} --project ${
     options.projectSlug
   } ${relativePosixArtifactPath}`;
+
+  const packageDotJson = await getPackageDotJson();
 
   packageDotJson.scripts = packageDotJson.scripts || {};
   packageDotJson.scripts[SENTRY_NPM_SCRIPT_NAME] = sentryCliNpmScript;

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -340,6 +340,12 @@ Or setup using ${chalk.cyan(
   });
 }
 
+/**
+ * Installs or updates a package with the user's package manager.
+ *
+ * IMPORTANT: This function modifies the `package.json`! Be sure to re-read
+ * it if you make additional modifications to it after calling this function!
+ */
 export async function installPackage({
   packageName,
   alreadyInstalled,


### PR DESCRIPTION
After installing the `@sentry/cli` package in the CLI flow of the source maps wizard, we didn't re-read the `package.json` which overwrote the previously added package after we adjusted the build command and wrote back the stale package.json. This PR fixes that by re-reading the package.json in the build script modification function.

Also went over the other usages of package.json reading and package installing and didn't find another situation like this. Did some cleanup in Remix though.

thanks @lucas-zimerman for reporting!

closes #483 