### PR TITLE
feat(nextjs): check for '[lang]' folder structure when creating example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(remix): Switch to OTEL setup (#593)
 - feat(remix): Update `start` script for built-in Remix servers (#604)
 - deps: Bump glob to `10.4.2` (#599)
+- feat(nextjs): Check for '[lang]' folder structure when creating example page ([#605](https://github.com/getsentry/sentry-wizard/pull/605))
 
 ## 3.23.3
 

--- a/lib/Helper/File.ts
+++ b/lib/Helper/File.ts
@@ -49,6 +49,10 @@ export function exists(globPattern: string): boolean {
   }, true);
 }
 
+export function directoryExists(dirPath: string): boolean {
+  return exists(dirPath) && fs.lstatSync(dirPath).isDirectory();
+}
+
 export function matchesContent(
   globPattern: string,
   contentPattern: RegExp,


### PR DESCRIPTION
Currently, for my project where pages are placed in `src/app/[lang]`, it will place the example page in the wrong place and it has to be manually moved.