### PR TITLE
Revert "chore(publish): Update prepare release action (#536)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,10 @@ on:
         description: Version to release
         required: true
       force:
-        description:
-          Force a release even when there are release-blockers (optional)
+        description: Force a release even when there are release-blockers (optional)
         required: false
       merge_target:
-        description:
-          Target branch to merge into. Uses the default branch as a fallback
-          (optional)
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
         required: false
         default: master
 jobs:
@@ -27,10 +24,11 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Prepare release
-        uses: getsentry/action-prepare-release@lms/write-config-branch
+        uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
+


### PR DESCRIPTION
changes were merged into `v1` tag of the prepare release action

This reverts commit 5a5187647fc3f755b30c5044dfa60b15abd6b8ed.

#skip-changelog