### PR TITLE
fix(nextjs): Replace `url` with `sentryUrl` in `withSentryConfig` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Replace `url` with `sentryUrl` in `withSentryConfig` options (#579)
+
 ## 3.23.0
 
 - feat(apple): Disable build script sandboxing (#574)

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -455,7 +455,7 @@ async function createOrMergeNextJsFiles(
       orgSlug: selectedProject.organization.slug,
       projectSlug: selectedProject.slug,
       selfHosted,
-      url: sentryUrl,
+      sentryUrl,
       tunnelRoute: sdkConfigOptions.tunnelRoute,
     });
 
@@ -665,7 +665,7 @@ async function createExamplePage(
       selfHosted,
       orgSlug: selectedProject.organization.slug,
       projectId: selectedProject.id,
-      url: sentryUrl,
+      sentryUrl,
       useClient: true,
     });
 
@@ -722,7 +722,7 @@ async function createExamplePage(
       selfHosted,
       orgSlug: selectedProject.organization.slug,
       projectId: selectedProject.id,
-      url: sentryUrl,
+      sentryUrl,
       useClient: false,
     });
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -5,7 +5,7 @@ type WithSentryConfigOptions = {
   orgSlug: string;
   projectSlug: string;
   selfHosted: boolean;
-  url: string;
+  sentryUrl: string;
   tunnelRoute: boolean;
 };
 
@@ -14,14 +14,16 @@ export function getWithSentryConfigOptionsTemplate({
   projectSlug,
   selfHosted,
   tunnelRoute,
-  url,
+  sentryUrl,
 }: WithSentryConfigOptions): string {
   return `{
     // For all available options, see:
     // https://github.com/getsentry/sentry-webpack-plugin#options
 
     org: "${orgSlug}",
-    project: "${projectSlug}",${selfHosted ? `\n    url: "${url}"` : ''}
+    project: "${projectSlug}",${
+    selfHosted ? `\n    sentryUrl: "${sentryUrl}"` : ''
+  }
 
     // Only print logs for uploading source maps in CI
     silent: !process.env.CI,
@@ -168,13 +170,13 @@ Sentry.init({
 
 export function getSentryExamplePageContents(options: {
   selfHosted: boolean;
-  url: string;
+  sentryUrl: string;
   orgSlug: string;
   projectId: string;
   useClient: boolean;
 }): string {
   const issuesPageLink = options.selfHosted
-    ? `${options.url}organizations/${options.orgSlug}/issues/?project=${options.projectId}`
+    ? `${options.sentryUrl}organizations/${options.orgSlug}/issues/?project=${options.projectId}`
     : `https://${options.orgSlug}.sentry.io/issues/?project=${options.projectId}`;
 
   return `${

--- a/test/nextjs/templates.test.ts
+++ b/test/nextjs/templates.test.ts
@@ -1,0 +1,147 @@
+import { getWithSentryConfigOptionsTemplate } from '../../src/nextjs/templates';
+
+describe('NextJS code templates', () => {
+  describe('getWithSentryConfigOptionsTemplate', () => {
+    it('generates options for SaaS', () => {
+      const template = getWithSentryConfigOptionsTemplate({
+        orgSlug: 'my-org',
+        projectSlug: 'my-project',
+        selfHosted: false,
+        sentryUrl: 'https://dont-use-this-url.com',
+        tunnelRoute: true,
+      });
+
+      expect(template).toMatchInlineSnapshot(`
+        "{
+            // For all available options, see:
+            // https://github.com/getsentry/sentry-webpack-plugin#options
+
+            org: "my-org",
+            project: "my-project",
+
+            // Only print logs for uploading source maps in CI
+            silent: !process.env.CI,
+
+            // For all available options, see:
+            // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+            // Upload a larger set of source maps for prettier stack traces (increases build time)
+            widenClientFileUpload: true,
+
+            // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+            // This can increase your server load as well as your hosting bill.
+            // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+            // side errors will fail.
+            tunnelRoute: "/monitoring",
+
+            // Hides source maps from generated client bundles
+            hideSourceMaps: true,
+
+            // Automatically tree-shake Sentry logger statements to reduce bundle size
+            disableLogger: true,
+
+            // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+            // See the following for more information:
+            // https://docs.sentry.io/product/crons/
+            // https://vercel.com/docs/cron-jobs
+            automaticVercelMonitors: true,
+          }"
+      `);
+    });
+
+    it('generates options for self-hosted', () => {
+      const template = getWithSentryConfigOptionsTemplate({
+        orgSlug: 'my-org',
+        projectSlug: 'my-project',
+        selfHosted: true,
+        sentryUrl: 'https://my-sentry.com',
+        tunnelRoute: true,
+      });
+
+      expect(template).toMatchInlineSnapshot(`
+        "{
+            // For all available options, see:
+            // https://github.com/getsentry/sentry-webpack-plugin#options
+
+            org: "my-org",
+            project: "my-project",
+            sentryUrl: "https://my-sentry.com"
+
+            // Only print logs for uploading source maps in CI
+            silent: !process.env.CI,
+
+            // For all available options, see:
+            // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+            // Upload a larger set of source maps for prettier stack traces (increases build time)
+            widenClientFileUpload: true,
+
+            // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+            // This can increase your server load as well as your hosting bill.
+            // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+            // side errors will fail.
+            tunnelRoute: "/monitoring",
+
+            // Hides source maps from generated client bundles
+            hideSourceMaps: true,
+
+            // Automatically tree-shake Sentry logger statements to reduce bundle size
+            disableLogger: true,
+
+            // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+            // See the following for more information:
+            // https://docs.sentry.io/product/crons/
+            // https://vercel.com/docs/cron-jobs
+            automaticVercelMonitors: true,
+          }"
+      `);
+    });
+
+    it('comments out tunnelRoute if `tunnelRoute` option is disabled', () => {
+      const template = getWithSentryConfigOptionsTemplate({
+        orgSlug: 'my-org',
+        projectSlug: 'my-project',
+        selfHosted: false,
+        sentryUrl: 'https://dont-use-this-url.com',
+        tunnelRoute: false,
+      });
+
+      expect(template).toMatchInlineSnapshot(`
+        "{
+            // For all available options, see:
+            // https://github.com/getsentry/sentry-webpack-plugin#options
+
+            org: "my-org",
+            project: "my-project",
+
+            // Only print logs for uploading source maps in CI
+            silent: !process.env.CI,
+
+            // For all available options, see:
+            // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+            // Upload a larger set of source maps for prettier stack traces (increases build time)
+            widenClientFileUpload: true,
+
+            // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+            // This can increase your server load as well as your hosting bill.
+            // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+            // side errors will fail.
+            // tunnelRoute: "/monitoring",
+
+            // Hides source maps from generated client bundles
+            hideSourceMaps: true,
+
+            // Automatically tree-shake Sentry logger statements to reduce bundle size
+            disableLogger: true,
+
+            // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+            // See the following for more information:
+            // https://docs.sentry.io/product/crons/
+            // https://vercel.com/docs/cron-jobs
+            automaticVercelMonitors: true,
+          }"
+      `);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes a leftover from them v8 release where we replaced the `url` option with `sentryUrl` in the `withSentryConfig` options.

Also added a couple of tests for the template generation function. 

Fixes #578 