### PR TITLE
fix: Add missing `Error.getInitialProps` calls in Next.js error page snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(nextjs): Support all `next.config` file types (#630)
 - fix(nextjs): Update instrumentation and example creation logic for app or pages usage (#629)
+- fix(nextjs): Add missing Error.getInitialProps calls in Next.js error page snippets (#632)
 
 ## 3.25.2
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -307,6 +307,7 @@ export default CustomErrorComponent;
 export function getSimpleUnderscoreErrorCopyPasteSnippet() {
   return `
 ${chalk.green(`import * as Sentry from '@sentry/nextjs';`)}
+${chalk.green(`import Error from "next/error";`)}
 
 ${chalk.dim(
   '// Replace "YourCustomErrorComponent" with your custom error component!',
@@ -317,6 +318,8 @@ YourCustomErrorComponent.getInitialProps = async (${chalk.green(
   ${chalk.green('await Sentry.captureUnderscoreErrorException(contextData);')}
 
   ${chalk.dim('// ...other getInitialProps code')}
+
+  return Error.getInitialProps(contextData);
 };
 `;
 }
@@ -326,6 +329,7 @@ export function getFullUnderscoreErrorCopyPasteSnippet(isTs: boolean) {
 import * as Sentry from '@sentry/nextjs';${
     isTs ? '\nimport type { NextPageContext } from "next";' : ''
   }
+import Error from "next/error";
 
 ${chalk.dim(
   '// Replace "YourCustomErrorComponent" with your custom error component!',
@@ -334,6 +338,8 @@ YourCustomErrorComponent.getInitialProps = async (contextData${
     isTs ? ': NextPageContext' : ''
   }) => {
   await Sentry.captureUnderscoreErrorException(contextData);
+
+  return Error.getInitialProps(contextData);
 };
 `;
 }


### PR DESCRIPTION
Without this call, the following error occurs when the Error page is invoked:
> TypeError: Cannot set properties of undefined (setting '_sentryTraceData')

as described in https://github.com/getsentry/sentry-javascript/issues/5906