### PR TITLE
fix: Remove quotes around auth token in .env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(nextjs): Make example page resilient to
   `typescript-eslint/no-floating-promises` (#568)
+- fix: Remove quotes around auth token in .env files (#570)
 
 ## 3.22.2
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -550,7 +550,7 @@ export async function addDotEnvSentryBuildPluginFile(
 # The SENTRY_AUTH_TOKEN variable is picked up by the Sentry Build Plugin.
 # It's used for authentication when uploading source maps.
 # You can also set this env variable in your own \`.env\` files and remove this file.
-SENTRY_AUTH_TOKEN="${authToken}"
+SENTRY_AUTH_TOKEN=${authToken}
 `;
 
   const dotEnvFilePath = path.join(process.cwd(), SENTRY_DOT_ENV_FILE);


### PR DESCRIPTION
The values of environments variables in .env files are not supposed to have quotes.