### PR TITLE
ref(wizard): Print error object if wizard endpoint API request failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- ref(wizard): Print error object if wizard endpoint API request failed
+- ref(wizard): Print error object if wizard endpoint API request failed (#524)
 
 ## 3.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref(wizard): Print error object if wizard endpoint API request failed
+
 ## 3.20.1
 
 - fix(nextjs): Replace deprecated Sentry API calls in example page templates (#520)

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -891,9 +891,10 @@ async function askForWizardLogin(options: {
     wizardHash = (
       await axios.get<{ hash: string }>(`${options.url}api/0/wizard/`)
     ).data.hash;
-  } catch {
+  } catch (e: unknown) {
     if (options.url !== SAAS_URL) {
       clack.log.error('Loading Wizard failed. Did you provide the right URL?');
+      clack.log.info(JSON.stringify(e, null, 2));
       await abort(
         chalk.red(
           'Please check your configuration and try again.\n\n   Let us know if you think this is an issue with the wizard or Sentry: https://github.com/getsentry/sentry-wizard/issues',
@@ -901,6 +902,7 @@ async function askForWizardLogin(options: {
       );
     } else {
       clack.log.error('Loading Wizard failed.');
+      clack.log.info(JSON.stringify(e, null, 2));
       await abort(
         chalk.red(
           'Please try again in a few minutes and let us know if this issue persists: https://github.com/getsentry/sentry-wizard/issues',


### PR DESCRIPTION
Seems like #405 is happening again and I have no idea what might be causing the errors here. 
Since I cannot reproduce this myself, let's log out the error so that users can report more details.