### PR TITLE
feat(nextjs): Support all `next.config` file types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(nextjs): Support all `next.config` file types (#630)
+
 ## 3.25.2
 
 - ref: Improve intro and wizard selection (#625)


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-wizard/issues/627

Added support for `cjs`, `ts`, `cts` and `mts` file extensions.