### PR TITLE
feat(nextjs): Automatically enable vercel cron monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - feat(reactnative): Make `pod install` step optional (#501)
 - feat(remix): Add Vite support (#495)
 - feat(reactnative): Add Sentry Metro serializer (#502)
+- feat(nextjs): Automatically enable vercel cron monitors (#507)
 
 ## 3.16.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(nextjs): Add instructions on how to add a `global-error` page to Next.js
   App Router (#506)
+- feat(nextjs): Automatically enable vercel cron monitors (#507)
 
 ## 3.17.0
 
@@ -11,7 +12,6 @@
 - feat(reactnative): Make `pod install` step optional (#501)
 - feat(remix): Add Vite support (#495)
 - feat(reactnative): Add Sentry Metro serializer (#502)
-- feat(nextjs): Automatically enable vercel cron monitors (#507)
 
 ## 3.16.5
 

--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -16,6 +16,12 @@ const moduleExports = {
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
     // for more information.
     hideSourceMaps: true,
+
+    // Enables automatic instrumentation of Vercel Cron Monitors.
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
   },
 };
 

--- a/scripts/NextJs/configs/next.config.js
+++ b/scripts/NextJs/configs/next.config.js
@@ -16,12 +16,6 @@ const moduleExports = {
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
     // for more information.
     hideSourceMaps: true,
-
-    // Enables automatic instrumentation of Vercel Cron Monitors.
-    // See the following for more information:
-    // https://docs.sentry.io/product/crons/
-    // https://vercel.com/docs/cron-jobs
-    automaticVercelMonitors: true,
   },
 };
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -36,6 +36,12 @@ export function getNextjsSentryBuildOptionsTemplate(): string {
 
     // Automatically tree-shake Sentry logger statements to reduce bundle size
     disableLogger: true,
+
+    // Enables automatic instrumentation of Vercel Cron Monitors.
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
   }`;
 }
 


### PR DESCRIPTION
Given we are disabling the creation of vercel cron monitors by default https://github.com/getsentry/sentry-javascript/pull/9697, let's update our onboarding to insert in `automaticVercelMonitors` as true.

Since this is being added during onboarding, we are being explicit about it being turned on. Users can easily remove this if they don't want this functionality.