### PR TITLE
feat: allow passing or and project slug parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- allow passing or and project slug parameters
+- feat: Allow passing or and project slug parameters
   ([#671](https://github.com/getsentry/sentry-wizard/pull/671))
 
 ## 3.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: Allow passing or and project slug parameters (#671)
+- feat: Allow passing org and project slug parameters (#671)
 
 ## 3.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,11 @@ Work in this release contributed by @MaximAL. Thank you for your contributions!
 
 ## 3.26.0
 
-- fix(nextjs): Don't add '.env.sentry-build-plugin' to .gitignore if it's
-  already there (#610)
+- fix(nextjs): Don't add '.env.sentry-build-plugin' to .gitignore if it's already there (#610)
 - feat(nextjs): Support all `next.config` file types (#630)
-- fix(nextjs): Update instrumentation and example creation logic for app or
-  pages usage (#629)
+- fix(nextjs): Update instrumentation and example creation logic for app or pages usage (#629)
 - feat(nextjs): Prompt for `reactComponentAnnotation` (#634)
-- fix(nextjs): Add missing Error.getInitialProps calls in Next.js error page
-  snippets (#632)
+- fix(nextjs): Add missing Error.getInitialProps calls in Next.js error page snippets (#632)
 - fix/feat: Improve error logging for package installation (#635)
 - fix: Properly close open handles (#638)
 
@@ -54,8 +51,7 @@ Work in this release contributed by @MaximAL. Thank you for your contributions!
 
 ## 3.24.1
 
-- fix(nextjs): Add trailing comma to `sentryUrl` option in `withSentryConfig`
-  template (#601)
+- fix(nextjs): Add trailing comma to `sentryUrl` option in `withSentryConfig` template (#601)
 
 ## 3.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- feat: Allow passing or and project slug parameters
-  ([#671](https://github.com/getsentry/sentry-wizard/pull/671))
+- feat: Allow passing or and project slug parameters (#671)
 
 ## 3.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- allow passing or and project slug parameters
+  ([#671](https://github.com/getsentry/sentry-wizard/pull/671))
+
 ## 3.29.0
 
 - ref(nextjs): Adjust dev server command in verification message (#665)
@@ -25,11 +30,14 @@ Work in this release contributed by @MaximAL. Thank you for your contributions!
 
 ## 3.26.0
 
-- fix(nextjs): Don't add '.env.sentry-build-plugin' to .gitignore if it's already there (#610)
+- fix(nextjs): Don't add '.env.sentry-build-plugin' to .gitignore if it's
+  already there (#610)
 - feat(nextjs): Support all `next.config` file types (#630)
-- fix(nextjs): Update instrumentation and example creation logic for app or pages usage (#629)
+- fix(nextjs): Update instrumentation and example creation logic for app or
+  pages usage (#629)
 - feat(nextjs): Prompt for `reactComponentAnnotation` (#634)
-- fix(nextjs): Add missing Error.getInitialProps calls in Next.js error page snippets (#632)
+- fix(nextjs): Add missing Error.getInitialProps calls in Next.js error page
+  snippets (#632)
 - fix/feat: Improve error logging for package installation (#635)
 - fix: Properly close open handles (#638)
 
@@ -47,7 +55,8 @@ Work in this release contributed by @MaximAL. Thank you for your contributions!
 
 ## 3.24.1
 
-- fix(nextjs): Add trailing comma to `sentryUrl` option in `withSentryConfig` template (#601)
+- fix(nextjs): Add trailing comma to `sentryUrl` option in `withSentryConfig`
+  template (#601)
 
 ## 3.24.0
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,7 +39,7 @@ type Args = {
 
   url?: string;
   platform?: Platform[];
-  slug?: string;
+  project?: string;
 };
 
 export async function run(argv: Args) {
@@ -81,7 +81,7 @@ export async function run(argv: Args) {
     telemetryEnabled: !argv.disableTelemetry,
     promoCode: argv.promoCode,
     url: argv.url,
-    slug: argv.slug,
+    project: argv.project,
   };
 
   switch (integration) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,6 +39,7 @@ type Args = {
 
   url?: string;
   platform?: Platform[];
+  org?: string;
   project?: string;
 };
 
@@ -81,7 +82,8 @@ export async function run(argv: Args) {
     telemetryEnabled: !argv.disableTelemetry,
     promoCode: argv.promoCode,
     url: argv.url,
-    project: argv.project,
+    orgSlug: argv.org,
+    projectSlug: argv.project,
   };
 
   switch (integration) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,6 +39,7 @@ type Args = {
 
   url?: string;
   platform?: Platform[];
+  slug?: string;
 };
 
 export async function run(argv: Args) {
@@ -80,6 +81,7 @@ export async function run(argv: Args) {
     telemetryEnabled: !argv.disableTelemetry,
     promoCode: argv.promoCode,
     url: argv.url,
+    slug: argv.slug,
   };
 
   switch (integration) {

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -823,7 +823,7 @@ export async function getOrAskForProjectData(
   }
 
   const selectedProject = await traceStep('select-project', () =>
-    askForProjectSelection(projects, options.slug),
+    askForProjectSelection(projects, options.project),
   );
 
   const { token } = apiKeys ?? {};
@@ -1041,7 +1041,7 @@ async function askForWizardLogin(options: {
 
 async function askForProjectSelection(
   projects: SentryProjectData[],
-  slug?: string,
+  projectSlug?: string,
 ): Promise<SentryProjectData> {
   const label = (project: SentryProjectData): string => {
     return `${project.organization.slug}/${project.slug}`;
@@ -1051,10 +1051,12 @@ async function askForProjectSelection(
     return label(a).localeCompare(label(b));
   });
 
-  if (slug) {
-    const project = sortedProjects.find((p) => label(p) === slug);
-    if (project) {
-      return project;
+  if (projectSlug) {
+    const selectedProject = sortedProjects.find(
+      (p) => label(p) === projectSlug,
+    );
+    if (selectedProject) {
+      return selectedProject;
     }
   }
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -869,7 +869,7 @@ export async function getOrAskForProjectData(
   }
 
   const selectedProject = await traceStep('select-project', () =>
-    askForProjectSelection(projects, options.project),
+    askForProjectSelection(projects, options.orgSlug, options.projectSlug),
   );
 
   const { token } = apiKeys ?? {};
@@ -1087,24 +1087,37 @@ async function askForWizardLogin(options: {
 
 async function askForProjectSelection(
   projects: SentryProjectData[],
+  orgSlug?: string,
   projectSlug?: string,
 ): Promise<SentryProjectData> {
   const label = (project: SentryProjectData): string => {
     return `${project.organization.slug}/${project.slug}`;
   };
-  const sortedProjects = [...projects];
+
+  const filteredProjects = filterProjectsBySlugs(
+    projects,
+    orgSlug,
+    projectSlug,
+  );
+
+  if (filteredProjects.length === 1) {
+    const selection = filteredProjects[0];
+
+    Sentry.setTag('project', selection.slug);
+    Sentry.setUser({ id: selection.organization.slug });
+    clack.log.step(`Selected project ${label(selection)}`);
+
+    return selection;
+  }
+
+  if (filteredProjects.length === 0) {
+    clack.log.warn('Could not find a project with the provided slugs.');
+  }
+
+  const sortedProjects = filteredProjects.length ? filteredProjects : projects;
   sortedProjects.sort((a: SentryProjectData, b: SentryProjectData) => {
     return label(a).localeCompare(label(b));
   });
-
-  if (projectSlug) {
-    const selectedProject = sortedProjects.find(
-      (p) => label(p) === projectSlug,
-    );
-    if (selectedProject) {
-      return selectedProject;
-    }
-  }
 
   const selection: SentryProjectData | symbol = await abortIfCancelled(
     clack.select({
@@ -1123,6 +1136,26 @@ async function askForProjectSelection(
   Sentry.setUser({ id: selection.organization.slug });
 
   return selection;
+}
+
+function filterProjectsBySlugs(
+  projects: SentryProjectData[],
+  orgSlug?: string,
+  projectSlug?: string,
+): SentryProjectData[] {
+  if (!orgSlug && !projectSlug) {
+    return projects;
+  }
+  if (orgSlug && !projectSlug) {
+    return projects.filter((p) => p.organization.slug === orgSlug);
+  }
+  if (!orgSlug && projectSlug) {
+    return projects.filter((p) => p.slug === projectSlug);
+  }
+
+  return projects.filter(
+    (p) => p.organization.slug === orgSlug && p.slug === projectSlug,
+  );
 }
 
 /**

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -823,7 +823,7 @@ export async function getOrAskForProjectData(
   }
 
   const selectedProject = await traceStep('select-project', () =>
-    askForProjectSelection(projects),
+    askForProjectSelection(projects, options.slug),
   );
 
   const { token } = apiKeys ?? {};
@@ -1041,6 +1041,7 @@ async function askForWizardLogin(options: {
 
 async function askForProjectSelection(
   projects: SentryProjectData[],
+  slug?: string,
 ): Promise<SentryProjectData> {
   const label = (project: SentryProjectData): string => {
     return `${project.organization.slug}/${project.slug}`;
@@ -1049,6 +1050,14 @@ async function askForProjectSelection(
   sortedProjects.sort((a: SentryProjectData, b: SentryProjectData) => {
     return label(a).localeCompare(label(b));
   });
+
+  if (slug) {
+    const project = sortedProjects.find((p) => label(p) === slug);
+    if (project) {
+      return project;
+    }
+  }
+
   const selection: SentryProjectData | symbol = await abortIfCancelled(
     clack.select({
       maxItems: 12,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -34,6 +34,13 @@ export type WizardOptions = {
   url?: string;
 
   /**
+   * Org slug and project slug to pre-select in the wizard.
+   * This can be passed via the `--slug` arg.
+   * Example: `--slug my-org/my-project`
+   */
+  slug?: string;
+
+  /**
    * If this is set, the wizard will skip the login and project selection step.
    * (This can not yet be set externally but for example when redirecting from
    * one wizard to another when the project was already selected)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -34,9 +34,16 @@ export type WizardOptions = {
   url?: string;
 
   /**
-   * Org slug and project slug to pre-select in the wizard.
+   * The org to pre-select in the wizard.
+   * This can be passed via the `--org` arg.
+   * Example: `--org my-org`
+   */
+  orgSlug?: string;
+
+  /**
+   * Project slug to pre-select in the wizard.
    * This can be passed via the `--project` arg.
-   * Example: `--project my-org/my-project`
+   * Example: `--project my-project`
    */
   projectSlug?: string;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,10 +35,10 @@ export type WizardOptions = {
 
   /**
    * Org slug and project slug to pre-select in the wizard.
-   * This can be passed via the `--slug` arg.
-   * Example: `--slug my-org/my-project`
+   * This can be passed via the `--project` arg.
+   * Example: `--project my-org/my-project`
    */
-  slug?: string;
+  projectSlug?: string;
 
   /**
    * If this is set, the wizard will skip the login and project selection step.


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry/issues/77381

Adds `--org` and `--project` parameters that narrow down options in project selection step.
If there is only one project matching the provided slugs it gets automatically selected.
If no projects match the passed slugs wizard falls back to the current behaviour