### PR TITLE
deps: Remove `xmldom` from lock file and resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,6 @@
     "tsx": "^3.14.0",
     "typescript": "^5.0.4"
   },
-  "resolutions": {
-    "**/xmldom": "^0.6.0"
-  },
   "engines": {
     "node": ">=14.18.0",
     "npm": ">=3.10.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4828,11 +4828,6 @@ xmlbuilder@^9.0.7:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
-
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"


### PR DESCRIPTION
#skip-changelog

Looks like one of our transitive dependencies, `plist` relied on `xmldom@0.6.0` in the past, which caused a dependabot alert in our repo. The version of plist we use [nowadays](https://github.com/TooTallNate/plist.js/blob/master/History.md#305--2022-03-23) doesn't require `xmldom` anymore at all. However, it was still mentioned in `yarn.lock` and there was an unnecessary dependency resolution in package.json. Both of which I removed.

fixes https://github.com/getsentry/sentry-wizard/security/dependabot/18