### PR TITLE
chore(publish): Update prepare release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,13 @@ on:
         description: Version to release
         required: true
       force:
-        description: Force a release even when there are release-blockers (optional)
+        description:
+          Force a release even when there are release-blockers (optional)
         required: false
       merge_target:
-        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        description:
+          Target branch to merge into. Uses the default branch as a fallback
+          (optional)
         required: false
         default: master
 jobs:
@@ -24,11 +27,10 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
+        uses: getsentry/action-prepare-release@lms/write-config-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
-


### PR DESCRIPTION
Need to test my changes to the release action w/ a repo that doesn't yet set the new `craft_config_from_merge_target ` option. I'll go back to the `v1` tag once we merged the release action changes and things work as expected