### PR TITLE
fix(nextjs): Update instrumentation and example creation logic for `app` or `pages` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Support instrumentation file in `app` folder (#629)
+
 ## 3.25.2
 
 - ref: Improve intro and wizard selection (#625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(nextjs): Support instrumentation file in `app` folder (#629)
+- fix(nextjs): Update instrumentation and example creation logic for app or pages usage (#629)
 
 ## 3.25.2
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -412,9 +412,18 @@ async function createOrMergeNextJsFiles(
     const instrumentationJsExists = fs.existsSync(
       path.join(process.cwd(), 'instrumentation.js'),
     );
+    const appInstrumentationTsExists = fs.existsSync(
+      path.join(process.cwd(), 'app', 'instrumentation.ts'),
+    );
+    const appInstrumentationJsExists = fs.existsSync(
+      path.join(process.cwd(), 'app', 'instrumentation.js'),
+    );
 
-    let instrumentationHookLocation: 'src' | 'root' | 'does-not-exist';
-    if (srcInstrumentationTsExists || srcInstrumentationJsExists) {
+    let instrumentationHookLocation: 'src' | 'root' | 'app' | 'does-not-exist';
+
+    if (appInstrumentationTsExists || appInstrumentationJsExists) {
+      instrumentationHookLocation = 'app';
+    } else if (srcInstrumentationTsExists || srcInstrumentationJsExists) {
       instrumentationHookLocation = 'src';
     } else if (instrumentationTsExists || instrumentationJsExists) {
       instrumentationHookLocation = 'root';
@@ -441,18 +450,23 @@ async function createOrMergeNextJsFiles(
         await showCopyPasteInstructions(
           newInstrumentationFileName,
           getInstrumentationHookCopyPasteSnippet(
+            // If src folder does not exist,
+            // we don't instruct the user to put it inside the `app/` folder.
+            // We instruct to put it in the root folder
             srcFolderExists ? 'src' : 'root',
           ),
         );
       }
     } else {
       await showCopyPasteInstructions(
-        srcInstrumentationTsExists
+        srcInstrumentationTsExists ||
+          appInstrumentationTsExists ||
+          instrumentationTsExists
           ? 'instrumentation.ts'
-          : srcInstrumentationJsExists
+          : srcInstrumentationJsExists ||
+            appInstrumentationJsExists ||
+            instrumentationJsExists
           ? 'instrumentation.js'
-          : instrumentationTsExists
-          ? 'instrumentation.ts'
           : 'instrumentation.js',
         getInstrumentationHookCopyPasteSnippet(instrumentationHookLocation),
       );

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -261,7 +261,7 @@ export default function Page() {
 `;
 }
 
-export function getSentryExampleApiRoute() {
+export function getSentryExamplePagesDirApiRoute() {
   return `// A faulty API route to test Sentry's error monitoring
 export default function handler(_req, res) {
   throw new Error("Sentry Example API Route Error");
@@ -339,7 +339,7 @@ YourCustomErrorComponent.getInitialProps = async (contextData${
 }
 
 export function getInstrumentationHookContent(
-  instrumentationHookLocation: 'src' | 'root' | 'app',
+  instrumentationHookLocation: 'src' | 'root',
 ) {
   return `export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
@@ -358,7 +358,7 @@ export function getInstrumentationHookContent(
 }
 
 export function getInstrumentationHookCopyPasteSnippet(
-  instrumentationHookLocation: 'src' | 'root' | 'app',
+  instrumentationHookLocation: 'src' | 'root',
 ) {
   return makeCodeSnippet(true, (unchanged, plus) => {
     return unchanged(`export ${plus('async')} function register() {

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -312,7 +312,7 @@ ${chalk.dim(
   '// Replace "YourCustomErrorComponent" with your custom error component!',
 )}
 YourCustomErrorComponent.getInitialProps = async (${chalk.green(
-    `contextData`,
+    'contextData',
   )}) => {
   ${chalk.green('await Sentry.captureUnderscoreErrorException(contextData);')}
 
@@ -339,7 +339,7 @@ YourCustomErrorComponent.getInitialProps = async (contextData${
 }
 
 export function getInstrumentationHookContent(
-  instrumentationHookLocation: 'src' | 'root',
+  instrumentationHookLocation: 'src' | 'root' | 'app',
 ) {
   return `export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
@@ -358,7 +358,7 @@ export function getInstrumentationHookContent(
 }
 
 export function getInstrumentationHookCopyPasteSnippet(
-  instrumentationHookLocation: 'src' | 'root',
+  instrumentationHookLocation: 'src' | 'root' | 'app',
 ) {
   return makeCodeSnippet(true, (unchanged, plus) => {
     return unchanged(`export ${plus('async')} function register() {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/12619

Resolves: https://github.com/getsentry/sentry-wizard/issues/633

This PR aligns the wizard to comply with NextJS's project structure.

1 - NextJS [expects the instrumentation hook either inside the root or inside the `src`  directory](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation#:~:text=The%20instrumentation%20file%20should%20be%20in%20the%20root%20of%20your%20project%20and%20not%20inside%20the%20app%20or%20pages%20directory.%20If%20you%27re%20using%20the%20src%20folder%2C%20then%20place%20the%20file%20inside%20src%20alongside%20pages%20and%20app.). So the wizard looks for it and puts it inside `src` if it exists, and there are no `pages` or `app` folder. Otherwise it puts it on the root directory.

2 - Refactors the example page creation logic, prioritising `app` folder over `pages` when they coexist.

Tested the potential cases below, which wizard-created instrumentation is working fine for all of them.

| Structure                 	| Instrumentation Hook 	| Example Page       	|
|---------------------------	|----------------------	|--------------------	|
| Only `pages` on root      	| inside root          	| inside `pages`     	|
| Only `app` on root        	| inside root          	| inside `app`       	|
| `app` inside `src`        	| inside `src`         	| inside `src/app`   	|
| `pages` inside `src`      	| inside `src`         	| inside `src/pages` 	|
| `pages` and `app` on root 	| inside root          	| inside `app`   	|
| `pages` and `src` on root 	| inside root          	| inside `pages`   	|