### PR TITLE
ref: Add `--project` and `--org` args to help message and update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- ref: Add `--project` and `--org` args to help message and update readme (#679)
 - feat: Add `--saas` CLI arg to skip self-hosted or SaaS selection step (#678)
+- ref: Add `--project` and `--org` args to help message and update readme (#679)
  
 ## 3.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- ref: Add `--project` and `--org` args to help message and update readme (#679)
 - feat: Add `--saas` CLI arg to skip self-hosted or SaaS selection step (#678)
  
 ## 3.31.0

--- a/README.md
+++ b/README.md
@@ -55,26 +55,37 @@ At the current moment, the wizard is meant to be used for React Native, Cordova,
 
 ```
 Options:
-  --help             Show help                                         [boolean]
-  --version          Show version number                               [boolean]
-  --debug            Enable verbose logging
-                     env: SENTRY_WIZARD_DEBUG                          [boolean]
-  --uninstall        Revert project set up process
-                     env: SENTRY_WIZARD_UNINSTALL                      [boolean]
-  --skip-connect     Skips the connection to the server
-                     env: SENTRY_WIZARD_SKIP_CONNECT                   [boolean]
-  --quiet            Do not fallback to prompting user asking questions
-                     env: SENTRY_WIZARD_QUIET                          [boolean]
-  -i, --integration  Choose the integration to set up
-                     env: SENTRY_WIZARD_INTEGRATION
-                       [choices: "reactNative", "cordova", "electron", "nextjs"]
-  -p, --platform     Choose platform(s)
-                     env: SENTRY_WIZARD_PLATFORM
+      --help               Show help                                   [boolean]
+      --version            Show version number                         [boolean]
+      --debug              Enable verbose logging
+                           env: SENTRY_WIZARD_DEBUG   [boolean] [default: false]
+      --uninstall          Revert project setup process
+                           env: SENTRY_WIZARD_UNINSTALL
+                                                      [boolean] [default: false]
+      --skip-connect       Skips the connection to the server
+                           env: SENTRY_WIZARD_SKIP_CONNECT
+                                                      [boolean] [default: false]
+      --quiet              Do not fallback to prompting user asking questions
+                           env: SENTRY_WIZARD_QUIET   [boolean] [default: false]
+  -i, --integration        Choose the integration to setup
+                           env: SENTRY_WIZARD_INTEGRATION
+     [choices: "reactNative", "ios", "android", "cordova", "electron", "nextjs",
+                                             "remix", "sveltekit", "sourcemaps"]
+  -p, --platform           Choose platform(s)
+                           env: SENTRY_WIZARD_PLATFORM
                                              [array] [choices: "ios", "android"]
-  -u, --url          The url to your Sentry installation
-                     env: SENTRY_WIZARD_URL      [default: "https://sentry.io/"]
-  -s, --signup       Redirect to signup page if not logged in
-                     Use if don't have a Sentry account                [boolean]
+  -u, --url                The url to your Sentry installation
+                           env: SENTRY_WIZARD_URL
+      --project            The Sentry project slug to use
+                                 [string] [default: Select project during setup]
+      --org                The Sentry org slug to use
+                                     [string] [default: Select org during setup]
+      --saas               Skip the self-hosted or SaaS URL selection process
+                    [boolean] [default: Select self-hosted or SaaS during setup]
+  -s, --signup             Redirect to signup page if not logged in
+                                                      [boolean] [default: false]
+      --disable-telemetry  Don't send telemetry data to Sentry
+                                                      [boolean] [default: false]
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -53,40 +53,24 @@ At the current moment, the wizard is meant to be used for React Native, Cordova,
 
 # Options
 
-```
-Options:
-      --help               Show help                                   [boolean]
-      --version            Show version number                         [boolean]
-      --debug              Enable verbose logging
-                           env: SENTRY_WIZARD_DEBUG   [boolean] [default: false]
-      --uninstall          Revert project setup process
-                           env: SENTRY_WIZARD_UNINSTALL
-                                                      [boolean] [default: false]
-      --skip-connect       Skips the connection to the server
-                           env: SENTRY_WIZARD_SKIP_CONNECT
-                                                      [boolean] [default: false]
-      --quiet              Do not fallback to prompting user asking questions
-                           env: SENTRY_WIZARD_QUIET   [boolean] [default: false]
-  -i, --integration        Choose the integration to setup
-                           env: SENTRY_WIZARD_INTEGRATION
-     [choices: "reactNative", "ios", "android", "cordova", "electron", "nextjs",
-                                             "remix", "sveltekit", "sourcemaps"]
-  -p, --platform           Choose platform(s)
-                           env: SENTRY_WIZARD_PLATFORM
-                                             [array] [choices: "ios", "android"]
-  -u, --url                The url to your Sentry installation
-                           env: SENTRY_WIZARD_URL
-      --project            The Sentry project slug to use
-                                 [string] [default: Select project during setup]
-      --org                The Sentry org slug to use
-                                     [string] [default: Select org during setup]
-      --saas               Skip the self-hosted or SaaS URL selection process
-                    [boolean] [default: Select self-hosted or SaaS during setup]
-  -s, --signup             Redirect to signup page if not logged in
-                                                      [boolean] [default: false]
-      --disable-telemetry  Don't send telemetry data to Sentry
-                                                      [boolean] [default: false]
-```
+The following CLI arguments are available:
+
+| Option                | Description                                                       | Type    | Default                                 | Choices                                                                                              | Environment Variable         |
+| --------------------- | ----------------------------------------------------------------- | ------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `--help`              | Show help                                                         | boolean |                                         |                                                                                                      |                              |
+| `--version`           | Show version number                                               | boolean |                                         |                                                                                                      |                              |
+| `--debug`             | Enable verbose logging                                            | boolean | `false`                                 |                                                                                                      | `SENTRY_WIZARD_DEBUG`        |
+| `--uninstall`         | Revert project setup process. Not available for all integrations. | boolean | `false`                                 |                                                                                                      | `SENTRY_WIZARD_UNINSTALL`    |
+| `--skip-connect`      | Skips the connection to the server                                | boolean | `false`                                 |                                                                                                      | `SENTRY_WIZARD_SKIP_CONNECT` |
+| `--quiet`             | Do not fallback to prompting user asking questions                | boolean | `false`                                 |                                                                                                      | `SENTRY_WIZARD_QUIET`        |
+| `-i, --integration`   | Choose the integration to setup                                   | choices | Select integration during setup         | "reactNative", "ios", "android", "cordova", "electron", "nextjs", "remix", "sveltekit", "sourcemaps" | `SENTRY_WIZARD_INTEGRATION`  |
+| `-p, --platform`      | Choose platform(s)                                                | array   | Select platform(s) during setup         | "ios", "android"                                                                                     | `SENTRY_WIZARD_PLATFORM`     |
+| `-u, --url`           | The URL to your Sentry installation                               | string  | `https://sentry.io`                     |                                                                                                      | `SENTRY_WIZARD_URL`          |
+| `--project`           | The Sentry project slug to use                                    | string  | Select project during setup             |                                                                                                      |                              |
+| `--org`               | The Sentry org slug to use                                        | string  | Select org during setup                 |                                                                                                      |                              |
+| `--saas`              | Skip the self-hosted or SaaS URL selection process                | boolean | Select self-hosted or SaaS during setup |                                                                                                      |                              |
+| `-s, --signup`        | Redirect to signup page if not logged in                          | boolean | `false`                                 |                                                                                                      |                              |
+| `--disable-telemetry` | Don't send telemetry data to Sentry                               | boolean | `false`                                 |                                                                                                      |                              |
 
 ## Resources
 

--- a/bin.ts
+++ b/bin.ts
@@ -60,9 +60,22 @@ const argv = yargs(hideBin(process.argv))
     alias: 'url',
     describe: 'The url to your Sentry installation\nenv: SENTRY_WIZARD_URL',
   })
+  .option('project', {
+    type: 'string',
+    describe: 'The Sentry project slug to use',
+    defaultDescription: 'Select project during setup',
+    default: undefined,
+  })
+  .option('org', {
+    type: 'string',
+    describe: 'The Sentry org slug to use',
+    defaultDescription: 'Select org during setup',
+    default: undefined,
+  })
   .option('saas', {
     default: false,
-    describe: 'If set, skip the self-hosted or SaaS URL selection process',
+    describe: 'Skip the self-hosted or SaaS URL selection process',
+    defaultDescription: 'Select self-hosted or SaaS during setup',
     type: 'boolean',
   })
   .option('s', {


### PR DESCRIPTION
Adds the `project` and `org` CLI args to the `--help` message.

Also, this PR  updates the outdated readme with all current CLI args and reformats the previous CLI output into a table: [Rendered Readme](https://github.com/getsentry/sentry-wizard/blob/6b300762c8d2af0be677da4c409e3bdd5d7312e7/README.md#options). (thx AI 🙏)

