### PR TITLE
fix: Properly close open handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - feat(nextjs): Prompt for `reactComponentAnnotation` (#634)
 - fix(nextjs): Add missing Error.getInitialProps calls in Next.js error page snippets (#632)
 - fix/feat: Improve error logging for package installation (#635)
+- fix: Properly close open handles (#638)
 
 ## 3.25.2
 

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -48,7 +48,7 @@ export class OpenSentry extends BaseStep {
 
       const urlToOpen = urlObj.toString();
 
-      opn(urlToOpen).catch(() => {
+      opn(urlToOpen, { wait: false }).catch(() => {
         // opn throws in environments that don't have a browser (e.g. remote shells) so we just noop here
       });
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,6 +8,7 @@ import {
   runWithAsyncContext,
   setTag,
   startSpan,
+  flush,
 } from '@sentry/node';
 import packageJson from '../package.json';
 
@@ -49,7 +50,12 @@ export async function withTelemetry<F>(
     throw e;
   } finally {
     sentryHub.endSession();
-    await sentryClient.flush(3000);
+    await sentryClient.flush(3000).then(null, () => {
+      // If telemetry flushing fails we generally don't care
+    });
+    await flush(3000).then(null, () => {
+      // If telemetry flushing fails we generally don't care
+    });
   }
 }
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -22,6 +22,9 @@ import { fulfillsVersionRange } from './semver';
 
 const opn = require('opn') as (
   url: string,
+  options?: {
+    wait?: boolean;
+  },
 ) => Promise<childProcess.ChildProcess>;
 
 export const SENTRY_DOT_ENV_FILE = '.env.sentry-build-plugin';
@@ -992,7 +995,7 @@ async function askForWizardLogin(options: {
     )}\n\n${chalk.cyan(urlToOpen)}`,
   );
 
-  opn(urlToOpen).catch(() => {
+  opn(urlToOpen, { wait: false }).catch(() => {
     // opn throws in environments that don't have a browser (e.g. remote shells) so we just noop here
   });
 


### PR DESCRIPTION
I used some dark magic debugging techniques and found that at the time the wizard was completing there were 2 open non-TTY handles:
- The telemetry flushing socket to Sentry (this one likely didn't prevent the process from exiting, at least until the flushing completed)
- A child process `'open -W https://sentry.io/account/settings/wizard/asdfadsf/'`

This PR should fix https://github.com/getsentry/sentry-wizard/issues/636 by adding the `wait: false` option to `opn`. I have no idea why this became a problem just now. Maybe with the recent bump of yargs in #625 it wasn't delegated to a non-blocking child process anymore or something (idk).