### PR TITLE
feat: Improve error logging for package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - feat(nextjs): Support all `next.config` file types (#630)
 - fix(nextjs): Update instrumentation and example creation logic for app or pages usage (#629)
+- Improve error logging for package installation (#635)
+
 
 ## 3.25.2
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -15,7 +15,6 @@ import { traceStep } from '../telemetry';
 import {
   detectPackageManger,
   PackageManager,
-  installPackageWithPackageManager,
   packageManagers,
 } from './package-manager';
 import { debug } from './debug';
@@ -383,7 +382,31 @@ export async function installPackage({
     );
 
     try {
-      await installPackageWithPackageManager(packageManager, packageName);
+      await new Promise<void>((resolve, reject) => {
+        childProcess.exec(
+          `${packageManager.installCommand} ${packageName} ${packageManager.flags}`,
+          (err, stdout, stderr) => {
+            if (err) {
+              // Write a log file so we can better troubleshoot issues
+              fs.writeFileSync(
+                path.join(
+                  process.cwd(),
+                  `sentry-wizard-installation-error-${Date.now()}.log`,
+                ),
+                JSON.stringify({
+                  stdout,
+                  stderr,
+                }),
+                { encoding: 'utf8' },
+              );
+
+              reject(err);
+            } else {
+              resolve();
+            }
+          },
+        );
+      });
     } catch (e) {
       sdkInstallSpinner.stop('Installation failed.');
       clack.log.error(
@@ -391,7 +414,7 @@ export async function installPackage({
           'Encountered the following error during installation:',
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         )}\n\n${e}\n\n${chalk.dim(
-          'If you think this issue is caused by the Sentry wizard, let us know here:\nhttps://github.com/getsentry/sentry-wizard/issues',
+          "The wizard has created a `sentry-wizard-installation-error-*.log` file. If you think this issue is caused by the Sentry wizard, create an issue on GitHub and include the log file's content:\nhttps://github.com/getsentry/sentry-wizard/issues",
         )}`,
       );
       await abort();

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/typedef */
-import { exec } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { promisify } from 'util';
 
 import * as Sentry from '@sentry/node';
 import { traceStep } from '../telemetry';
@@ -15,6 +13,7 @@ export interface PackageManager {
   buildCommand: string;
   /* The command that the package manager uses to run a script from package.json */
   runScriptCommand: string;
+  flags: string;
 }
 
 export const BUN: PackageManager = {
@@ -24,6 +23,7 @@ export const BUN: PackageManager = {
   installCommand: 'bun add',
   buildCommand: 'bun run build',
   runScriptCommand: 'bun run',
+  flags: '',
 };
 export const YARN: PackageManager = {
   name: 'yarn',
@@ -32,6 +32,7 @@ export const YARN: PackageManager = {
   installCommand: 'yarn add',
   buildCommand: 'yarn build',
   runScriptCommand: 'yarn',
+  flags: '--ignore-workspace-root-check',
 };
 export const PNPM: PackageManager = {
   name: 'pnpm',
@@ -40,6 +41,7 @@ export const PNPM: PackageManager = {
   installCommand: 'pnpm add',
   buildCommand: 'pnpm build',
   runScriptCommand: 'pnpm',
+  flags: '--ignore-workspace-root-check',
 };
 export const NPM: PackageManager = {
   name: 'npm',
@@ -48,6 +50,7 @@ export const NPM: PackageManager = {
   installCommand: 'npm add',
   buildCommand: 'npm run build',
   runScriptCommand: 'npm run',
+  flags: '',
 };
 
 export const packageManagers = [BUN, YARN, PNPM, NPM];
@@ -63,11 +66,4 @@ export function detectPackageManger(): PackageManager | null {
     Sentry.setTag('package-manager', 'not-detected');
     return null;
   });
-}
-
-export async function installPackageWithPackageManager(
-  packageManager: PackageManager,
-  packageName: string,
-): Promise<void> {
-  await promisify(exec)(`${packageManager.installCommand} ${packageName}`);
 }


### PR DESCRIPTION
- Emits a `.log` file when package installation fails
- Updates the resulting log message to instruct the user to include the log file in the issue
- Adds flags to the package manager commands to ignore potential errors when running the wizard in the workspace root (noticed this to be an issue in our docs repo for example)

Relates to https://github.com/getsentry/sentry-wizard/issues/553