### PR TITLE
fix(remix): Don't create `.sentrclirc` if project uses Vite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - ref(nextjs): Adjust dev server command in verification message (#665)
 - feat(remix): Add feature selection (#646)
+- fix(remix): Don't create `.sentrclirc` if project uses Vite (#667)
 
 ## 3.28.0
 

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -94,8 +94,6 @@ async function runRemixWizardWithTelemetry(
     },
   ] as const);
 
-  await addSentryCliConfig({ authToken }, rcCliSetupConfig);
-
   if (viteConfig) {
     await traceStep(
       'Update vite configuration for sourcemap uploads',
@@ -125,6 +123,8 @@ async function runRemixWizardWithTelemetry(
           url: sentryUrl === DEFAULT_URL ? undefined : sentryUrl,
           isHydrogen: isHydrogenApp(packageJson),
         });
+
+        await addSentryCliConfig({ authToken }, rcCliSetupConfig);
       } catch (e) {
         clack.log
           .warn(`Could not update build script to generate and upload sourcemaps.


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-wizard/issues/664

We need `.sentryclirc` file for the projects that do not use Vite, where we update the `build` script in `package.json` to use `sentry-upload-sourcemaps`. 

It is currently creating both for projects using Vite, so I moved it to where we update the build script instead. 