### PR TITLE
feat(react-native): Add minimum supported Sentry React Native SDK version detection (>=5.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat(react-native): Add minimum supported Sentry React Native SDK version detection (>=5.0.0) ([#752](https://github.com/getsentry/sentry-wizard/pull/752))
+
 ## 3.37.0
 
 - feat(nuxt): Add `import-in-the-middle` install step when using pnpm ([#727](https://github.com/getsentry/sentry-wizard/pull/727))

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -17,6 +17,7 @@ import {
   printWelcome,
   propertiesCliSetupConfig,
   runPrettierIfInstalled,
+  abort,
 } from '../utils/clack-utils';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import { podInstall } from '../apple/cocoapod';
@@ -57,6 +58,7 @@ import { addExpoEnvLocal } from './expo-env-file';
 const xcode = require('xcode');
 
 export const RN_SDK_PACKAGE = '@sentry/react-native';
+export const RN_SDK_SUPPORTED_RANGE = '>=5.0.0';
 
 export const RN_PACKAGE = 'react-native';
 export const RN_HUMAN_NAME = 'React Native';
@@ -68,21 +70,20 @@ export const SUPPORTED_EXPO_RANGE = '>=50.0.0';
  * The following SDK version ship with bundled Xcode scripts
  * which simplifies the Xcode Build Phases setup.
  */
-export const SDK_XCODE_SCRIPTS_SUPPORTED_SDK_RANGE = '>=5.11.0';
+export const XCODE_SCRIPTS_SUPPORTED_SDK_RANGE = '>=5.11.0';
 
 /**
  * The following SDK version ship with Sentry Metro plugin
  */
-export const SDK_SENTRY_METRO_PLUGIN_SUPPORTED_SDK_RANGE = '>=5.11.0';
+export const SENTRY_METRO_PLUGIN_SUPPORTED_SDK_RANGE = '>=5.11.0';
 
 /**
  * The following SDK version ship with bundled Expo plugin
  */
-export const SDK_EXPO_SUPPORTED_SDK_RANGE = `>=5.16.0`;
+export const EXPO_SUPPORTED_SDK_RANGE = `>=5.16.0`;
 
 // The following SDK version shipped `withSentryConfig`
-export const SDK_SENTRY_METRO_WITH_SENTRY_CONFIG_SUPPORTED_SDK_RANGE =
-  '>=5.17.0';
+export const METRO_WITH_SENTRY_CONFIG_SUPPORTED_SDK_RANGE = '>=5.17.0';
 
 export type RNCliSetupConfigContent = Pick<
   Required<CliSetupConfigContent>,
@@ -151,6 +152,26 @@ Or setup using ${chalk.cyan(
     RN_SDK_PACKAGE,
     await getPackageDotJson(),
   );
+  if (sdkVersion) {
+    await confirmContinueIfPackageVersionNotSupported({
+      packageName: 'Sentry React Native SDK',
+      packageVersion: sdkVersion,
+      packageId: RN_SDK_PACKAGE,
+      acceptableVersions: RN_SDK_SUPPORTED_RANGE,
+      note: `Please upgrade to ${RN_SDK_SUPPORTED_RANGE} to continue with the wizard in this project.`,
+    });
+  } else {
+    const continueWithoutSdk = await abortIfCancelled(
+      clack.confirm({
+        message:
+          'Could not detect Sentry React Native SDK version. Do you want to continue anyway?',
+      }),
+    );
+    if (!continueWithoutSdk) {
+      await abort(undefined, 0);
+    }
+  }
+  Sentry.setTag(`detected-sentry-react-native-sdk-version`, sdkVersion);
 
   const expoVersion = getPackageVersion('expo', packageJson);
   const isExpo = !!expoVersion;
@@ -159,8 +180,8 @@ Or setup using ${chalk.cyan(
       packageName: 'Sentry React Native SDK',
       packageVersion: sdkVersion,
       packageId: RN_SDK_PACKAGE,
-      acceptableVersions: SDK_EXPO_SUPPORTED_SDK_RANGE,
-      note: `Please upgrade to ${SDK_EXPO_SUPPORTED_SDK_RANGE} to continue with the wizard in this Expo project.`,
+      acceptableVersions: EXPO_SUPPORTED_SDK_RANGE,
+      note: `Please upgrade to ${EXPO_SUPPORTED_SDK_RANGE} to continue with the wizard in this Expo project.`,
     });
     await confirmContinueIfPackageVersionNotSupported({
       packageName: 'Expo SDK',
@@ -250,8 +271,7 @@ function addSentryToMetroConfig({
     sdkVersion &&
     fulfillsVersionRange({
       version: sdkVersion,
-      acceptableVersions:
-        SDK_SENTRY_METRO_WITH_SENTRY_CONFIG_SUPPORTED_SDK_RANGE,
+      acceptableVersions: METRO_WITH_SENTRY_CONFIG_SUPPORTED_SDK_RANGE,
       canBeLatest: true,
     })
   ) {
@@ -262,7 +282,7 @@ function addSentryToMetroConfig({
     sdkVersion &&
     fulfillsVersionRange({
       version: sdkVersion,
-      acceptableVersions: SDK_SENTRY_METRO_PLUGIN_SUPPORTED_SDK_RANGE,
+      acceptableVersions: SENTRY_METRO_PLUGIN_SUPPORTED_SDK_RANGE,
       canBeLatest: true,
     })
   ) {
@@ -356,7 +376,7 @@ async function patchXcodeFiles(
       context.sdkVersion &&
       fulfillsVersionRange({
         version: context.sdkVersion,
-        acceptableVersions: SDK_XCODE_SCRIPTS_SUPPORTED_SDK_RANGE,
+        acceptableVersions: XCODE_SCRIPTS_SUPPORTED_SDK_RANGE,
         canBeLatest: true,
       })
     ) {
@@ -381,7 +401,7 @@ async function patchXcodeFiles(
       context.sdkVersion &&
       fulfillsVersionRange({
         version: context.sdkVersion,
-        acceptableVersions: SDK_XCODE_SCRIPTS_SUPPORTED_SDK_RANGE,
+        acceptableVersions: XCODE_SCRIPTS_SUPPORTED_SDK_RANGE,
         canBeLatest: true,
       })
     ) {


### PR DESCRIPTION
Add warning when running on lower than supported Sentry RN SDK version.

Aborts when canceled or answered no.

This will be helpful when cutting min supported version in the future. Example min 6.X.X.

Example:

<img width="634" alt="Screenshot 2025-01-07 at 15 53 53" src="https://github.com/user-attachments/assets/e137553c-5830-4f35-b631-015b0a10f8fa" />
