### PR TITLE
feat(Remix): Added Spotlight option in server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
+- feat(remix): Added comment to add spotlight in Sentry.init for remix server config (#547)
 
 ## 3.20.5
 

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -102,12 +102,14 @@ function insertServerInitCall(
   dsn: string,
   originalHooksMod: ProxifiedModule<any>,
 ) {
-  const initCall = builders.functionCall('Sentry.init', {
-    dsn,
-    tracesSampleRate: 1.0,
-    // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-    // spotlight: process.env.NODE_ENV === 'development',
-  });
+  const code = [
+    "Sentry.init({",
+    `  dsn: "${dsn}",`,
+    "  tracesSampleRate: 1.0,",
+    "  // uncomment the line below to enable Spotlight (https://spotlightjs.com)",
+    "  // spotlight: process.env.NODE_ENV === 'development',",
+    "});"
+  ].join("\n");
 
   const originalHooksModAST = originalHooksMod.$ast as Program;
 
@@ -118,7 +120,7 @@ function insertServerInitCall(
     0,
     // @ts-expect-error - string works here because the AST is proxified by magicast
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    generateCode(initCall).code,
+    code,
   );
 }
 

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -105,6 +105,8 @@ function insertServerInitCall(
   const initCall = builders.functionCall('Sentry.init', {
     dsn,
     tracesSampleRate: 1.0,
+    // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+    // spotlight: process.env.NODE_ENV === 'development',
   });
 
   const originalHooksModAST = originalHooksMod.$ast as Program;


### PR DESCRIPTION
Added comment to add spotlight in Sentry.init for remix server config

Note: We did not include the installation and setup of Spotlight because it is not added by default, and it is also not mandatory.

#535 