### PR TITLE
fix(nextjs): Fix Types of GlobalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Fix Types of GlobalError (#592)
+
 ## 3.23.2
 
 - feat(nextjs): Detect typescript usage and emit files accordingly (#580)

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -244,7 +244,7 @@ export async function runNextjsWizardWithTelemetry(
 
       await fs.promises.writeFile(
         path.join(process.cwd(), ...appDirLocation, newGlobalErrorFileName),
-        getSentryDefaultGlobalErrorPage(),
+        getSentryDefaultGlobalErrorPage(typeScriptDetected),
         { encoding: 'utf8', flag: 'w' },
       );
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -393,7 +393,10 @@ export default function GlobalError({ error }: { error: Error & { digest?: strin
   return (
     <html>
       <body>
-        {/* Passing \`0\` as \`statusCode\` as the type has to be a number, but we do not get a status code here. */}
+        {/* \`NextError\` is the default Next.js error page component. Its type
+        definition requires a \`statusCode\` prop. However, since the App Router
+        does not expose status codes for errors, we simply pass 0 to render a
+        generic error message. */}
         <NextError statusCode={0} />
       </body>
     </html>

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -385,7 +385,7 @@ import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
-export default function GlobalError({ error }: { error: NextError & { digest?: string } }) {
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -393,12 +393,12 @@ export default function GlobalError({ error }: { error: NextError & { digest?: s
   return (
     <html>
       <body>
-        <NextError statusCode={error.props?.statusCode || 0} />
+        {/* Passing \`0\` as \`statusCode\` as the type has to be a number, but we do not get a status code here. */}
+        <NextError statusCode={0} />
       </body>
     </html>
   );
-}
-`
+}`
     : `"use client";
 
 import * as Sentry from "@sentry/nextjs";

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -377,11 +377,32 @@ export function getInstrumentationHookCopyPasteSnippet(
   });
 }
 
-export function getSentryDefaultGlobalErrorPage() {
-  return `"use client";
+export function getSentryDefaultGlobalErrorPage(isTs: boolean) {
+  return isTs
+    ? `"use client";
 
 import * as Sentry from "@sentry/nextjs";
-import Error from "next/error";
+import NextError from "next/error";
+import { useEffect } from "react";
+
+export default function GlobalError({ error }: { error: NextError & { digest?: string } }) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <NextError statusCode={error.props?.statusCode || 0} />
+      </body>
+    </html>
+  );
+}
+`
+    : `"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import NextError from "next/error";
 import { useEffect } from "react";
 
 export default function GlobalError({ error }) {
@@ -392,7 +413,7 @@ export default function GlobalError({ error }) {
   return (
     <html>
       <body>
-        <Error />
+        <NextError statusCode={error.props?.statusCode || 0} />
       </body>
     </html>
   );

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -416,7 +416,11 @@ export default function GlobalError({ error }) {
   return (
     <html>
       <body>
-        <NextError statusCode={error.props?.statusCode || 0} />
+        {/* \`NextError\` is the default Next.js error page component. Its type
+        definition requires a \`statusCode\` prop. However, since the App Router
+        does not expose status codes for errors, we simply pass 0 to render a
+        generic error message. */}
+        <NextError statusCode={0} />
       </body>
     </html>
   );


### PR DESCRIPTION
Adding a TS snippet for `GlobalError`. 
fixes https://github.com/getsentry/sentry-javascript/issues/12520