### PR TITLE
feat(nextjs): Ask for confirmation before creating example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(remix): Add instrumentation step for Express server adapters (#504)s
+- feat(nextjs): Ask for confirmation before creating example page (#515)
 - fix(nextjs): Instruct users to restart dev server after setup (#513)
 
 ## 3.19.0

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -271,11 +271,7 @@ export async function runNextjsWizardWithTelemetry(
     }
   });
 
-  const shouldCreateExamplePage = await traceStep(
-    'ask-create-example-page',
-    askShouldCreateExamplePage,
-  );
-
+  const shouldCreateExamplePage = await askShouldCreateExamplePage();
   if (shouldCreateExamplePage) {
     await traceStep('create-example-page', async () =>
       createExamplePage(selfHosted, selectedProject, sentryUrl),

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1201,7 +1201,7 @@ export async function askShouldCreateExamplePage(
   const route = chalk.cyan(customRoute ?? '/sentry-example-page');
   return abortIfCancelled(
     clack.select({
-      message: `Do you want us to create an example page ("${route}") to test your setup?`,
+      message: `Do you want to create an example page ("${route}") to test your Sentry setup?`,
       options: [
         {
           value: true,

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1199,17 +1199,19 @@ export async function askShouldCreateExamplePage(
   customRoute?: string,
 ): Promise<boolean> {
   const route = chalk.cyan(customRoute ?? '/sentry-example-page');
-  return abortIfCancelled(
-    clack.select({
-      message: `Do you want to create an example page ("${route}") to test your Sentry setup?`,
-      options: [
-        {
-          value: true,
-          label: 'Yes',
-          hint: 'Recommended - Check your git status before committing!',
-        },
-        { value: false, label: 'No' },
-      ],
-    }),
+  return traceStep('ask-create-example-page', () =>
+    abortIfCancelled(
+      clack.select({
+        message: `Do you want to create an example page ("${route}") to test your Sentry setup?`,
+        options: [
+          {
+            value: true,
+            label: 'Yes',
+            hint: 'Recommended - Check your git status before committing!',
+          },
+          { value: false, label: 'No' },
+        ],
+      }),
+    ),
   );
 }

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1126,7 +1126,7 @@ type CodeSnippetFormatter = (
  * This is useful for printing the snippet to the console as part of copy/paste instructions.
  *
  * @param callback the callback that returns the formatted code snippet.
- * It exposes takes the helper functions for marking code as unchaned, new or removed.
+ * It exposes takes the helper functions for marking code as unchanged, new or removed.
  * These functions no-op if no special formatting should be applied
  * and otherwise apply the appropriate formatting/coloring.
  * (@see {@link CodeSnippetFormatter})
@@ -1161,7 +1161,7 @@ export function makeCodeSnippet(
  * @param moreInformation (optional) the message to be printed after the file was created
  * For example, this can be a link to more information about configuring the tool.
  *
- * @returns true on sucess, false otherwise
+ * @returns true on success, false otherwise
  */
 export async function createNewConfigFile(
   filepath: string,
@@ -1193,4 +1193,23 @@ export async function createNewConfigFile(
   }
 
   return false;
+}
+
+export async function askShouldCreateExamplePage(
+  customRoute?: string,
+): Promise<boolean> {
+  const route = chalk.cyan(customRoute ?? '/sentry-example-page');
+  return abortIfCancelled(
+    clack.select({
+      message: `Do you want us to create an example page ("${route}") to test your setup?`,
+      options: [
+        {
+          value: true,
+          label: 'Yes',
+          hint: 'Recommended - Check your git status before committing!',
+        },
+        { value: false, label: 'No' },
+      ],
+    }),
+  );
 }


### PR DESCRIPTION
This PR adds a prompt asking if the wizard should create an example page to test the Sentry setup.
Only if the user replies with yes, we'll create the example route and mention it in the outro.
Adding this prompt should decrease the likelihood of users accidentally comitting the example files.

<img width="665" alt="image" src="https://github.com/getsentry/sentry-wizard/assets/8420481/93ec62d4-6ac5-490d-9d1f-f771f4f6c05d">

Will follow up with adding the adjustment to other wizards in future PRs once we agreed on wording.

ref https://github.com/getsentry/sentry-wizard/issues/503