### PR TITLE
feat(telemetry): Add telemetry for org and project CLI argument usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(sveltekit): Create bundler plugin env file instead of sentryclirc (#675)
 - fix(check-sdk-version): update sentry sdk packages (#676)
+- feat(telemetry): Add telemetry for org and project CLI argument usage (#677)
 
 ## 3.30.0
 

--- a/src/android/android-wizard.ts
+++ b/src/android/android-wizard.ts
@@ -30,6 +30,7 @@ export async function runAndroidWizard(options: WizardOptions): Promise<void> {
     {
       enabled: options.telemetryEnabled,
       integration: 'android',
+      wizardOptions: options,
     },
     () => runAndroidWizardWithTelemetry(options),
   );

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -34,6 +34,7 @@ export async function runAppleWizard(options: WizardOptions): Promise<void> {
     {
       enabled: options.telemetryEnabled,
       integration: 'ios',
+      wizardOptions: options,
     },
     () => runAppleWizardWithTelementry(options),
   );

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -55,6 +55,7 @@ export function runNextjsWizard(options: WizardOptions) {
     {
       enabled: options.telemetryEnabled,
       integration: 'nextjs',
+      wizardOptions: options,
     },
     () => runNextjsWizardWithTelemetry(options),
   );

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -96,6 +96,7 @@ export async function runReactNativeWizard(
     {
       enabled: params.telemetryEnabled,
       integration: 'react-native',
+      wizardOptions: params,
     },
     () => runReactNativeWizardWithTelemetry(params),
   );

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -43,6 +43,7 @@ export async function runRemixWizard(options: WizardOptions): Promise<void> {
     {
       enabled: options.telemetryEnabled,
       integration: 'remix',
+      wizardOptions: options,
     },
     () => runRemixWizardWithTelemetry(options),
   );

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -39,6 +39,7 @@ export async function runSourcemapsWizard(
     {
       enabled: options.telemetryEnabled,
       integration: 'sourcemaps',
+      wizardOptions: options,
     },
     () => runSourcemapsWizardWithTelemetry(options),
   );

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -32,6 +32,7 @@ export async function runSvelteKitWizard(
     {
       enabled: options.telemetryEnabled,
       integration: 'sveltekit',
+      wizardOptions: options,
     },
     () => runSvelteKitWizardWithTelemetry(options),
   );

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,11 +11,13 @@ import {
   flush,
 } from '@sentry/node';
 import packageJson from '../package.json';
+import { WizardOptions } from './utils/types';
 
 export async function withTelemetry<F>(
   options: {
     enabled: boolean;
     integration: string;
+    wizardOptions: WizardOptions;
   },
   callback: () => F | Promise<F>,
 ): Promise<F> {
@@ -28,6 +30,10 @@ export async function withTelemetry<F>(
 
   const sentrySession = sentryHub.startSession();
   sentryHub.captureSession();
+
+  // Set tag for passed CLI args
+  sentryHub.setTag('args.project', !!options.wizardOptions.projectSlug);
+  sentryHub.setTag('args.org', !!options.wizardOptions.orgSlug);
 
   try {
     return await startSpan(


### PR DESCRIPTION
Adding some tags to check if (how often) users started the wizard with `--org` and/or `--project` args. 

somewhat ref #357 