### PR TITLE
chore: Cleanup changelog before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## Unreleased
 
 - feat: Add `forceInstall` option to NPM-based wizards ([#791](https://github.com/getsentry/sentry-wizard/pull/791))
+- feat(apple): Add extended whitespace support to AppDelegate detection; add tests for code-tools (#785)
 - fix(apple): Fix null-handling in apple-wizard with typings ([#775](https://github.com/getsentry/sentry-wizard/pull/775))
-- feat(apple): add extended whitespace support to AppDelegate detection; add tests for code-tools (#785)
-- test(apple): Add unit tests for Fastfile injection ([#786](https://github.com/getsentry/sentry-wizard/pull/786))
 
 ## 3.40.0
 


### PR DESCRIPTION
just a small cleanup, removing non-user-facing entry and fixing ordering before cutting a release

#skip-changelog