### PR TITLE
feat: Update `nextjs`, `remix`, `sveltekit` and `nuxt` wizards to install v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: Update `nextjs`, `remix`, `sveltekit` and `nuxt` wizards to install v9 ([#794](https://github.com/getsentry/sentry-wizard/pull/794))
+
 ## 3.41.0
 
 - feat: Add `forceInstall` option to NPM-based wizards ([#791](https://github.com/getsentry/sentry-wizard/pull/791))

--- a/e2e-tests/tests/remix.test.ts
+++ b/e2e-tests/tests/remix.test.ts
@@ -184,8 +184,7 @@ function checkRemixProject(
       'import * as Sentry from "@sentry/remix";',
       `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
-    tracesSampleRate: 1,
-    autoInstrumentRemix: true
+    tracesSampleRate: 1
 })`,
     ]);
   });

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -95,7 +95,7 @@ export async function runNextjsWizardWithTelemetry(
 
   const { packageManager: packageManagerFromInstallStep } =
     await installPackage({
-      packageName: '@sentry/nextjs@^8',
+      packageName: '@sentry/nextjs@^9',
       packageNameDisplayLabel: '@sentry/nextjs',
       alreadyInstalled: !!packageJson?.dependencies?.['@sentry/nextjs'],
       forceInstall,

--- a/src/nuxt/nuxt-wizard.ts
+++ b/src/nuxt/nuxt-wizard.ts
@@ -103,7 +103,7 @@ export async function runNuxtWizardWithTelemetry(
   Sentry.setTag('sdk-already-installed', sdkAlreadyInstalled);
 
   await installPackage({
-    packageName: '@sentry/nuxt',
+    packageName: '@sentry/nuxt@^9',
     alreadyInstalled: sdkAlreadyInstalled,
     packageManager,
     forceInstall,

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -72,7 +72,7 @@ async function runRemixWizardWithTelemetry(
     await getOrAskForProjectData(options, 'javascript-remix');
 
   await installPackage({
-    packageName: '@sentry/remix@^8',
+    packageName: '@sentry/remix@^9',
     packageNameDisplayLabel: '@sentry/remix',
     alreadyInstalled: hasPackageInstalled('@sentry/remix', packageJson),
     forceInstall,

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -124,11 +124,6 @@ function getInitCallArgs(
     }
   }
 
-  // Adding autoInstrumentRemix option only for server
-  if (type === 'server') {
-    initCallArgs.autoInstrumentRemix = true;
-  }
-
   return initCallArgs;
 }
 

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -97,7 +97,7 @@ export async function runSvelteKitWizardWithTelemetry(
   Sentry.setTag('sdk-already-installed', sdkAlreadyInstalled);
 
   await installPackage({
-    packageName: '@sentry/sveltekit@^8',
+    packageName: '@sentry/sveltekit@^9',
     packageNameDisplayLabel: '@sentry/sveltekit',
     alreadyInstalled: sdkAlreadyInstalled,
     forceInstall,

--- a/test/remix/server-instrumentation.test.ts
+++ b/test/remix/server-instrumentation.test.ts
@@ -13,8 +13,7 @@ describe('generateServerInstrumentationFile', () => {
 
       Sentry.init({
           dsn: "https://sentry.io/123",
-          tracesSampleRate: 1,
-          autoInstrumentRemix: true
+          tracesSampleRate: 1
       })"
     `);
   });
@@ -30,8 +29,7 @@ describe('generateServerInstrumentationFile', () => {
       "import * as Sentry from "@sentry/remix";
 
       Sentry.init({
-          dsn: "https://sentry.io/123",
-          autoInstrumentRemix: true
+          dsn: "https://sentry.io/123"
       })"
     `);
   });


### PR DESCRIPTION
- Updated SDKs to v9
- Followed migration guide to remove `autoInstrumentRemix` from Remix
- Pinned nuxt wizard to v9

Closes: https://github.com/getsentry/sentry-javascript/issues/14266