### PR TITLE
ref(remix): Replace `BrowserTracing` with `browserTracingIntegration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref(remix): Replace `BrowserTracing` with `browserTracingIntegration` (#533)
+
 ## 3.20.3
 
 - ref(nextjs): Replace `new Replay()` with `replayIntegration` (#532)

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -78,15 +78,10 @@ function insertClientInitCall(
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
     integrations: [
-      // TODO: Replace as soon as we have the new browserTracingIntegration for Remix
-      builders.newExpression('Sentry.BrowserTracing', {
-        routingInstrumentation: builders.functionCall(
-          'Sentry.remixRouterInstrumentation',
-          builders.raw('useEffect'),
-          builders.raw('useLocation'),
-          builders.raw('useMatches'),
-        ),
-      }),
+      builders.functionCall(
+        'Sentry.browserTracingIntegration',
+        builders.raw('{ useEffect, useLocation, useMatches }'),
+      ),
       builders.functionCall('Sentry.replayIntegration'),
     ],
   });


### PR DESCRIPTION
This concludes removing all deprecated integration classes from the wizard with SDK version 7.100.0