### PR TITLE
feat: Add `--saas` CLI arg to skip self-hosted or SaaS selection step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 - feat: Add `--saas` CLI arg to skip self-hosted or SaaS selection step (#678)
  
 ## 3.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- feat: Add `--saas` CLI arg to skip self-hosted or SaaS selection step (#678)
+ 
 ## 3.31.0
 
 - fix(sveltekit): Create bundler plugin env file instead of sentryclirc (#675)

--- a/bin.ts
+++ b/bin.ts
@@ -60,6 +60,11 @@ const argv = yargs(hideBin(process.argv))
     alias: 'url',
     describe: 'The url to your Sentry installation\nenv: SENTRY_WIZARD_URL',
   })
+  .option('saas', {
+    default: false,
+    describe: 'If set, skip the self-hosted or SaaS URL selection process',
+    type: 'boolean',
+  })
   .option('s', {
     alias: 'signup',
     default: false,

--- a/src/run.ts
+++ b/src/run.ts
@@ -41,6 +41,7 @@ type Args = {
   platform?: Platform[];
   org?: string;
   project?: string;
+  saas: boolean;
 };
 
 export async function run(argv: Args) {
@@ -79,18 +80,18 @@ export async function run(argv: Args) {
   }
 
   const wizardOptions: WizardOptions = {
-    telemetryEnabled: !argv.disableTelemetry,
-    promoCode: argv.promoCode,
-    url: argv.url,
-    orgSlug: argv.org,
-    projectSlug: argv.project,
+    telemetryEnabled: !finalArgs.disableTelemetry,
+    promoCode: finalArgs.promoCode,
+    url: finalArgs.url,
+    orgSlug: finalArgs.org,
+    projectSlug: finalArgs.project,
   };
 
   switch (integration) {
     case 'reactNative':
       await runReactNativeWizard({
         ...wizardOptions,
-        uninstall: argv.uninstall,
+        uninstall: finalArgs.uninstall,
       });
       break;
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -41,7 +41,7 @@ type Args = {
   platform?: Platform[];
   org?: string;
   project?: string;
-  saas: boolean;
+  saas?: boolean;
 };
 
 export async function run(argv: Args) {
@@ -85,6 +85,7 @@ export async function run(argv: Args) {
     url: finalArgs.url,
     orgSlug: finalArgs.org,
     projectSlug: finalArgs.project,
+    saas: finalArgs.saas,
   };
 
   switch (integration) {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -34,6 +34,7 @@ export async function withTelemetry<F>(
   // Set tag for passed CLI args
   sentryHub.setTag('args.project', !!options.wizardOptions.projectSlug);
   sentryHub.setTag('args.org', !!options.wizardOptions.orgSlug);
+  sentryHub.setTag('args.saas', !!options.wizardOptions.saas);
 
   try {
     return await startSpan(

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -845,10 +845,12 @@ export async function getOrAskForProjectData(
       selectedProject: options.preSelectedProject.project,
     };
   }
-  const { url: sentryUrl, selfHosted } = await traceStep(
-    'ask-self-hosted',
-    () => askForSelfHosted(options.url),
-  );
+  const { url: sentryUrl, selfHosted } = options.saas
+    ? {
+        url: SAAS_URL,
+        selfHosted: false,
+      }
+    : await traceStep('ask-self-hosted', () => askForSelfHosted(options.url));
 
   const { projects, apiKeys } = await traceStep('login', () =>
     askForWizardLogin({

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -48,6 +48,12 @@ export type WizardOptions = {
   projectSlug?: string;
 
   /**
+   * If this option is set, the wizard will skip the self-hosted or SaaS
+   * selection step and directly assume that the wizard is used for Sentry SaaS.
+   */
+  saas?: boolean;
+
+  /**
    * If this is set, the wizard will skip the login and project selection step.
    * (This can not yet be set externally but for example when redirecting from
    * one wizard to another when the project was already selected)


### PR DESCRIPTION
Currently, our in-product onboarding shows the `--url` option because we want to skip the "Are you using Sentry.io or self-hosted" question (in-product, we already know the URL). 

From the wizard perspective, we default to the SaaS url if users don't pass a custom`--url`. However, if users pass a custom URL that is the SaaS URL we unnecessarily inject `url` params into code where it's not strictly necessary. 

The new `--saas` flag introduced in this PR will skip over the self-hosted question and if it's set to `true` assume that users are using SaaS. We can display `--saas` in the UI (for SaaS) instead of `--url`, making the snippet a bit shorter and avoiding to unnecessarily inject the `url` params into user code.  
