### PR TITLE
ref(nuxt): Remove option to downgrade override nitropack

### DIFF
--- a/e2e-tests/tests/nuxt-3.test.ts
+++ b/e2e-tests/tests/nuxt-3.test.ts
@@ -44,25 +44,12 @@ async function runWizardOnNuxtProject(projectDir: string): Promise<void> {
     'Please select your package manager.',
   );
 
-  const nitropackOverridePrompted =
+  const nftOverridePrompted =
     packageManagerPrompted &&
     (await wizardInstance.sendStdinAndWaitForOutput(
       // Selecting `yarn` as the package manager
       [KEYS.DOWN, KEYS.ENTER],
-      // Do you want to install version 2.9.7 of nitropack and add an override to package.json?
-      'Do you want to add an override for nitropack version ~2.9.7?',
-      {
-        timeout: 240_000,
-      },
-    ));
-
-  const nftOverridePrompted =
-    nitropackOverridePrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      // Selecting `yes` to downgrade nitropack
-      KEYS.ENTER,
       'Do you want to add an override for @vercel/nft version ^0.27.4?',
-      // 'Do you want to install version',
       {
         timeout: 240_000,
       },

--- a/e2e-tests/tests/nuxt-4.test.ts
+++ b/e2e-tests/tests/nuxt-4.test.ts
@@ -43,25 +43,12 @@ async function runWizardOnNuxtProject(projectDir: string): Promise<void> {
     'Please select your package manager.',
   );
 
-  const nitropackOverridePrompted =
+  const nftOverridePrompted =
     packageManagerPrompted &&
     (await wizardInstance.sendStdinAndWaitForOutput(
       // Selecting `yarn` as the package manager
       [KEYS.DOWN, KEYS.ENTER],
-      // Do you want to install version 2.9.7 of nitropack and add an override to package.json?
-      'Do you want to add an override for nitropack version ~2.9.7?',
-      {
-        timeout: 240_000,
-      },
-    ));
-
-  const nftOverridePrompted =
-    nitropackOverridePrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      // Selecting `yes` to downgrade nitropack
-      KEYS.ENTER,
       'Do you want to add an override for @vercel/nft version ^0.27.4?',
-      // 'Do you want to install version',
       {
         timeout: 240_000,
       },

--- a/src/nuxt/sdk-setup.ts
+++ b/src/nuxt/sdk-setup.ts
@@ -223,10 +223,6 @@ export async function addNuxtOverrides(
 
   const overrides = [
     {
-      pkgName: 'nitropack',
-      pkgVersion: '~2.9.7',
-    },
-    {
       pkgName: '@vercel/nft',
       pkgVersion: '^0.27.4',
     },


### PR DESCRIPTION
Note: I kept the `@vercel/nft` override in without a version check because checking if a dependency of a dependency is installed is not super straight forward. I previously used https://github.com/browserify/resolve to check, but it requires dependencies to be installed - which they might not be yet at the point in time when we want to add overrides.

The alternative would be to run the install command for users again, which also seemed suboptimal.

So I opted to keep the override for `@vercel/nft` regardless of whether nitro is already over `2.10.0`.

Closes: #736
