### PR TITLE
feat(SvelteKit): Added Spotlight option in server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
-- Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
-- feat(sveltekit): Added comment to add spotlight in Sentry.init for SvelteKit server hooks config (#546)
+- feat(nextjs): Pin installed Next.js SDK version to version 7 (#550)
+- feat(nextjs): Added comment to add spotlight in Sentry.init for Next.js server config (#545)
+- feat(remix): Add example page (#542)
+- feat(sveltekit): Add comment for spotlight in Sentry.init for SvelteKit server hooks config (#546)
+- ref(nextjs): Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
+- ref(remix): Remove Vite dev-mode modification step (#543)
 
 ## 3.20.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
+- feat(sveltekit): Added comment to add spotlight in Sentry.init for SvelteKit server hooks config (#546)
 
 ## 3.20.5
 

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -31,6 +31,9 @@ import * as Sentry from '@sentry/sveltekit';
 Sentry.init({
   dsn: '${dsn}',
   tracesSampleRate: 1.0,
+
+  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+  // spotlight: import.meta.env.DEV,  
 });
 
 // If you have custom handlers, make sure to place them after \`sentryHandle()\` in the \`sequence\` function.


### PR DESCRIPTION
added comment to add spotlight in Sentry.init for svelteKit server hooks config

Note: We did not include the installation and setup of Spotlight because it is not added by default, and it is also not mandatory.

#535 