### PR TITLE
feat(nextjs): Pin installed Next.js SDK version to version 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(nextjs): Pin installed Next.js SDK version to version 7 (#550)
 - Add note about `tunnelRoute` and Next.js middleware incompatibility (#544)
 
 ## 3.20.5
@@ -24,8 +25,10 @@
 
 ## 3.20.1
 
-- fix(nextjs): Replace deprecated Sentry API calls in example page templates (#520)
-- fix(sveltekit): Replace deprecated Sentry API calls in example page templates (#520)
+- fix(nextjs): Replace deprecated Sentry API calls in example page templates
+  (#520)
+- fix(sveltekit): Replace deprecated Sentry API calls in example page templates
+  (#520)
 
 ## 3.20.0
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -82,7 +82,7 @@ export async function runNextjsWizardWithTelemetry(
   Sentry.setTag('sdk-already-installed', sdkAlreadyInstalled);
 
   await installPackage({
-    packageName: '@sentry/nextjs',
+    packageName: '@sentry/nextjs@^7.105.0',
     alreadyInstalled: !!packageJson?.dependencies?.['@sentry/nextjs'],
   });
 


### PR DESCRIPTION
Once we release v8 the inserted snippet would not work in combination with the newest SDK, so we instead pin the version so that the wizard keeps working!