### PR TITLE
fix(step-wizards): Show correct URL when prompting DSN (Backport to v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(step-wizards): Show correct URL when prompting DSN (#577) 
+
 ## 1.4.0
 
 - feat(react-native): Xcode plugin includes collect modules script ([#213](https://github.com/getsentry/sentry-wizard/pull/213))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(step-wizards): Show correct URL when prompting DSN (#577) 
+- fix(step-wizards): Show correct URL when prompting DSN (#581) 
 
 ## 1.4.0
 

--- a/lib/Steps/PromptForParameters.ts
+++ b/lib/Steps/PromptForParameters.ts
@@ -46,6 +46,7 @@ export class PromptForParameters extends BaseStep {
     ]);
 
     url = this._getFullUrl(answers, organization.slug, project.slug);
+    const dsnKeyUrl = this._getDSNKeyUrl(answers, project.slug);
     const dsn = await prompt([
       {
         message: 'DSN:',
@@ -55,7 +56,7 @@ export class PromptForParameters extends BaseStep {
         validate: this._validateDSN,
         when: this._shouldAsk(answers, 'config.dsn.secret', () => {
           dim('Please copy/paste your DSN');
-          dim(`It can be found here: ${url}`);
+          dim(`It can be found here: ${dsnKeyUrl}`);
         }),
       },
     ]);
@@ -104,6 +105,16 @@ export class PromptForParameters extends BaseStep {
       projectSlug || 'project_slug',
     );
     return `${baseUrl}${orgSlug}/${projSlug}`;
+  }
+
+  private _getDSNKeyUrl(answers: Answers, projectSlug?: string): string {
+    const baseUrl = this._argv.url;
+    const projSlug = _.get(
+      answers,
+      'config.project.slug',
+      projectSlug || 'project_slug',
+    );
+    return `${baseUrl}settings/projects/${projSlug}/keys`;
   }
 
   private _shouldAsk(


### PR DESCRIPTION
This PR backports #577 to version 1 of the wizard.

Created `1.x` branch from which we can cut future 1.x releases and backport fixes to.

Why create a 1.x release in 2024? Because RN documentation still references using `@sentry/wizard@1` in [the docs](https://docs.sentry.io/platforms/react-native/troubleshooting/#set-up-sdk-v4-with-react-native-069-or-higher).

Initial PR against `master` created by @hisamafahri  