### PR TITLE
chore(Android): Removes profiling from android manifest template

### DIFF
--- a/src/android/templates.ts
+++ b/src/android/templates.ts
@@ -33,8 +33,6 @@ export const manifest = (dsn: string) => `
 
     <!-- enable the performance API by setting a sample-rate, adjust in production env -->
     <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-    <!-- enable profiling when starting transactions, adjust in production env -->
-    <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 `;
 
 export const sentryImport = `import io.sentry.Sentry;\n`;


### PR DESCRIPTION
Removes Profiling from Android Manifest template. Related: https://github.com/getsentry/sentry-docs/pull/11905