### PR TITLE
fix(check-sdk-version): add @sentry/nestjs to sentry sdk packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix(sveltekit): Create bundler plugin env file instead of sentryclirc (#675)
+- fix(check-sdk-version): add @sentry/nestjs to sentry sdk packages (#676)
 
 ## 3.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - fix(sveltekit): Create bundler plugin env file instead of sentryclirc (#675)
-- fix(check-sdk-version): add @sentry/nestjs to sentry sdk packages (#676)
+- fix(check-sdk-version): update sentry sdk packages (#676)
 
 ## 3.30.0
 

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -28,6 +28,7 @@ const SENTRY_SDK_PACKAGE_NAMES = [
   '@sentry/angular',
   '@sentry/angular-ivy',
   '@sentry/ember',
+  '@sentry/nestjs',
   '@sentry/react',
   '@sentry/svelte',
   '@sentry/vue',

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -19,6 +19,7 @@ const MINIMUM_DEBUG_ID_SDK_VERSION = '7.47.0';
 // that we actually detect the "top-level" SDK first.
 const SENTRY_SDK_PACKAGE_NAMES = [
   // SDKs using other framework SDKs need to be checked first
+  '@sentry/astro',
   '@sentry/gatsby',
   '@sentry/nextjs',
   '@sentry/nuxt',
@@ -27,7 +28,6 @@ const SENTRY_SDK_PACKAGE_NAMES = [
   '@sentry/sveltekit',
 
   // Framework SDKs
-  '@sentry/astro',
   '@sentry/angular',
   '@sentry/angular-ivy',
   '@sentry/aws-serverless',

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -21,15 +21,22 @@ const SENTRY_SDK_PACKAGE_NAMES = [
   // SDKs using other framework SDKs need to be checked first
   '@sentry/gatsby',
   '@sentry/nextjs',
+  '@sentry/nuxt',
   '@sentry/remix',
+  '@sentry/solidstart',
   '@sentry/sveltekit',
 
   // Framework SDKs
+  '@sentry/astro',
   '@sentry/angular',
   '@sentry/angular-ivy',
+  '@sentry/aws-serverless',
+  '@sentry/bun',
   '@sentry/ember',
+  '@sentry/google-cloud-serverless',
   '@sentry/nestjs',
   '@sentry/react',
+  '@sentry/solid',
   '@sentry/svelte',
   '@sentry/vue',
   '@sentry/serverless',
@@ -37,6 +44,7 @@ const SENTRY_SDK_PACKAGE_NAMES = [
   // Base SDKs
   '@sentry/browser',
   '@sentry/node',
+  '@sentry/deno',
 ];
 
 /**


### PR DESCRIPTION
- closes https://github.com/getsentry/sentry/issues/77914