### PR TITLE
chore(1.x/publish): Use `craft.yml` from 1.x branch for 1.x releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          craft_config_from_merge_target: true


### PR DESCRIPTION
depends on https://github.com/getsentry/publish/pull/3950