### PR TITLE
feat(nuxt): Add deployment-platform flow with links to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(nuxt): Add `import-in-the-middle` install step when using pnpm ([#727](https://github.com/getsentry/sentry-wizard/pull/727))
 - fix(nuxt): Remove unused parameter in sentry-example-api template ([#734](https://github.com/getsentry/sentry-wizard/pull/734))
 - fix(nuxt): Remove option to downgrade override nitropack ([#744](https://github.com/getsentry/sentry-wizard/pull/744))
+- feat(nuxt): Add deployment-platform flow with links to docs ([#747](https://github.com/getsentry/sentry-wizard/pull/747))
 
 ## 3.36.0
 

--- a/e2e-tests/tests/nuxt-3.test.ts
+++ b/e2e-tests/tests/nuxt-3.test.ts
@@ -55,8 +55,18 @@ async function runWizardOnNuxtProject(projectDir: string): Promise<void> {
       },
     ));
 
-  const tracingOptionPrompted =
+  const deploymentPlatformPrompted =
     nftOverridePrompted &&
+    (await wizardInstance.sendStdinAndWaitForOutput(
+      KEYS.ENTER,
+      'Please select your deployment platform.',
+      {
+        timeout: 240_000,
+      },
+    ));
+
+  const tracingOptionPrompted =
+    deploymentPlatformPrompted &&
     (await wizardInstance.sendStdinAndWaitForOutput(
       KEYS.ENTER,
       // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.

--- a/e2e-tests/tests/nuxt-4.test.ts
+++ b/e2e-tests/tests/nuxt-4.test.ts
@@ -54,8 +54,18 @@ async function runWizardOnNuxtProject(projectDir: string): Promise<void> {
       },
     ));
 
-  const tracingOptionPrompted =
+  const deploymentPlatformPrompted =
     nftOverridePrompted &&
+    (await wizardInstance.sendStdinAndWaitForOutput(
+      KEYS.ENTER,
+      'Please select your deployment platform.',
+      {
+        timeout: 240_000,
+      },
+    ));
+
+  const tracingOptionPrompted =
+    deploymentPlatformPrompted &&
     (await wizardInstance.sendStdinAndWaitForOutput(
       KEYS.ENTER,
       // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.

--- a/src/nuxt/nuxt-wizard.ts
+++ b/src/nuxt/nuxt-wizard.ts
@@ -27,6 +27,7 @@ import {
   createConfigFiles,
   addNuxtOverrides,
   askDeploymentPlatform,
+  confirmReadImportDocs,
 } from './sdk-setup';
 import {
   createExampleComponent,
@@ -34,7 +35,6 @@ import {
   supportsExamplePage,
 } from './sdk-example';
 import { isNuxtV4 } from './utils';
-import { DeploymentPlatform } from './types';
 
 export function runNuxtWizard(options: WizardOptions) {
   return withTelemetry(
@@ -152,32 +152,18 @@ export async function runNuxtWizardWithTelemetry(
 
   await runPrettierIfInstalled();
 
+  await confirmReadImportDocs(deploymentPlatform);
+
   clack.outro(
-    buildOutroMessage(
-      shouldCreateExamplePage,
-      shouldCreateExampleButton,
-      deploymentPlatform,
-    ),
+    buildOutroMessage(shouldCreateExamplePage, shouldCreateExampleButton),
   );
 }
 
 function buildOutroMessage(
   shouldCreateExamplePage: boolean,
   shouldCreateExampleButton: boolean,
-  deploymentPlatform: DeploymentPlatform | symbol,
 ): string {
-  const canImportSentryServerConfigFile =
-    deploymentPlatform !== 'vercel' && deploymentPlatform !== 'netlify';
-
   let msg = chalk.green('\nSuccessfully installed the Sentry Nuxt SDK!');
-
-  if (canImportSentryServerConfigFile) {
-    msg += `\n\nAfter building your Nuxt app, you need to ${chalk.cyan(
-      '--import',
-    )} the Sentry server config file when running your app.\n\nFor more info see: ${chalk.cyan(
-      'https://docs.sentry.io/platforms/javascript/guides/nuxt/install/cli-import/#initializing-sentry-with---import',
-    )}`;
-  }
 
   if (shouldCreateExamplePage) {
     msg += `\n\nYou can validate your setup by visiting ${chalk.cyan(
@@ -190,7 +176,7 @@ function buildOutroMessage(
     )} component to a page and triggering it.`;
   }
 
-  msg += `\n\nCheck out the SDK documentation for further configuration: ${chalk.cyan(
+  msg += `\n\nCheck out the SDK documentation for further configuration: ${chalk.underline(
     'https://docs.sentry.io/platforms/javascript/guides/nuxt/',
   )}`;
 

--- a/src/nuxt/nuxt-wizard.ts
+++ b/src/nuxt/nuxt-wizard.ts
@@ -174,7 +174,7 @@ function buildOutroMessage(
   if (canImportSentryServerConfigFile) {
     msg += `\n\nAfter building your Nuxt app, you need to ${chalk.cyan(
       '--import',
-    )} the Sentry server config file.\n\nFor more info see: ${chalk.cyan(
+    )} the Sentry server config file when running your app.\n\nFor more info see: ${chalk.cyan(
       'https://docs.sentry.io/platforms/javascript/guides/nuxt/install/cli-import/#initializing-sentry-with---import',
     )}`;
   }

--- a/src/nuxt/sdk-setup.ts
+++ b/src/nuxt/sdk-setup.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/node';
 import chalk from 'chalk';
 import fs from 'fs';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
-import { loadFile, generateCode, MagicastError } from 'magicast';
+import { loadFile, generateCode } from 'magicast';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { addNuxtModule } from 'magicast/helpers';
 import path from 'path';

--- a/src/nuxt/templates.ts
+++ b/src/nuxt/templates.ts
@@ -14,12 +14,15 @@ export default defineNuxtConfig({
 `;
 }
 
-export function getNuxtModuleFallbackTemplate(options: {
-  org: string;
-  project: string;
-  url: string;
-  selfHosted: boolean;
-}): string {
+export function getNuxtModuleFallbackTemplate(
+  options: {
+    org: string;
+    project: string;
+    url: string;
+    selfHosted: boolean;
+  },
+  shouldTopLevelImport: boolean,
+): string {
   return `  modules: ["@sentry/nuxt/module"],
   sentry: {
     sourceMapsUploadOptions: {
@@ -27,7 +30,11 @@ export function getNuxtModuleFallbackTemplate(options: {
       project: "${options.project}",${
     options.selfHosted ? `\n      url: "${options.url}",` : ''
   }
-    },
+    },${
+      shouldTopLevelImport
+        ? `\n    autoInjectServerSentry: "top-level-import",`
+        : ''
+    }
   },
   sourcemap: { client: "hidden" },`;
 }

--- a/src/nuxt/types.ts
+++ b/src/nuxt/types.ts
@@ -1,0 +1,8 @@
+export const deploymentPlatforms = [
+  'vercel',
+  'netlify',
+  'other',
+  'none',
+] as const;
+
+export type DeploymentPlatform = (typeof deploymentPlatforms)[number];

--- a/src/nuxt/utils.ts
+++ b/src/nuxt/utils.ts
@@ -1,6 +1,9 @@
+// @ts-ignore - clack is ESM and TS complains about that. It works though
+import * as clack from '@clack/prompts';
 import { gte, minVersion } from 'semver';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { loadFile } from 'magicast';
+import { abortIfCancelled } from '../utils/clack-utils';
 
 export async function isNuxtV4(
   nuxtConfig: string,
@@ -18,14 +21,21 @@ export async function isNuxtV4(
   // At the time of writing, nuxt 4 is not on its own
   // major yet. We must read the `compatibilityVersion`
   // from the nuxt config.
-  const mod = await loadFile(nuxtConfig);
-  const config =
-    mod.exports.default.$type === 'function-call'
-      ? mod.exports.default.$args[0]
-      : mod.exports.default;
+  try {
+    const mod = await loadFile(nuxtConfig);
+    const config =
+      mod.exports.default.$type === 'function-call'
+        ? mod.exports.default.$args[0]
+        : mod.exports.default;
 
-  if (config && config.future && config.future.compatibilityVersion === 4) {
-    return true;
+    if (config && config.future && config.future.compatibilityVersion === 4) {
+      return true;
+    }
+  } catch {
+    // If we cannot parse their config, just ask.
+    return await abortIfCancelled(
+      clack.confirm({ message: 'Are you using Nuxt version 4?' }),
+    );
   }
 
   return false;

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -20,7 +20,7 @@ import {
 import { debug } from './debug';
 import { fulfillsVersionRange } from './semver';
 
-const opn = require('opn') as (
+export const opn = require('opn') as (
   url: string,
   options?: {
     wait?: boolean;

--- a/test/nuxt/templates.test.ts
+++ b/test/nuxt/templates.test.ts
@@ -206,12 +206,15 @@ describe('Nuxt code templates', () => {
 
   describe('getNuxtModuleFallbackTemplate', () => {
     it('generates configuration options for the nuxt config', () => {
-      const template = getNuxtModuleFallbackTemplate({
-        org: 'my-org',
-        project: 'my-project',
-        url: 'https://sentry.io',
-        selfHosted: false,
-      });
+      const template = getNuxtModuleFallbackTemplate(
+        {
+          org: 'my-org',
+          project: 'my-project',
+          url: 'https://sentry.io',
+          selfHosted: false,
+        },
+        false,
+      );
 
       expect(template).toMatchInlineSnapshot(`
         "  modules: ["@sentry/nuxt/module"],
@@ -220,6 +223,30 @@ describe('Nuxt code templates', () => {
               org: "my-org",
               project: "my-project",
             },
+          },
+          sourcemap: { client: "hidden" },"
+      `);
+    });
+
+    it('generates configuration options for the nuxt config with top level import', () => {
+      const template = getNuxtModuleFallbackTemplate(
+        {
+          org: 'my-org',
+          project: 'my-project',
+          url: 'https://sentry.io',
+          selfHosted: false,
+        },
+        true,
+      );
+
+      expect(template).toMatchInlineSnapshot(`
+        "  modules: ["@sentry/nuxt/module"],
+          sentry: {
+            sourceMapsUploadOptions: {
+              org: "my-org",
+              project: "my-project",
+            },
+            autoInjectServerSentry: "top-level-import",
           },
           sourcemap: { client: "hidden" },"
       `);


### PR DESCRIPTION
We now ask where users plan to deploy their app:
![Screenshot 2024-12-18 at 17 01 15@2x](https://github.com/user-attachments/assets/2ac8e428-5832-4df3-9c16-f77b6e1545ce)

For Vercel and Netlify we configure top level import of the Sentry server config file and link to docs:
![Screenshot 2024-12-18 at 17 01 27@2x](https://github.com/user-attachments/assets/0d4bc22c-a338-408d-89b8-d4fdeeda0b3f)

For other/none we instruct people at the end to `--import` their Sentry server config file and link to docs:
![Screenshot 2024-12-18 at 17 02 50@2x](https://github.com/user-attachments/assets/95e448ba-a2ba-437f-a61d-a36a4185244b)

This also improves the handling when a user's nuxt config can not be read. Instead of exiting the wizard, we continue and instruct people how to manually add it (already existed, but we bailed immediately after instructing).

Closes: #739