### PR TITLE
feat: Update minimum supported Electron version

### DIFF
--- a/lib/Steps/Integrations/Electron.ts
+++ b/lib/Steps/Integrations/Electron.ts
@@ -9,7 +9,7 @@ import { dim, green, l, nl, red } from '../../Helper/Logging';
 import { SentryCli } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
 
-const MIN_ELECTRON_VERSION_STRING = '2.0.0';
+const MIN_ELECTRON_VERSION_STRING = '23.0.0';
 const MIN_ELECTRON_VERSION = parseInt(
   MIN_ELECTRON_VERSION_STRING.replace(/\D+/g, ''),
   10,


### PR DESCRIPTION
The recently released v6.0.0 of the Electron SDK bumps the minimum supported version of Electron to v23. 

It looks like we didn't update this for the last major version!

#skip-changelog