### PR TITLE
feat(apple): Build script phase update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(Apple): Sentry-cli not found by build phase when installed with homebrew (#691)
+
 ## 3.34.2
 
 - fix(nextjs): Don't ask for package manager twice (#690)

--- a/src/apple/templates.ts
+++ b/src/apple/templates.ts
@@ -2,12 +2,15 @@ export function getRunScriptTemplate(
   orgSlug: string,
   projectSlug: string,
   uploadSource = true,
-  includeHomebrewPath = false
+  includeHomebrewPath = false,
 ): string {
   // eslint-disable-next-line no-useless-escape
-  let includeHomebrew = includeHomebrewPath ? '\\nif [[ "$(uname -m)" == arm64 ]]; then\\nexport PATH="/opt/homebrew/bin:$PATH"\\nfi' : '';
-  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${uploadSource ? '--include-sources ' : ''
-    }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
+  let includeHomebrew = includeHomebrewPath
+    ? '\\nif [[ "$(uname -m)" == arm64 ]]; then\\nexport PATH="/opt/homebrew/bin:$PATH"\\nfi'
+    : '';
+  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${
+    uploadSource ? '--include-sources ' : ''
+  }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
 }
 
 export const scriptInputPath =

--- a/src/apple/templates.ts
+++ b/src/apple/templates.ts
@@ -5,12 +5,11 @@ export function getRunScriptTemplate(
   includeHomebrewPath = false,
 ): string {
   // eslint-disable-next-line no-useless-escape
-  let includeHomebrew = includeHomebrewPath
+  const includeHomebrew = includeHomebrewPath
     ? '\\nif [[ "$(uname -m)" == arm64 ]]; then\\nexport PATH="/opt/homebrew/bin:$PATH"\\nfi'
     : '';
-  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${
-    uploadSource ? '--include-sources ' : ''
-  }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
+  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${uploadSource ? '--include-sources ' : ''
+    }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
 }
 
 export const scriptInputPath =

--- a/src/apple/templates.ts
+++ b/src/apple/templates.ts
@@ -2,11 +2,12 @@ export function getRunScriptTemplate(
   orgSlug: string,
   projectSlug: string,
   uploadSource = true,
+  includeHomebrewPath = false
 ): string {
   // eslint-disable-next-line no-useless-escape
-  return `# This script is responsable to upload debug symbols and source context for Sentry.\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${
-    uploadSource ? '--include-sources ' : ''
-  }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
+  let includeHomebrew = includeHomebrewPath ? '\\nif [[ "$(uname -m)" == arm64 ]]; then\\nexport PATH="/opt/homebrew/bin:$PATH"\\nfi' : '';
+  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${uploadSource ? '--include-sources ' : ''
+    }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
 }
 
 export const scriptInputPath =

--- a/src/apple/templates.ts
+++ b/src/apple/templates.ts
@@ -8,8 +8,9 @@ export function getRunScriptTemplate(
   const includeHomebrew = includeHomebrewPath
     ? '\\nif [[ "$(uname -m)" == arm64 ]]; then\\nexport PATH="/opt/homebrew/bin:$PATH"\\nfi'
     : '';
-  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${uploadSource ? '--include-sources ' : ''
-    }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
+  return `# This script is responsable to upload debug symbols and source context for Sentry.${includeHomebrew}\\nif which sentry-cli >/dev/null; then\\nexport SENTRY_ORG=${orgSlug}\\nexport SENTRY_PROJECT=${projectSlug}\\nERROR=$(sentry-cli debug-files upload ${
+    uploadSource ? '--include-sources ' : ''
+  }"$DWARF_DSYM_FOLDER_PATH" 2>&1 >/dev/null)\\nif [ ! $? -eq 0 ]; then\\necho "warning: sentry-cli - $ERROR"\\nfi\\nelse\\necho "warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"\\nfi\\n`;
 }
 
 export const scriptInputPath =

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -164,9 +164,7 @@ function addUploadSymbolsScript(
     }
   }
 
-  // Check if sentry-cli is installed via Homebrew
   let isHomebrewInstalled = fs.existsSync('/opt/homebrew/bin/sentry-cli');
-
   xcodeProject.addBuildPhase(
     [],
     'PBXShellScriptBuildPhase',

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -164,6 +164,9 @@ function addUploadSymbolsScript(
     }
   }
 
+  // Check if sentry-cli is installed via Homebrew
+  let isHomebrewInstalled = fs.existsSync('/opt/homebrew/bin/sentry-cli');
+
   xcodeProject.addBuildPhase(
     [],
     'PBXShellScriptBuildPhase',
@@ -178,6 +181,7 @@ function addUploadSymbolsScript(
         sentryProject.organization.slug,
         sentryProject.slug,
         uploadSource,
+        isHomebrewInstalled,
       ),
     },
   );

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -164,7 +164,7 @@ function addUploadSymbolsScript(
     }
   }
 
-  let isHomebrewInstalled = fs.existsSync('/opt/homebrew/bin/sentry-cli');
+  const isHomebrewInstalled = fs.existsSync('/opt/homebrew/bin/sentry-cli');
   xcodeProject.addBuildPhase(
     [],
     'PBXShellScriptBuildPhase',


### PR DESCRIPTION
This tackle an issue reported in [here](https://github.com/getsentry/sentry-docs/issues/7597), where Xcode does not work with sentry-cli installed with homebrew automatically. 

 