### PR TITLE
feat(nextjs): Make example page resilient to `typescript-eslint/no-floating-promises`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- feat(nextjs): Make example page resilient to
+  `typescript-eslint/no-floating-promises` (#568)
+
 ## 3.22.2
 
 - feat(nextjs): Adjust Next.js wizard for usage with v8 SDK (#567)

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -230,8 +230,8 @@ export default function Page() {
             fontSize: "14px",
             margin: "18px",
           }}
-          onClick={() => {
-            Sentry.startSpan({
+          onClick={async () => {
+            await Sentry.startSpan({
               name: 'Example Frontend Span',
               op: 'test'
             }, async () => {


### PR DESCRIPTION
The example page may have a `typescript-eslint/no-floating-promises` eslint warning/error. Since this confused a user on discord we probably want to fix it: https://discord.com/channels/621778831602221064/621778831602221072/1239945781608190022 