### PR TITLE
fix(nextjs): Mention correct local auth token file during source map generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Always send platform query param to auth page ([#757](https://github.com/getsentry/sentry-wizard/pull/757))
+- fix(nextjs): Mention correct local auth token file during source map generation ([#764](https://github.com/getsentry/sentry-wizard/pull/764))
 
 
 ## 3.38.0

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -354,7 +354,6 @@ export function checkEnvBuildPlugin(projectDir: string) {
 export async function checkIfBuilds(projectDir: string) {
   const testEnv = new WizardTestEnv('npm', ['run', 'build'], {
     cwd: projectDir,
-    debug: true,
   });
 
   await expect(

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -354,6 +354,7 @@ export function checkEnvBuildPlugin(projectDir: string) {
 export async function checkIfBuilds(projectDir: string) {
   const testEnv = new WizardTestEnv('npm', ['run', 'build'], {
     cwd: projectDir,
+    debug: true,
   });
 
   await expect(

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -267,13 +267,9 @@ export async function configureCI(
     'create-react-app',
   ].includes(selectedTool);
 
-  // some non-cli-based flows also use the .sentryclirc file
-  const usesSentryCliRc = selectedTool === 'nextjs';
-
-  const authTokenFile =
-    isCliBasedFlowTool || usesSentryCliRc
-      ? SENTRY_CLI_RC_FILE
-      : SENTRY_DOT_ENV_FILE;
+  const authTokenFile = isCliBasedFlowTool
+    ? SENTRY_CLI_RC_FILE
+    : SENTRY_DOT_ENV_FILE;
 
   if (!isUsingCI) {
     clack.log.info(


### PR DESCRIPTION
Remove a leftover check in the source maps wizard which is also used in the NextJS wizard that would mention `.sentryclirc` instead of `.env.sentry-build-plugins`. This was a leftover from the days where NextJS would still write `.sentryclirc`.

fixes #763 