### PR TITLE
fix(sourcemaps): Re-read `package.json` when modifying build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(sourcemaps): Re-read package.json when modifying build command #493
+
 ## 3.16.2
 
 - fix(sourcemaps): Re-read package.json after CLI install (#489)

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -12,7 +12,7 @@ import {
 } from '../../utils/clack-utils';
 
 import { SourceMapUploadToolConfigurationOptions } from './types';
-import { hasPackageInstalled, PackageDotJson } from '../../utils/package-json';
+import { hasPackageInstalled } from '../../utils/package-json';
 import { traceStep } from '../../telemetry';
 import { detectPackageManger, NPM } from '../../utils/package-manager';
 
@@ -82,7 +82,7 @@ export async function configureSentryCLI(
 
   if (await askShouldAddToBuildCommand()) {
     await traceStep('sentry-cli-add-to-build-cmd', () =>
-      addSentryCommandToBuildCommand(packageDotJson),
+      addSentryCommandToBuildCommand(),
     );
   } else {
     clack.log.info(
@@ -191,9 +191,8 @@ async function askShouldAddToBuildCommand(): Promise<boolean> {
  *
  * @param packageDotJson The package.json which will be modified.
  */
-export async function addSentryCommandToBuildCommand(
-  packageDotJson: PackageDotJson,
-): Promise<void> {
+export async function addSentryCommandToBuildCommand(): Promise<void> {
+  const packageDotJson = await getPackageDotJson();
   // This usually shouldn't happen because earlier we added the
   // SENTRY_NPM_SCRIPT_NAME script but just to be sure
   packageDotJson.scripts = packageDotJson.scripts || {};

--- a/test/sourcemaps/tools/sentry-cli.test.ts
+++ b/test/sourcemaps/tools/sentry-cli.test.ts
@@ -19,6 +19,17 @@ jest.mock('@clack/prompts', () => {
   };
 });
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('../../../src/utils/clack-utils', () => ({
+  ...jest.requireActual('../../../src/utils/clack-utils'),
+  getPackageDotJson: jest.fn().mockResolvedValue({
+    scripts: {
+      build: 'tsc',
+    },
+    version: '1.0.0',
+  }),
+}));
+
 describe('addSentryCommandToBuildCommand', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -34,13 +45,7 @@ describe('addSentryCommandToBuildCommand', () => {
     jest
       .spyOn(packageManagerHelpers, 'detectPackageManger')
       .mockReturnValue(pacMan);
-    const packageJson = {
-      scripts: {
-        build: 'tsc',
-      },
-      version: '1.0.0',
-    };
-    await addSentryCommandToBuildCommand(packageJson);
+    await addSentryCommandToBuildCommand();
     expect(writeFileSpy).toHaveBeenCalledWith(
       expect.stringContaining('package.json'),
       expect.stringContaining(


### PR DESCRIPTION
Following up on #489 we made the same mistake twice... This PR pulls in re-reading the package.json into the build command modification function to make sure we're not passing in a stale version.

closes #483 (again) 