### PR TITLE
Fix typo in a couple of steps

### DIFF
--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -196,7 +196,7 @@ export async function runNextjsWizardWithTelemetry(
 
       const shouldContinue = await abortIfCancelled(
         clack.confirm({
-          message: `Did add the code to your ${chalk.cyan(
+          message: `Did you add the code to your ${chalk.cyan(
             path.join(...pagesLocation, underscoreErrorPageFile),
           )} file as described above?`,
           active: 'Yes',
@@ -278,7 +278,7 @@ export async function runNextjsWizardWithTelemetry(
 
       const shouldContinue = await abortIfCancelled(
         clack.confirm({
-          message: `Did add the code to your ${chalk.cyan(
+          message: `Did you add the code to your ${chalk.cyan(
             path.join(...appDirLocation, globalErrorPageFile),
           )} file as described above?`,
           active: 'Yes',


### PR DESCRIPTION
Added a missing word "you" in a couple of the wizard steps because it read like a typo: `Did add the code to your app/global-error.tsx file as described above?`

#skip-changelog