### PR TITLE
fix(v1/publish): Pass on `merge_target` property

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,11 @@ on:
         description: Force a release even when there are release-blockers (optional)
         required: false
       merge_target:
-        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        description:
+          Target branch to merge into. Uses the default branch as a fallback
+          (optional)
         required: false
+        default: master
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,4 +32,5 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}
           craft_config_from_merge_target: true


### PR DESCRIPTION
So apparently I was wrong in #588 and manually dispatching workflows is just confusing:

* The `master` version of the workflow has a merge target input field
* But, when I run the action from another branch like `1.x`, this version of the release workflow is used, but with the GUI from the default branch.
* So you could in fact set a merge target branch as always but the `1.x` release workflow was missing this input parameter and hence didn't pass it on to `getsentry/action-prepare-release`.

This PR adds the merge target option to the `1.x` release workflow and makes sure that the input value is passed on to `getsentry/action-prepare-release`.