### PR TITLE
ref(nextjs): Adjust dev server command in verification message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref(nextjs): Adjust dev server command in verification message (#665)
+
 ## 3.28.0
 
 - feat(nextjs): Warn about Turbopack incompatibility (#657)

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -20,6 +20,7 @@ import {
   featureSelectionPrompt,
   getOrAskForProjectData,
   getPackageDotJson,
+  getPackageManager,
   installPackage,
   isUsingTypeScript,
   printWelcome,
@@ -328,12 +329,14 @@ export async function runNextjsWizardWithTelemetry(
     await traceStep('configure-ci', () => configureCI('nextjs', authToken));
   }
 
+  const pacMan = await getPackageManager();
+
   clack.outro(`${chalk.green(
     'Successfully installed the Sentry Next.js SDK!',
   )}${
     shouldCreateExamplePage
-      ? `\n\nYou can validate your setup by (re)starting your dev environment (${chalk.cyan(
-          `next dev`,
+      ? `\n\nYou can validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
+          `${pacMan.runScriptCommand} dev`,
         )}) and visiting ${chalk.cyan('"/sentry-example-page"')}`
       : ''
   }${

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -734,7 +734,7 @@ export async function getPackageDotJson(): Promise<PackageDotJson> {
   return packageJson || {};
 }
 
-async function getPackageManager(): Promise<PackageManager> {
+export async function getPackageManager(): Promise<PackageManager> {
   const detectedPackageManager = detectPackageManger();
 
   if (detectedPackageManager) {


### PR DESCRIPTION
Reported by @vgrozdanic 

The `next dev` command is usually not directly used by people but rather the wrapping package.json script. So this PR now shows `<pacMan run> dev` instead of `next dev`.

![image](https://github.com/user-attachments/assets/3245cb21-d581-4137-92ac-9d1af99dcf64)
