### PR TITLE
fix(nextjs): Remove outdated `hideSourceMaps` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - ref!: Bump main Node.js version to the earliest LTS v18 ([#793](https://github.com/getsentry/sentry-wizard/pull/793))
+- fix(nextjs): Remove outdated `hideSourceMaps` option (#798)
 
 ## 3.42.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## Unreleased
 
 - ref!: Bump main Node.js version to the earliest LTS v18 ([#793](https://github.com/getsentry/sentry-wizard/pull/793))
+
+## 3.42.1
+
 - fix(nextjs): Remove outdated `hideSourceMaps` option (#798)
 
 ## 3.42.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/wizard",
-  "version": "3.42.0",
+  "version": "3.42.1",
   "homepage": "https://github.com/getsentry/sentry-wizard",
   "repository": "https://github.com/getsentry/sentry-wizard",
   "description": "Sentry wizard helping you to configure your project",

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -52,9 +52,6 @@ export function getWithSentryConfigOptionsTemplate({
     // side errors will fail.
     ${tunnelRoute ? '' : '// '}tunnelRoute: "/monitoring",
 
-    // Hides source maps from generated client bundles
-    hideSourceMaps: true,
-
     // Automatically tree-shake Sentry logger statements to reduce bundle size
     disableLogger: true,
 

--- a/src/sourcemaps/tools/nextjs.ts
+++ b/src/sourcemaps/tools/nextjs.ts
@@ -33,9 +33,6 @@ const getCodeSnippet = (options: SourceMapUploadToolConfigurationOptions) =>
   ${chalk.greenBright(`const sentryOptions = {
     // Upload additional client files (increases upload size)
     widenClientFileUpload: true,
-
-    // Hides source maps from generated client bundles
-    hideSourceMaps: true,
   };`)}
 
   ${chalk.greenBright(`module.exports = withSentryConfig(

--- a/test/nextjs/templates.test.ts
+++ b/test/nextjs/templates.test.ts
@@ -273,9 +273,6 @@ describe('Next.js code templates', () => {
             // side errors will fail.
             tunnelRoute: "/monitoring",
 
-            // Hides source maps from generated client bundles
-            hideSourceMaps: true,
-
             // Automatically tree-shake Sentry logger statements to reduce bundle size
             disableLogger: true,
 
@@ -322,9 +319,6 @@ describe('Next.js code templates', () => {
             // side errors will fail.
             tunnelRoute: "/monitoring",
 
-            // Hides source maps from generated client bundles
-            hideSourceMaps: true,
-
             // Automatically tree-shake Sentry logger statements to reduce bundle size
             disableLogger: true,
 
@@ -369,9 +363,6 @@ describe('Next.js code templates', () => {
             // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
             // side errors will fail.
             // tunnelRoute: "/monitoring",
-
-            // Hides source maps from generated client bundles
-            hideSourceMaps: true,
 
             // Automatically tree-shake Sentry logger statements to reduce bundle size
             disableLogger: true,
@@ -422,9 +413,6 @@ describe('Next.js code templates', () => {
             // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
             // side errors will fail.
             tunnelRoute: "/monitoring",
-
-            // Hides source maps from generated client bundles
-            hideSourceMaps: true,
 
             // Automatically tree-shake Sentry logger statements to reduce bundle size
             disableLogger: true,


### PR DESCRIPTION
In v9, we removed the `hideSourceMaps` option from the nextJS SDK (`withSentryConfig` build option) because we by default set source maps to `hidden`. When we bumped the downloaded SDK version in the wizard to v9 (#794), we started installing a wizard that didn't support this option in its typedef anymore but the wizard still added it to users' code, resulting in an immediate build error during type checking. 

This PR removes the `hideSourceMaps` option from the Next config modification logic to fix this. 

#skip-changelog

Update: I created a release from this branch specifically because we couldn't release from `master` at the time of creating this PR and I wanted the fix to be released soon. That's the reason why this branch has a release bot commit and why I'm merging it without squashing into `master`. That's also the reason for the `#skip-changelog` directive. The changelog was updated but our check doesn't catch it because it is not under `## Unreleased` anymore.