### PR TITLE
ref(remix-wizard): Fix creation sentry example when no routes folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix creation sentry example when no routes folder ([#680](https://github.com/getsentry/sentry-wizard/pull/680))
+
 ## 3.32.0
 
 - feat: Add `--saas` CLI arg to skip self-hosted or SaaS selection step (#678)

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -13,6 +13,12 @@ export async function createExamplePage(options: {
   url: string;
   isTS: boolean;
 }) {
+  const routesPath = 'app/routes';
+
+  if (!fs.existsSync(routesPath)) {
+    fs.mkdirSync(routesPath);
+  }
+
   const exampleRoutePath = `app/routes/sentry-example-page.${
     options.isTS ? 'ts' : 'js'
   }x`;


### PR DESCRIPTION
**Problem**

If a Remix project doesn't yet have a routes folder, as was the case when I followed only the initial steps of [this tutorial](https://remix.run/docs/en/main/start/tutorial), running the Sentry wizard and answering 'yes' to create a Sentry example fails to generate the example, and no feedback is provided.

**Solution**

Update the code to check whether the routes folder exists. If it doesn’t, create the folder to allow the Sentry example to be successfully generated.

**Note**
Users will still need to complete [this step](https://remix.run/docs/en/main/start/tutorial#nested-routes-and-outlets) to fully view the Sentry example. However, since the route will be created, users will at least see some feedback in the project - the new file.


closes https://github.com/getsentry/sentry/issues/78331