### PR TITLE
feat(nuxt): Add example page/component creation and final messaging

### DIFF
--- a/src/nuxt/nuxt-wizard.ts
+++ b/src/nuxt/nuxt-wizard.ts
@@ -8,15 +8,25 @@ import {
   abort,
   abortIfCancelled,
   addDotEnvSentryBuildPluginFile,
+  askShouldCreateExampleComponent,
+  askShouldCreateExamplePage,
   confirmContinueIfNoOrDirtyGitRepo,
   ensurePackageIsInstalled,
   getOrAskForProjectData,
   getPackageDotJson,
   installPackage,
   printWelcome,
+  runPrettierIfInstalled,
 } from '../utils/clack-utils';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import { addSDKModule, getNuxtConfig, createConfigFiles } from './sdk-setup';
+import {
+  createExampleComponent,
+  createExamplePage,
+  supportsExamplePage,
+} from './sdk-example';
+import { isNuxtV4 } from './utils';
+import chalk from 'chalk';
 
 export function runNuxtWizard(options: WizardOptions) {
   return withTelemetry(
@@ -47,7 +57,7 @@ export async function runNuxtWizardWithTelemetry(
   const nuxtVersion = getPackageVersion('nuxt', packageJson);
   Sentry.setTag('nuxt-version', nuxtVersion);
 
-  const minVer = minVersion(nuxtVersion || 'none');
+  const minVer = minVersion(nuxtVersion || '0.0.0');
 
   if (!nuxtVersion || !minVer || lt(minVer, '3.13.2')) {
     clack.log.warn(
@@ -87,13 +97,70 @@ export async function runNuxtWizardWithTelemetry(
 
   const nuxtConfig = await traceStep('load-nuxt-config', getNuxtConfig);
 
-  await traceStep('configure-sdk', async () => {
-    await addSDKModule(nuxtConfig, {
-      org: selectedProject.organization.slug,
-      project: selectedProject.slug,
-      url: selfHosted ? sentryUrl : undefined,
-    });
+  const projectData = {
+    org: selectedProject.organization.slug,
+    project: selectedProject.slug,
+    projectId: selectedProject.id,
+    url: sentryUrl,
+    selfHosted,
+  };
 
+  await traceStep('configure-sdk', async () => {
+    await addSDKModule(nuxtConfig, projectData);
     await createConfigFiles(selectedProject.keys[0].dsn.public);
   });
+
+  let shouldCreateExamplePage = false;
+  let shouldCreateExampleButton = false;
+
+  const isV4 = await isNuxtV4(nuxtConfig, nuxtVersion);
+  const canCreateExamplePage = await supportsExamplePage(isV4);
+  Sentry.setTag('supports-example-page-creation', canCreateExamplePage);
+
+  if (canCreateExamplePage) {
+    shouldCreateExamplePage = await askShouldCreateExamplePage();
+
+    if (shouldCreateExamplePage) {
+      await traceStep('create-example-page', async () =>
+        createExamplePage(isV4, projectData),
+      );
+    }
+  } else {
+    shouldCreateExampleButton = await askShouldCreateExampleComponent();
+
+    if (shouldCreateExampleButton) {
+      await traceStep('create-example-component', async () =>
+        createExampleComponent(isV4),
+      );
+    }
+  }
+
+  await runPrettierIfInstalled();
+
+  clack.outro(
+    buildOutroMessage(shouldCreateExamplePage, shouldCreateExampleButton),
+  );
+}
+
+function buildOutroMessage(
+  shouldCreateExamplePage: boolean,
+  shouldCreateExampleButton: boolean,
+): string {
+  let msg = chalk.green('\nSuccessfully installed the Sentry Nuxt SDK!');
+
+  if (shouldCreateExamplePage) {
+    msg += `\n\nYou can validate your setup by visiting ${chalk.cyan(
+      '"/sentry-example-page"',
+    )}.`;
+  }
+  if (shouldCreateExampleButton) {
+    msg += `\n\nYou can validate your setup by adding the ${chalk.cyan(
+      '`SentryExampleButton`',
+    )} component to a page and triggering it.`;
+  }
+
+  msg += `\n\nCheck out the SDK documentation for further configuration:
+https://docs.sentry.io/platforms/javascript/guides/nuxt/`;
+
+  return msg;
 }

--- a/src/nuxt/sdk-example.ts
+++ b/src/nuxt/sdk-example.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs';
+import * as path from 'path';
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import {
+  getIndexRouteTemplate,
+  getSentryExampleApiTemplate,
+  getSentryExamplePageTemplate,
+  getSentryErrorButtonTemplate,
+} from './templates';
+import { abort, isUsingTypeScript } from '../utils/clack-utils';
+import chalk from 'chalk';
+import * as Sentry from '@sentry/node';
+
+function getSrcDirectory(isNuxtV4: boolean) {
+  // In nuxt v4, the src directory is `app/` unless
+  // users already had a `pages` directory
+  return isNuxtV4 && !fs.existsSync(path.resolve('pages')) ? 'app' : '.';
+}
+
+export async function supportsExamplePage(isNuxtV4: boolean) {
+  // We currently only support creating an example page
+  // if users can reliably access it without having to
+  // add code changes themselves.
+  //
+  // If users have an `app.vue` layout without the
+  // needed component to render routes (<NuxtPage/>),
+  // we bail out of creating an example page altogether.
+  const src = getSrcDirectory(isNuxtV4);
+  const app = path.join(src, 'app.vue');
+
+  // If there's no `app.vue` layout, nuxt automatically renders
+  // the routes.
+  if (!fs.existsSync(path.resolve(app))) {
+    return true;
+  }
+
+  const content = await fs.promises.readFile(path.resolve(app), 'utf8');
+  return !!content.match(/<NuxtPage/g);
+}
+
+export async function createExamplePage(
+  isNuxtV4: boolean,
+  options: {
+    org: string;
+    project: string;
+    projectId: string;
+    url: string;
+  },
+) {
+  try {
+    const src = getSrcDirectory(isNuxtV4);
+    const pages = path.join(src, 'pages');
+
+    if (!fs.existsSync(path.resolve(pages))) {
+      fs.mkdirSync(path.resolve(pages), { recursive: true });
+
+      const indexPage = path.join(pages, 'index.vue');
+
+      await fs.promises.writeFile(
+        path.resolve(indexPage),
+        getIndexRouteTemplate(),
+      );
+
+      clack.log.success(`Created ${chalk.cyan(indexPage)}.`);
+    }
+
+    const examplePage = path.join(pages, 'sentry-example-page.vue');
+
+    if (fs.existsSync(path.resolve(examplePage))) {
+      clack.log.warn(
+        `It seems like a sentry example page already exists. Skipping creation of example page.`,
+      );
+      return;
+    }
+
+    await fs.promises.writeFile(
+      path.resolve(examplePage),
+      getSentryExamplePageTemplate(options),
+    );
+
+    clack.log.success(`Created ${chalk.cyan(examplePage)}.`);
+
+    const api = path.join('server', 'api');
+
+    if (!fs.existsSync(path.resolve(api))) {
+      fs.mkdirSync(path.resolve(api), { recursive: true });
+    }
+
+    const exampleApi = path.join(
+      api,
+      isUsingTypeScript() ? 'sentry-example-api.ts' : 'sentry-example-api.js',
+    );
+
+    await fs.promises.writeFile(
+      path.resolve(exampleApi),
+      getSentryExampleApiTemplate(),
+    );
+
+    clack.log.success(`Created ${chalk.cyan(exampleApi)}.`);
+  } catch (e: unknown) {
+    clack.log.error('Error while creating an example page to test Sentry:');
+    clack.log.info(
+      chalk.dim(
+        typeof e === 'object' && e != null && 'toString' in e
+          ? e.toString()
+          : typeof e === 'string'
+          ? e
+          : 'Unknown error',
+      ),
+    );
+    Sentry.captureException(
+      'Error while creating an example Nuxt page to test Sentry',
+    );
+    await abort('Exiting Wizard');
+  }
+}
+
+export async function createExampleComponent(isNuxtV4: boolean) {
+  const src = getSrcDirectory(isNuxtV4);
+  const components = path.join(src, 'components');
+
+  if (!fs.existsSync(path.resolve(components))) {
+    fs.mkdirSync(path.resolve(components), { recursive: true });
+  }
+
+  const exampleComponent = path.join(components, 'SentryErrorButton.vue');
+
+  await fs.promises.writeFile(
+    path.resolve(exampleComponent),
+    getSentryErrorButtonTemplate(),
+  );
+
+  clack.log.success(`Created ${chalk.cyan(exampleComponent)}.`);
+}

--- a/src/nuxt/sdk-setup.ts
+++ b/src/nuxt/sdk-setup.ts
@@ -55,7 +55,7 @@ export async function getNuxtConfig(): Promise<string> {
 
 export async function addSDKModule(
   config: string,
-  options: { org: string; project: string; url?: string },
+  options: { org: string; project: string; url: string; selfHosted: boolean },
 ): Promise<void> {
   clack.log.info('Adding Sentry Nuxt Module to Nuxt config.');
 
@@ -66,7 +66,7 @@ export async function addSDKModule(
       sourceMapsUploadOptions: {
         org: options.org,
         project: options.project,
-        ...(options.url && { url: options.url }),
+        ...(options.selfHosted && { url: options.url }),
       },
     });
     addNuxtModule(mod, '@sentry/nuxt/module', 'sourcemap', { client: true });

--- a/src/nuxt/templates.ts
+++ b/src/nuxt/templates.ts
@@ -1,3 +1,4 @@
+import { getIssueStreamUrl } from '../utils/url';
 type SelectedSentryFeatures = {
   performance: boolean;
   replay: boolean;
@@ -101,5 +102,176 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });
+`;
+}
+
+export function getIndexRouteTemplate(): string {
+  return `<!--
+This is just to verify the sentry-example-page.
+Feel free to delete this file.
+-->
+
+<template></template>`;
+}
+
+export function getSentryExamplePageTemplate(options: {
+  url: string;
+  org: string;
+  projectId: string;
+}): string {
+  const { url, org, projectId } = options;
+  const issuesPageLink = getIssueStreamUrl({ url, orgSlug: org, projectId });
+
+  return `<!--
+This is just a very simple page with a button to throw an example error.
+Feel free to delete this file.
+-->
+
+<script setup>
+  import * as Sentry from '@sentry/nuxt';
+  import { useFetch} from '#imports'
+  
+  function getSentryData() {
+    Sentry.startSpan(
+      {
+        name: 'Example Frontend Span',
+        op: 'test'
+      },
+      async () => {
+        const { error } = await useFetch('/api/sentry-example-api');
+        if (error.value) {
+          throw new Error('Sentry Example Frontend Error');
+        }
+      }
+    )
+  }
+</script>
+
+<template>
+  <title>Sentry Onboarding</title>
+  <div>
+  <main>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44">
+      <path
+        fill="currentColor"
+        d="M124.32,28.28,109.56,9.22h-3.68V34.77h3.73V15.19l15.18,19.58h3.26V9.22h-3.73ZM87.15,23.54h13.23V20.22H87.14V12.53h14.93V9.21H83.34V34.77h18.92V31.45H87.14ZM71.59,20.3h0C66.44,19.06,65,18.08,65,15.7c0-2.14,1.89-3.59,4.71-3.59a12.06,12.06,0,0,1,7.07,2.55l2-2.83a14.1,14.1,0,0,0-9-3c-5.06,0-8.59,3-8.59,7.27,0,4.6,3,6.19,8.46,7.52C74.51,24.74,76,25.78,76,28.11s-2,3.77-5.09,3.77a12.34,12.34,0,0,1-8.3-3.26l-2.25,2.69a15.94,15.94,0,0,0,10.42,3.85c5.48,0,9-2.95,9-7.51C79.75,23.79,77.47,21.72,71.59,20.3ZM195.7,9.22l-7.69,12-7.64-12h-4.46L186,24.67V34.78h3.84V24.55L200,9.22Zm-64.63,3.46h8.37v22.1h3.84V12.68h8.37V9.22H131.08ZM169.41,24.8c3.86-1.07,6-3.77,6-7.63,0-4.91-3.59-8-9.38-8H154.67V34.76h3.8V25.58h6.45l6.48,9.2h4.44l-7-9.82Zm-10.95-2.5V12.6h7.17c3.74,0,5.88,1.77,5.88,4.84s-2.29,4.86-5.84,4.86Z M29,2.26a4.67,4.67,0,0,0-8,0L14.42,13.53A32.21,32.21,0,0,1,32.17,40.19H27.55A27.68,27.68,0,0,0,12.09,17.47L6,28a15.92,15.92,0,0,1,9.23,12.17H4.62A.76.76,0,0,1,4,39.06l2.94-5a10.74,10.74,0,0,0-3.36-1.9l-2.91,5a4.54,4.54,0,0,0,1.69,6.24A4.66,4.66,0,0,0,4.62,44H19.15a19.4,19.4,0,0,0-8-17.31l2.31-4A23.87,23.87,0,0,1,23.76,44H36.07a35.88,35.88,0,0,0-16.41-31.8l4.67-8a.77.77,0,0,1,1.05-.27c.53.29,20.29,34.77,20.66,35.17a.76.76,0,0,1-.68,1.13H40.6q.09,1.91,0,3.81h4.78A4.59,4.59,0,0,0,50,39.43a4.49,4.49,0,0,0-.62-2.28Z"
+      />
+    </svg>
+    <p>
+      Get Started with this <strong>simple Example:</strong>
+    </p>
+
+    <p>1. Send us a sample error:</p>
+    <button type="button" @click="getSentryData"> Throw error! </button>
+
+    <p>
+      2. Look for the error on the
+      <a href="${issuesPageLink}">Issues Page</a>.
+    </p>
+    <p style="margin-top: 24px;">
+      For more information, take a look at the
+      <a href="https://docs.sentry.io/platforms/javascript/guides/nuxt/">
+        Sentry Nuxt Documentation
+      </a>
+    </p>
+  </main>
+</div>
+</template>
+
+<style>
+  main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  svg {
+    font-size: 4rem;
+    margin: 14px 0;
+    height: 1em;
+  }
+
+  button {
+    padding: 12px;
+    cursor: pointer;
+    background-color: rgb(54, 45, 89);
+    border-radius: 4px;
+    border: none;
+    color: white;
+    font-size: 1em;
+    margin: 1em;
+    transition: all 0.25s ease-in-out;
+  }
+  button:hover {
+    background-color: #8c5393;
+    box-shadow: 4px;
+    box-shadow: 0px 0px 15px 2px rgba(140, 83, 147, 0.5);
+  }
+  button:active {
+    background-color: #c73852;
+  }
+</style>
+`;
+}
+
+export function getSentryExampleApiTemplate() {
+  return `// This is just a very simple API route that throws an example error.
+// Feel free to delete this file.
+import { defineEventHandler } from '#imports';
+
+export default defineEventHandler(event => {
+  throw new Error("Sentry Example API Route Error");
+});
+`;
+}
+
+export function getSentryErrorButtonTemplate() {
+  return `<!--
+This is just a very simple component that throws an example error.
+Feel free to delete this file.
+-->
+
+<script setup>
+  import * as Sentry from '@sentry/nuxt';
+  
+  const throwError = () => {
+    Sentry.startSpan(
+      {
+        name: 'Example Frontend Span',
+        op: 'test'
+      },
+      () => {
+        throw new Error('Sentry Example Error');
+      }
+    )
+  };
+</script>
+
+<template>
+  <button id="errorBtn" @click="throwError"> Throw Error! </button>
+</template>
+
+<style>
+  button {
+    padding: 12px;
+    cursor: pointer;
+    background-color: rgb(54, 45, 89);
+    border-radius: 4px;
+    border: none;
+    color: white;
+    font-size: 1em;
+    margin: 1em;
+    transition: all 0.25s ease-in-out;
+  }
+  button:hover {
+    background-color: #8c5393;
+    box-shadow: 4px;
+    box-shadow: 0px 0px 15px 2px rgba(140, 83, 147, 0.5);
+  }
+  button:active {
+    background-color: #c73852;
+  }
+</style>
 `;
 }

--- a/src/nuxt/utils.ts
+++ b/src/nuxt/utils.ts
@@ -1,0 +1,32 @@
+import { gte, minVersion } from 'semver';
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
+import { loadFile } from 'magicast';
+
+export async function isNuxtV4(
+  nuxtConfig: string,
+  packageVersion: string | undefined,
+) {
+  if (!packageVersion) {
+    return false;
+  }
+
+  const minVer = minVersion(packageVersion);
+  if (minVer && gte(minVer, '4.0.0')) {
+    return true;
+  }
+
+  // At the time of writing, nuxt 4 is not on its own
+  // major yet. We must read the `compatibilityVersion`
+  // from the nuxt config.
+  const mod = await loadFile(nuxtConfig);
+  const config =
+    mod.exports.default.$type === 'function-call'
+      ? mod.exports.default.$args[0]
+      : mod.exports.default;
+
+  if (config && config.future && config.future.compatibilityVersion === 4) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1415,6 +1415,24 @@ export async function askShouldCreateExamplePage(
   );
 }
 
+export async function askShouldCreateExampleComponent(): Promise<boolean> {
+  return traceStep('ask-create-example-component', () =>
+    abortIfCancelled(
+      clack.select({
+        message: `Do you want to create an example component to test your Sentry setup?`,
+        options: [
+          {
+            value: true,
+            label: 'Yes',
+            hint: 'Recommended - Check your git status before committing!',
+          },
+          { value: false, label: 'No' },
+        ],
+      }),
+    ),
+  );
+}
+
 export async function featureSelectionPrompt<F extends ReadonlyArray<Feature>>(
   features: F,
 ): Promise<{ [key in F[number]['id']]: boolean }> {


### PR DESCRIPTION
Sets up either an example page or an example vue component depending on whether the user has `<NuxtPage />` in their `app.vue`.

For users that have an `app.vue` but no `pages` route directory, adding an example page would probably be confusing as it will not visibly render anything unless `app.vue` has a `<NuxtPage/>` component.

Since we cannot reliably place <NuxtPage/> ourselves, I opted to create an example component instead for such cases.

#skip-changelog

Closes: #709 