### PR TITLE
feat(reactnative): Make `pod install` step optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix(wizard): Update wizard API data type and issue stream url creation (#500)
+- feat(reactnative): Make `pod install` step optional (#501)
 
 ## 3.16.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- feat(reactnative): Make `pod install` step optional (#501)
+
 ## 3.16.5
 
 - feat(remix): Add Vite support (#495)
 - fix(wizard): Update wizard API data type and issue stream url creation (#500)
-- feat(reactnative): Make `pod install` step optional (#501)
 
 ## 3.16.4
 

--- a/src/apple/cocoapod.ts
+++ b/src/apple/cocoapod.ts
@@ -56,8 +56,10 @@ export async function podInstall(dir = '.') {
     await bash.execute(`cd ${dir} && pod repo update`);
     await bash.execute(`cd ${dir} && pod install --silent`);
     installSpinner.stop('Pods installed.');
+    Sentry.setTag('pods-installed', true);
   } catch (e) {
     installSpinner.stop('Failed to install pods.');
+    Sentry.setTag('pods-installed', false);
     clack.log.error(
       `${chalk.red(
         'Encountered the following error during pods installation:',

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -377,13 +377,14 @@ async function patchAndroidFiles(config: RNCliSetupConfigContent) {
 
 async function confirmPodInstall(): Promise<boolean> {
   return traceStep('confirm-pod-install', async () => {
-    const continueWithPodInstall: boolean = await abortIfCancelled(
+    const continueWithPodInstall = await abortIfCancelled(
       clack.select({
         message:'Do you want to run `pod install` now?',
         options: [
           { value: true, label: 'Yes', hint: 'Recommended for smaller projects.' },
           { value: false, label: `No, I'll do it later.` }
         ],
+        initialValue: true,
       }),
     );
     Sentry.setTag('continue-with-pod-install', continueWithPodInstall);

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -249,7 +249,7 @@ async function patchXcodeFiles(config: RNCliSetupConfigContent) {
     gitignore: false,
   });
 
-  if (platform() === 'darwin' && await confirmPodInstall()) {
+  if (platform() === 'darwin' && (await confirmPodInstall())) {
     await traceStep('pod-install', () => podInstall('ios'));
   }
 
@@ -379,10 +379,14 @@ async function confirmPodInstall(): Promise<boolean> {
   return traceStep('confirm-pod-install', async () => {
     const continueWithPodInstall = await abortIfCancelled(
       clack.select({
-        message:'Do you want to run `pod install` now?',
+        message: 'Do you want to run `pod install` now?',
         options: [
-          { value: true, label: 'Yes', hint: 'Recommended for smaller projects.' },
-          { value: false, label: `No, I'll do it later.` }
+          {
+            value: true,
+            label: 'Yes',
+            hint: 'Recommended for smaller projects, this might take several minutes',
+          },
+          { value: false, label: `No, I'll do it later` },
         ],
         initialValue: true,
       }),


### PR DESCRIPTION
This PR adds dialog before running `pod install`. 

This step can take minutes and is prone to fail. This way users can avoid it and run it later, when their environment is setup for it.
