### PR TITLE
feat(`PromptForParameters`): user `_getDSNKeyUrl` on DSN url prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(step-wizards): Show correct URL when prompting DSN (#577)
+
 ## 3.23.1
 
 - fix(nextjs): Replace `url` with `sentryUrl` in `withSentryConfig` options (#579)

--- a/lib/Steps/PromptForParameters.ts
+++ b/lib/Steps/PromptForParameters.ts
@@ -47,6 +47,7 @@ export class PromptForParameters extends BaseStep {
     ]);
 
     url = this._getFullUrl(answers, organization.slug, project.slug);
+    const dsnKeyUrl = this._getDSNKeyUrl(answers, project.slug)
     const dsn = await prompt([
       {
         message: 'DSN:',
@@ -56,7 +57,7 @@ export class PromptForParameters extends BaseStep {
         validate: this._validateDSN,
         when: this._shouldAsk(answers, 'config.dsn.public', () => {
           dim('Please copy/paste your DSN');
-          dim(`It can be found here: ${url}`);
+          dim(`It can be found here: ${dsnKeyUrl}`);
         }),
       },
     ]);
@@ -105,6 +106,19 @@ export class PromptForParameters extends BaseStep {
       projectSlug || 'project_slug',
     );
     return `${baseUrl}${orgSlug}/${projSlug}`;
+  }
+
+  private _getDSNKeyUrl(
+    answers: Answers,
+    projectSlug?: string,
+  ): string {
+    const baseUrl = this._argv.url;
+    const projSlug = _.get(
+      answers,
+      'config.project.slug',
+      projectSlug || 'project_slug',
+    );
+    return `${baseUrl}settings/projects/${projSlug}/keys`;
   }
 
   private _shouldAsk(

--- a/lib/Steps/PromptForParameters.ts
+++ b/lib/Steps/PromptForParameters.ts
@@ -47,7 +47,7 @@ export class PromptForParameters extends BaseStep {
     ]);
 
     url = this._getFullUrl(answers, organization.slug, project.slug);
-    const dsnKeyUrl = this._getDSNKeyUrl(answers, project.slug)
+    const dsnKeyUrl = this._getDSNKeyUrl(answers, project.slug);
     const dsn = await prompt([
       {
         message: 'DSN:',
@@ -108,10 +108,7 @@ export class PromptForParameters extends BaseStep {
     return `${baseUrl}${orgSlug}/${projSlug}`;
   }
 
-  private _getDSNKeyUrl(
-    answers: Answers,
-    projectSlug?: string,
-  ): string {
+  private _getDSNKeyUrl(answers: Answers, projectSlug?: string): string {
     const baseUrl = this._argv.url;
     const projSlug = _.get(
       answers,


### PR DESCRIPTION
## What does this PR do?

On inputting the DSN prompt, instead of the main project's URL (eg: `https://sentry.io/org/project-name`), guide the user to the `Client Keys` page (eg: `https://sentry.io/settings/projects/project-name/keys/`).

I personally encounter this while running `npx @sentry/wizard@1 -i reactNative -p ios android`