### PR TITLE
Update CHANGELOG for 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.1
 
 - fix(step-wizards): Show correct URL when prompting DSN (#581) 
 


### PR DESCRIPTION
Seems like the changelog policy for 1.x is different than for 3.x so this manually changes the changelog version