### PR TITLE
feat(reactnative): Use Xcode scripts bundled with Sentry RN SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(reactnative): Use Xcode scripts bundled with Sentry RN SDK (#499)
+
 ## 3.16.4
 
 - feat(nextjs): Add instructions for custom \_error page (#496)


### PR DESCRIPTION


Since RN SDK 5.11.0 we ship Xcode scripts which replace directly patch code into the build phases of the RN Xcode project.

This PR updates the wizard to detect the SDK version which shipps with the scripts and use them to create the Xcode build phases.
