### PR TITLE
fix(nextjs): Add trailing comma to `sentryUrl` option in `withSentryConfig` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Add trailing comma to `sentryUrl` option in `withSentryConfig` template (#601)
+
 ## 3.24.0
 
 - feat(remix): Switch to OTEL setup (#593)

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -22,7 +22,7 @@ export function getWithSentryConfigOptionsTemplate({
 
     org: "${orgSlug}",
     project: "${projectSlug}",${
-    selfHosted ? `\n    sentryUrl: "${sentryUrl}"` : ''
+    selfHosted ? `\n    sentryUrl: "${sentryUrl}",` : ''
   }
 
     // Only print logs for uploading source maps in CI

--- a/test/nextjs/templates.test.ts
+++ b/test/nextjs/templates.test.ts
@@ -65,7 +65,7 @@ describe('NextJS code templates', () => {
 
             org: "my-org",
             project: "my-project",
-            sentryUrl: "https://my-sentry.com"
+            sentryUrl: "https://my-sentry.com",
 
             // Only print logs for uploading source maps in CI
             silent: !process.env.CI,


### PR DESCRIPTION
A trailing comma is missing when selecting `selfHosted` when running the `sentry-wizard`.

<img width="575" alt="image" src="https://github.com/getsentry/sentry-wizard/assets/9056632/c3ac5697-32c9-421c-bc86-3e8ce78228ff">
