### PR TITLE
fix(nextjs,sveltekit): Replace deprecated Sentry API calls in example page templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.20.1
+## Unreleased
 
 - fix(nextjs): Replace deprecated Sentry API calls in example page templates (#520)
 - fix(sveltekit): Replace deprecated Sentry API calls in example page templates (#520)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.20.1
+
+- fix(nextjs): Replace deprecated Sentry API calls in example page templates (#520)
+- fix(sveltekit): Replace deprecated Sentry API calls in example page templates (#520)
+
 ## 3.20.0
 
 - feat(nextjs): Ask for confirmation before creating example page (#515)

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -216,8 +216,9 @@ export default function Page() {
             margin: "18px",
           }}
           onClick={async () => {
-            Sentry.startSpan({
+            await Sentry.startSpan({
               name: 'Example Frontend Span',
+              op: 'test'
             }, async () => {
               const res = await fetch("/api/sentry-example-api");
               if (!res.ok) {

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -216,22 +216,14 @@ export default function Page() {
             margin: "18px",
           }}
           onClick={async () => {
-            const transaction = Sentry.startTransaction({
-              name: "Example Frontend Transaction",
-            });
-
-            Sentry.configureScope((scope) => {
-              scope.setSpan(transaction);
-            });
-
-            try {
+            Sentry.startSpan({
+              name: 'Example Frontend Span',
+            }, async () => {
               const res = await fetch("/api/sentry-example-api");
               if (!res.ok) {
                 throw new Error("Sentry Example Frontend Error");
               }
-            } finally {
-              transaction.finish();
-            }
+            });
           }}
         >
           Throw error!

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -215,8 +215,8 @@ export default function Page() {
             fontSize: "14px",
             margin: "18px",
           }}
-          onClick={async () => {
-            await Sentry.startSpan({
+          onClick={() => {
+            Sentry.startSpan({
               name: 'Example Frontend Span',
               op: 'test'
             }, async () => {

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -131,7 +131,7 @@ export async function runSvelteKitWizardWithTelemetry(
   }
 
   const shouldCreateExamplePage = await askShouldCreateExamplePage(
-    'sentry-example',
+    '/sentry-example',
   );
 
   if (shouldCreateExamplePage) {

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -63,8 +63,9 @@ Feel free to delete this file and the entire sentry route.
   import * as Sentry from '@sentry/sveltekit';
 
   async function getSentryData() {
-    Sentry.startSpan({
+    await Sentry.startSpan({
       name: 'Example Frontend Span',
+      op: 'test',
     }, async () => {
       const res = await fetch('/sentry-example');
       if (!res.ok) {

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -63,22 +63,14 @@ Feel free to delete this file and the entire sentry route.
   import * as Sentry from '@sentry/sveltekit';
 
   async function getSentryData() {
-    const transaction = Sentry.startTransaction({
-      name: 'Example Frontend Transaction'
-    });
-
-    Sentry.configureScope((scope) => {
-      scope.setSpan(transaction);
-    });
-
-    try {
+    Sentry.startSpan({
+      name: 'Example Frontend Span',
+    }, async () => {
       const res = await fetch('/sentry-example');
       if (!res.ok) {
         throw new Error('Sentry Example Frontend Error');
       }
-    } finally {
-      transaction.finish();
-    }
+    });
   }
 </script>
 

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -62,8 +62,8 @@ Feel free to delete this file and the entire sentry route.
 <script>
   import * as Sentry from '@sentry/sveltekit';
 
-  async function getSentryData() {
-    await Sentry.startSpan({
+  function getSentryData() {
+    Sentry.startSpan({
       name: 'Example Frontend Span',
       op: 'test',
     }, async () => {


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-wizard/issues/519

We had `configureScope` and `startTransaction` calls in the example page templates. Given we've deprecated the former and will soon deprecate the other, this PR updates the templates to use the new `startSpan` API instead.

Also shows how much simpler the new API makes this example.