### PR TITLE
ref(telemetry): Set tunnelroute decision as attribute and tag

### DIFF
--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -926,7 +926,7 @@ async function createExamplePage(
  * It's valuable enough to for users to justify asking the additional question.
  */
 async function askShouldSetTunnelRoute() {
-  return await traceStep('ask-tunnelRoute-option', async () => {
+  return await traceStep('ask-tunnelRoute-option', async (span) => {
     const shouldSetTunnelRoute = await abortIfCancelled(
       clack.select({
         message:
@@ -952,6 +952,9 @@ async function askShouldSetTunnelRoute() {
         "Sounds good! We'll leave the option commented for later, just in case :)",
       );
     }
+
+    span?.setAttribute('tunnelRoute', shouldSetTunnelRoute);
+    Sentry.setTag('tunnelRoute', shouldSetTunnelRoute);
 
     return shouldSetTunnelRoute;
   });

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -9,6 +9,7 @@ import {
   setTag,
   startSpan,
   flush,
+  Span,
 } from '@sentry/node';
 import packageJson from '../package.json';
 import { WizardOptions } from './utils/types';
@@ -110,9 +111,12 @@ function createSentryInstance(enabled: boolean, integration: string) {
   return { sentryHub: hub, sentryClient: client };
 }
 
-export function traceStep<T>(step: string, callback: () => T): T {
+export function traceStep<T>(
+  step: string,
+  callback: (span: Span | undefined) => T,
+): T {
   updateProgress(step);
-  return startSpan({ name: step, op: 'wizard.step' }, () => callback());
+  return startSpan({ name: step, op: 'wizard.step' }, (span) => callback(span));
 }
 
 export function updateProgress(step: string) {


### PR DESCRIPTION
also pass the span to the `traceStep` callback so that we can more easily interact with the step span.
#skip-changelog