### PR TITLE
feat(nextjs): Detect typescript usage and emit files accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(nextjs): Detect typescript usage and emit files accordingly (#580)
+
 ## 3.22.3
 
 - feat(nextjs): Make example page resilient to

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -417,11 +417,14 @@ async function createOrMergeNextJsFiles(
     }
 
     if (instrumentationHookLocation === 'does-not-exist') {
+      const newInstrumentationFileName = `instrumentation.${
+        typeScriptDetected ? 'ts' : 'js'
+      }`;
       const srcFolderExists = fs.existsSync(path.join(process.cwd(), 'src'));
 
       const instrumentationHookPath = srcFolderExists
-        ? path.join(process.cwd(), 'src', 'instrumentation.ts')
-        : path.join(process.cwd(), 'instrumentation.ts');
+        ? path.join(process.cwd(), 'src', newInstrumentationFileName)
+        : path.join(process.cwd(), newInstrumentationFileName);
 
       const successfullyCreated = await createNewConfigFile(
         instrumentationHookPath,
@@ -430,7 +433,7 @@ async function createOrMergeNextJsFiles(
 
       if (!successfullyCreated) {
         await showCopyPasteInstructions(
-          'instrumentation.ts',
+          newInstrumentationFileName,
           getInstrumentationHookCopyPasteSnippet(
             srcFolderExists ? 'src' : 'root',
           ),

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -639,6 +639,8 @@ async function createExamplePage(
   const maybeAppDirPath = path.join(process.cwd(), 'app');
   const maybeSrcAppDirPath = path.join(srcDir, 'app');
 
+  const typeScriptDetected = isUsingTypeScript();
+
   let pagesLocation =
     fs.existsSync(maybePagesDirPath) &&
     fs.lstatSync(maybePagesDirPath).isDirectory()
@@ -685,12 +687,14 @@ async function createExamplePage(
       },
     );
 
+    const newPageFileName = `page.${typeScriptDetected ? 'tsx' : 'jsx'}`;
+
     await fs.promises.writeFile(
       path.join(
         process.cwd(),
         ...appLocation,
         'sentry-example-page',
-        'page.jsx',
+        newPageFileName,
       ),
       examplePageContents,
       { encoding: 'utf8', flag: 'w' },
@@ -698,7 +702,7 @@ async function createExamplePage(
 
     clack.log.success(
       `Created ${chalk.cyan(
-        path.join(...appLocation, 'sentry-example-page', 'page.jsx'),
+        path.join(...appLocation, 'sentry-example-page', newPageFileName),
       )}.`,
     );
 
@@ -709,13 +713,15 @@ async function createExamplePage(
       },
     );
 
+    const newRouteFileName = `route.${typeScriptDetected ? 'ts' : 'js'}`;
+
     await fs.promises.writeFile(
       path.join(
         process.cwd(),
         ...appLocation,
         'api',
         'sentry-example-api',
-        'route.js',
+        newRouteFileName,
       ),
       getSentryExampleAppDirApiRoute(),
       { encoding: 'utf8', flag: 'w' },
@@ -723,7 +729,12 @@ async function createExamplePage(
 
     clack.log.success(
       `Created ${chalk.cyan(
-        path.join(...appLocation, 'api', 'sentry-example-api', 'route.js'),
+        path.join(
+          ...appLocation,
+          'api',
+          'sentry-example-api',
+          newRouteFileName,
+        ),
       )}.`,
     );
   } else if (pagesLocation) {

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -66,6 +66,8 @@ export async function runNextjsWizardWithTelemetry(
     telemetryEnabled: options.telemetryEnabled,
   });
 
+  const typeScriptDetected = isUsingTypeScript();
+
   await confirmContinueIfNoOrDirtyGitRepo();
 
   const packageJson = await getPackageDotJson();
@@ -236,15 +238,19 @@ export async function runNextjsWizardWithTelemetry(
       : undefined;
 
     if (!globalErrorPageFile) {
+      const newGlobalErrorFileName = `global-error.${
+        typeScriptDetected ? 'tsx' : 'jsx'
+      }`;
+
       await fs.promises.writeFile(
-        path.join(process.cwd(), ...appDirLocation, 'global-error.jsx'),
+        path.join(process.cwd(), ...appDirLocation, newGlobalErrorFileName),
         getSentryDefaultGlobalErrorPage(),
         { encoding: 'utf8', flag: 'w' },
       );
 
       clack.log.success(
-        `Created ${chalk.cyan(
-          path.join(...appDirLocation, 'global-error.jsx'),
+        `testing Created ${chalk.cyan(
+          path.join(...appDirLocation, newGlobalErrorFileName),
         )}.`,
       );
     } else {

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -249,7 +249,7 @@ export async function runNextjsWizardWithTelemetry(
       );
 
       clack.log.success(
-        `testing Created ${chalk.cyan(
+        `Created ${chalk.cyan(
           path.join(...appDirLocation, newGlobalErrorFileName),
         )}.`,
       );


### PR DESCRIPTION
I've noticed that some of the generated file extensions are not consistent with the project being in JS or TS, this doesn't _actually_ impact much as next.js runs with both. 

Unsure if this is a desired change, if not, absolutely feel free to disregard and close. :)


### Description
Some minor file extension fixes for generated files on JS/TS projects.

### Fixes for JS projects:
- generated intrumention.**ts** -> instrumentation.**js**

### Fixes for TS projects:
- app/global-error.**jsx** -> app/global-error.**tsx**
- app/sentry-example-page/page.**jsx** -> app/sentry-example-page/page.**tsx**
- api/sentry-example-api/route.**js** -> api/sentry-example-api/route.**ts**

