### PR TITLE
fix(wizard): Update wizard API data type and issue stream url creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(wizard): Update wizard API data type and issue stream url creation (#500)
+
 ## 3.16.4
 
 - feat(nextjs): Add instructions for custom \_error page (#496)

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -74,7 +74,7 @@ async function runRemixWizardWithTelemetry(
     try {
       await updateBuildScript({
         org: selectedProject.organization.slug,
-        project: selectedProject.name,
+        project: selectedProject.slug,
         url: sentryUrl === DEFAULT_URL ? undefined : sentryUrl,
         isHydrogen: isHydrogenApp(packageJson),
       });

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -24,13 +24,13 @@ import { WizardOptions } from '../utils/types';
 import { configureCRASourcemapGenerationFlow } from './tools/create-react-app';
 import { ensureMinimumSdkVersionIsInstalled } from './utils/sdk-version';
 import { traceStep, withTelemetry } from '../telemetry';
-import { URL } from 'url';
 import { checkIfMoreSuitableWizardExistsAndAskForRedirect } from './utils/other-wizards';
 import { configureAngularSourcemapGenerationFlow } from './tools/angular';
 import { detectUsedTool, SupportedTools } from './utils/detect-tool';
 import { configureNextJsSourceMapsUpload } from './tools/nextjs';
 import { configureRemixSourceMapsUpload } from './tools/remix';
 import { detectPackageManger } from '../utils/package-manager';
+import { getIssueStreamUrl } from '../utils/url';
 
 export async function runSourcemapsWizard(
   options: WizardOptions,
@@ -334,12 +334,7 @@ function printOutro(url: string, orgSlug: string, projectId: string) {
   const packageManager = detectPackageManger();
   const buildCommand = packageManager?.buildCommand ?? 'npm run build';
 
-  const urlObject = new URL(url);
-  urlObject.host = `${orgSlug}.${urlObject.host}`;
-  urlObject.pathname = '/issues/';
-  urlObject.searchParams.set('project', projectId);
-
-  const issueStreamUrl = urlObject.toString();
+  const issueStreamUrl = getIssueStreamUrl({ url, orgSlug, projectId });
 
   const arrow = isUnicodeSupported() ? '→' : '->';
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1001,7 +1001,6 @@ async function askForProjectSelection(
   );
 
   Sentry.setTag('project', selection.slug);
-  Sentry.setTag('project-platform', selection.platform);
   Sentry.setUser({ id: selection.organization.slug });
 
   return selection;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,15 +1,18 @@
 export interface SentryProjectData {
   id: string;
   slug: string;
-  name: string;
-  platform: string;
+  status: string;
   organization: {
+    id: string;
+    name: string;
     slug: string;
-    links: {
-      organizationUrl: string;
+    region: string;
+    status: {
+      id: string;
+      name: string;
     };
   };
-  keys: [{ dsn: { public: string } }];
+  keys: [{ dsn: { public: string }; isActive: boolean }];
 }
 
 export type WizardOptions = {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,23 @@
+import { URL } from 'url';
+
+/**
+ * Returns the url to the Sentry project stream.
+ *
+ * Example: https://org-slug.sentry.io/issues/?project=1234567
+ */
+export function getIssueStreamUrl({
+  url,
+  orgSlug,
+  projectId,
+}: {
+  url: string;
+  orgSlug: string;
+  projectId: string;
+}): string {
+  const urlObject = new URL(url);
+  urlObject.host = `${orgSlug}.${urlObject.host}`;
+  urlObject.pathname = '/issues/';
+  urlObject.searchParams.set('project', projectId);
+
+  return urlObject.toString();
+}


### PR DESCRIPTION
This PR updates the wizard API types to reflect recent changes.

Updates API data usage. And issue stream url creating. Adds helper function for the URL.

- Fix RN issue stream url
- Fix remix builds script -> use project slag
- Remove `project-platform` tag as the value is not send by the API

Context:
- https://github.com/getsentry/sentry/pull/59153
