### PR TITLE
feat(wizard-ui): Always send platform query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Always send platform query param to auth page ([#757](https://github.com/getsentry/sentry-wizard/pull/757))
+
+
 ## 3.38.0
 
 - feat(react-native): Add minimum supported Sentry React Native SDK version detection (>=5.0.0) ([#752](https://github.com/getsentry/sentry-wizard/pull/752))

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1096,11 +1096,12 @@ async function askForWizardLogin(options: {
 
   if (!hasSentryAccount) {
     loginUrl.searchParams.set('signup', '1');
-    if (options.platform) {
-      loginUrl.searchParams.set('project_platform', options.platform);
-    }
   }
-
+  
+  if (options.platform) {
+    loginUrl.searchParams.set('project_platform', options.platform);
+  }
+  
   if (options.promoCode) {
     loginUrl.searchParams.set('code', options.promoCode);
   }

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1097,11 +1097,11 @@ async function askForWizardLogin(options: {
   if (!hasSentryAccount) {
     loginUrl.searchParams.set('signup', '1');
   }
-  
+
   if (options.platform) {
     loginUrl.searchParams.set('project_platform', options.platform);
   }
-  
+
   if (options.promoCode) {
     loginUrl.searchParams.set('code', options.promoCode);
   }


### PR DESCRIPTION
Always send the current platform to the auth / project selection page.
The page will pick it up and allow creating a new project using this platform.

part of https://github.com/getsentry/sentry-wizard/issues/549