### PR TITLE
ref: Handle edge cases in formatting step more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref: Handle edge cases in formatting step more gracefully  ([#687](https://github.com/getsentry/sentry-wizard/pull/686))
+
 ## 3.34.0
 
 - feat: Forward slugs to auth page ([#686](https://github.com/getsentry/sentry-wizard/pull/686))


### PR DESCRIPTION
Just noticed while running a repro sveltekit app in a new directory where I didn't yet initialize git that the auto-format step wasn't behaving correctly. For some reason, the child process promise when running `npx prettier ...` never resolved and I had to quit the wizard.

This PR makes a couple of changes to the prettier formatting step:
- bail if we're not in a git repo
- bail if no unchanged/untracked files are detected (could happen if users commit the changes while the wizard is runningI)
- only then prompt users if they want to run prettier

