### PR TITLE
chore(v1/publish): Set `v1` as NPM tag instead of `latest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "bin": {
     "sentry-wizard": "dist/bin.js"
   },
+  "publishConfig": {
+    "access": "public",
+    "tag": "v1"
+  },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "typescript": {


### PR DESCRIPTION
Prevents NPM from assigning `latest` so that we can release a v1 version without having to release an actual new, latest version directly afterwards

#skip-changelog