### PR TITLE
feat(nextjs): Add note about `tunnelRoute` and Next.js middleware incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
+
 ## 3.20.5
 
 - fix: Update `@clack/core` to fix selection error on Windows (#539)

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -28,7 +28,9 @@ export function getNextjsSentryBuildOptionsTemplate(): string {
     // Transpiles SDK to be compatible with IE11 (increases bundle size)
     transpileClientSDK: true,
 
-    // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
+    // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers. (increases server load)
+    // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+    // side errors will fail.
     tunnelRoute: "/monitoring",
 
     // Hides source maps from generated client bundles


### PR DESCRIPTION
Adds note about `tunnnelRotue` being incompatible with Next.js middleware.