### PR TITLE
fix(nextjs): Instruct users to restart dev server after setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(remix): Add instrumentation step for Express server adapters (#504)s
+- fix(nextjs): Instruct users to restart dev server after setup (#513)
 
 ## 3.19.0
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -291,9 +291,9 @@ export async function runNextjsWizardWithTelemetry(
   clack.outro(
     `${chalk.green('Everything is set up!')}
 
-   ${chalk.cyan(
-     'You can validate your setup by starting your dev environment (`next dev`) and visiting "/sentry-example-page".',
-   )}
+     You can validate your setup by restarting your dev environment (${chalk.cyan(
+       `next dev`,
+     )}) and visiting ${chalk.cyan('"/sentry-example-page"')}
 
    ${chalk.dim(
      'If you encounter any issues, let us know here: https://github.com/getsentry/sentry-javascript/issues',


### PR DESCRIPTION
Instructs users to restart their dev server instead of starting it. As pointed out by @ingridkindem, it wasn't entirely clear that the dev server needs to be restarted so that the next.config changes from the wizard are applied. Thanks for the suggestion!

Also made a slight change to the printing color. We wanna use `cyan` for code, file names or commands. not entire sentences.

closes https://github.com/getsentry/sentry-wizard/issues/480
