### PR TITLE
feat(remix): Update `start` script for built-in Remix servers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(remix): Switch to OTEL setup (#593)
+- feat(remix): Update `start` script for built-in Remix servers (#604)
 - deps: Bump glob to `10.4.2` (#599)
 
 ## 3.23.3

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -177,16 +177,19 @@ async function runRemixWizardWithTelemetry(
   );
 
   if (!serverFileInstrumented && instrumentationFile) {
-    await traceStep('Initialize Sentry on server entry', async () => {
-      try {
-        await updateStartScript(instrumentationFile);
-      } catch (e) {
-        clack.log
-          .warn(`Could not automatically add Sentry initialization to server entry.
+    await traceStep(
+      'Update `start` script to import instrumentation file.',
+      async () => {
+        try {
+          await updateStartScript(instrumentationFile);
+        } catch (e) {
+          clack.log
+            .warn(`Could not automatically add Sentry initialization to server entry.
     Please do it manually using instructions from https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup/`);
-        debug(e);
-      }
-    });
+          debug(e);
+        }
+      },
+    );
   }
 
   await traceStep('Instrument server `handleError`', async () => {

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -18,13 +18,15 @@ import { hasPackageInstalled } from '../utils/package-json';
 import { WizardOptions } from '../utils/types';
 import {
   initializeSentryOnEntryClient,
-  initializeSentryOnEntryServer,
+  instrumentSentryOnEntryServer,
   updateBuildScript,
   instrumentRootRoute,
   isRemixV2,
   loadRemixConfig,
   runRemixReveal,
   insertServerInstrumentationFile,
+  createServerInstrumentationFile,
+  updateStartScript,
 } from './sdk-setup';
 import { debug } from '../utils/debug';
 import { traceStep, withTelemetry } from '../telemetry';
@@ -145,13 +147,26 @@ async function runRemixWizardWithTelemetry(
     }
   });
 
-  let customServerInstrumented = false;
+  let instrumentationFile = '';
+
+  await traceStep('Create server instrumentation file', async () => {
+    try {
+      instrumentationFile = await createServerInstrumentationFile(dsn);
+    } catch (e) {
+      clack.log.warn(
+        'Could not create a server instrumentation file. Please do it manually using instructions from https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup/',
+      );
+      debug(e);
+    }
+  });
+
+  let serverFileInstrumented = false;
 
   await traceStep(
     'Create server instrumentation file and import it',
     async () => {
       try {
-        customServerInstrumented = await insertServerInstrumentationFile(dsn);
+        serverFileInstrumented = await insertServerInstrumentationFile(dsn);
       } catch (e) {
         clack.log.warn(
           'Could not create a server instrumentation file. Please do it manually using instructions from https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup/',
@@ -161,10 +176,10 @@ async function runRemixWizardWithTelemetry(
     },
   );
 
-  if (!customServerInstrumented) {
+  if (!serverFileInstrumented && instrumentationFile) {
     await traceStep('Initialize Sentry on server entry', async () => {
       try {
-        await initializeSentryOnEntryServer(dsn, isV2, isTS);
+        await updateStartScript(instrumentationFile);
       } catch (e) {
         clack.log
           .warn(`Could not automatically add Sentry initialization to server entry.
@@ -173,6 +188,16 @@ async function runRemixWizardWithTelemetry(
       }
     });
   }
+
+  await traceStep('Instrument server `handleError`', async () => {
+    try {
+      await instrumentSentryOnEntryServer(isV2, isTS);
+    } catch (e) {
+      clack.log.warn(`Could not initialize Sentry on server entry.
+  Please do it manually using instructions from https://docs.sentry.io/platforms/javascript/guides/remix/manual-setup/`);
+      debug(e);
+    }
+  });
 
   const shouldCreateExamplePage = await askShouldCreateExamplePage();
 

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -362,6 +362,30 @@ export async function updateStartScript(instrumentationFile: string) {
     );
   }
 
+  if (packageJson.scripts.start.includes('NODE_OPTIONS')) {
+    clack.log.warn(
+      `Found existing NODE_OPTIONS in ${chalk.cyan(
+        'start',
+      )} script. Skipping adding Sentry initialization.`,
+    );
+
+    return;
+  }
+
+  if (
+    !packageJson.scripts.start.includes('remix-serve') &&
+    // Adding a following empty space not to match a path that includes `node`
+    !packageJson.scripts.start.includes('node ')
+  ) {
+    clack.log.warn(
+      `Found a ${chalk.cyan('start')} script that doesn't use ${chalk.cyan(
+        'remix-serve',
+      )} or ${chalk.cyan('node')}. Skipping adding Sentry initialization.`,
+    );
+
+    return;
+  }
+
   const startCommand = packageJson.scripts.start;
 
   packageJson.scripts.start = `NODE_OPTIONS='--import ./${instrumentationFile}' ${startCommand}`;

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -356,11 +356,7 @@ export async function initializeSentryOnEntryClient(
 export async function updateStartScript(instrumentationFile: string) {
   const packageJson = await getPackageDotJson();
 
-  if (!packageJson.scripts) {
-    packageJson.scripts = {};
-  }
-
-  if (!packageJson.scripts.start) {
+  if (!packageJson.scripts || !packageJson.scripts.start) {
     throw new Error(
       "Couldn't find a `start` script in your package.json. Please add one manually.",
     );


### PR DESCRIPTION
Updates `start` script in `package.json` with `NODE_OPTIONS="--import ..."` when the server instrumentation file is not imported inside server file (or server file does not exist).