### PR TITLE
fix: Fix issue stream URL for self-hosted instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - feat(nextjs): Add feature selection (#631)
+- fix: Fix issue stream URL for self-hosted instances (#645)
+
+Work in this release contributed by @MaximAL. Thank you for your contributions!
 
 ## 3.26.0
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,8 +15,12 @@ export function getIssueStreamUrl({
   projectId: string;
 }): string {
   const urlObject = new URL(url);
-  urlObject.host = `${orgSlug}.${urlObject.host}`;
-  urlObject.pathname = '/issues/';
+  if (urlObject.host === 'sentry.io') {
+    urlObject.host = `${orgSlug}.${urlObject.host}`;
+    urlObject.pathname = '/issues/';
+  } else {
+    urlObject.pathname = `/organizations/${orgSlug}/issues/`;
+  }
   urlObject.searchParams.set('project', projectId);
 
   return urlObject.toString();


### PR DESCRIPTION
Otherwise, the wizard would print something like
```
https://org-slug.my-sentry-instance.domain.org/issues/?project=666
```
intead of the correct one
```
https://my-sentry-instance.domain.org/organizations/org-slug/issues/?project=666
```
