### PR TITLE
feat(React Native): Added Spotlight option in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
+- feat(reactnative): Added comment to add spotlight in Sentry.init for React Native config
 
 ## 3.20.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
-- feat(reactnative): Added comment to add spotlight in Sentry.init for React Native config
+- feat(reactnative): Added comment to add spotlight in Sentry.init for React Native config (#548)
 
 ## 3.20.5
 

--- a/src/react-native/javascript.ts
+++ b/src/react-native/javascript.ts
@@ -29,5 +29,8 @@ export function getSentryInitPlainTextSnippet(dsn: string) {
 
 Sentry.init({
   dsn: '${dsn}',
+
+  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+  // enableSpotlight: __DEV__,
 });`;
 }

--- a/test/react-native/javascript.test.ts
+++ b/test/react-native/javascript.test.ts
@@ -31,6 +31,9 @@ import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
   dsn: 'dsn',
+
+  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+  // enableSpotlight: __DEV__,
 });
 
 const App = () => {


### PR DESCRIPTION
Added comment to add spotlight in Sentry.init for react-native config

Note: We did not include the installation and setup of Spotlight because it is not added by default, and it is also not mandatory.


#535 