### PR TITLE
fix(react-native): Replaces the deprecated enableSpotlight option with spotlight

### DIFF
--- a/src/react-native/javascript.ts
+++ b/src/react-native/javascript.ts
@@ -98,6 +98,6 @@ Sentry.init({
   dsn: '${dsn}',
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-  // enableSpotlight: __DEV__,
+  // spotlight: __DEV__,
 });`;
 }

--- a/test/react-native/javascript.test.ts
+++ b/test/react-native/javascript.test.ts
@@ -33,7 +33,7 @@ Sentry.init({
   dsn: 'dsn',
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-  // enableSpotlight: __DEV__,
+  // spotlight: __DEV__,
 });
 
 const App = () => {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-react-native/issues/4403

## Description
Replaces[ the deprecated `enableSpotlight` option](https://github.com/getsentry/sentry-react-native/pull/4086) with `spotlight` in the suggested `Sentry.init` comment.

[The option was deprecated in v6](https://docs.sentry.io/platforms/react-native/migration/v5-to-v6/#enablespotlight-and-spotlightsidecarurl-replaced-by-spotlight).

#skip-changelog