### PR TITLE
fix(nextjs): Remove `transpileClientSDK` from template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(nextjs): Make example page resilient to
   `typescript-eslint/no-floating-promises` (#568)
 - fix: Remove quotes around auth token in .env files (#570)
+- fix(nextjs): Remove `transpileClientSDK` from template (#571)
 
 ## 3.22.2
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -32,9 +32,6 @@ export function getWithSentryConfigOptionsTemplate({
     // Upload a larger set of source maps for prettier stack traces (increases build time)
     widenClientFileUpload: true,
 
-    // Transpiles SDK to be compatible with IE11 (increases bundle size)
-    transpileClientSDK: true,
-
     // ${
       tunnelRoute ? 'Route' : 'Uncomment to route'
     } browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.


### PR DESCRIPTION
`transpileClientSDK` has been removed from the next.js sentry JS SDK ([reference commit](https://github.com/getsentry/sentry-javascript/commit/7a01742ebcf5dc2b298d8e940886dea9029a6886)). 

Removes the `transpileClientSDK` property from the nextjs wizard template.