### PR TITLE
ref: No more dynamic requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - ref!: Bump main Node.js version to the earliest LTS v18 ([#793](https://github.com/getsentry/sentry-wizard/pull/793))
 - ref!: Follow up to Node v18 changes ([#797](https://github.com/getsentry/sentry-wizard/pull/797))
 - ref: Remove obsolete deps (r2, lodash) ([#799](https://github.com/getsentry/sentry-wizard/pull/799))
-- ref: No more dynamic requires ([#800](https://github.com/getsentry/sentry-wizard/pull/800))
+- ref: No more dynamic requires ([#801](https://github.com/getsentry/sentry-wizard/pull/801))
 
 ## 3.42.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ref!: Bump main Node.js version to the earliest LTS v18 ([#793](https://github.com/getsentry/sentry-wizard/pull/793))
 - ref!: Follow up to Node v18 changes ([#797](https://github.com/getsentry/sentry-wizard/pull/797))
 - ref: Remove obsolete deps (r2, lodash) ([#799](https://github.com/getsentry/sentry-wizard/pull/799))
+- ref: No more dynamic requires ([#800](https://github.com/getsentry/sentry-wizard/pull/800))
 
 ## 3.42.1
 

--- a/lib/Steps/ChooseIntegration.ts
+++ b/lib/Steps/ChooseIntegration.ts
@@ -12,14 +12,19 @@ import { Cordova } from './Integrations/Cordova';
 import { Electron } from './Integrations/Electron';
 import { hasPackageInstalled } from '../../src/utils/package-json';
 import { dim } from '../Helper/Logging';
+import { readFileSync } from 'node:fs';
 
-let projectPackage: any = {};
+let projectPackage: Record<string, unknown> = {};
 
 try {
   // If we run directly in setup-wizard
-  projectPackage = require('../../package.json');
+  projectPackage = JSON.parse(
+    readFileSync('../../package.json', 'utf-8'),
+  ) as Record<string, unknown>;
 } catch {
-  projectPackage = require(`${process.cwd()}/package.json`);
+  projectPackage = JSON.parse(
+    readFileSync(`${process.cwd()}/package.json`, 'utf-8'),
+  ) as Record<string, unknown>;
 }
 
 type IntegrationPromptAnswer = {

--- a/lib/Steps/Initial.ts
+++ b/lib/Steps/Initial.ts
@@ -3,27 +3,36 @@ import { join, dirname } from 'node:path';
 
 import { dim } from '../Helper/Logging';
 import { BaseStep } from './BaseStep';
+import { readFileSync } from 'node:fs';
 
 type PackageJSON = { version?: string };
 let wizardPackage: PackageJSON = {};
 let sentryCliPackage: PackageJSON = {};
 
 try {
-  wizardPackage = require(join(
-    dirname(require.resolve('@sentry/wizard')),
-    '..',
-    'package.json',
-  ));
+  wizardPackage = process.env.npm_package_version
+    ? { version: process.env.npm_package_version }
+    : (JSON.parse(
+        readFileSync(
+          join(
+            dirname(require.resolve('@sentry/wizard')),
+            '..',
+            'package.json',
+          ),
+          'utf-8',
+        ),
+      ) as PackageJSON);
 } catch {
   // We don't need to have this
 }
 
 try {
-  sentryCliPackage = require(join(
-    dirname(require.resolve('@sentry/cli')),
-    '..',
-    'package.json',
-  ));
+  sentryCliPackage = JSON.parse(
+    readFileSync(
+      join(dirname(require.resolve('@sentry/cli')), '..', 'package.json'),
+      'utf-8',
+    ),
+  ) as PackageJSON;
 } catch {
   // We don't need to have this
 }

--- a/lib/Steps/OpenSentry.ts
+++ b/lib/Steps/OpenSentry.ts
@@ -1,5 +1,5 @@
+import { URL } from 'node:url';
 import type { Answers } from 'inquirer';
-import { URL } from 'url';
 
 import { mapIntegrationToPlatform } from '../Constants';
 import { BottomBar } from '../Helper/BottomBar';
@@ -7,7 +7,7 @@ import { dim, green, l, nl, red } from '../Helper/Logging';
 import { getCurrentIntegration } from '../Helper/Wizard';
 import { BaseStep } from './BaseStep';
 
-const opn = require('opn');
+import opn from 'opn';
 
 export class OpenSentry extends BaseStep {
   public async emit(answers: Answers): Promise<Answers> {

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -501,8 +501,8 @@ export default function GlobalError(${chalk.green(
   );
 }
 `;
-  } else {
-    return `"use client";
+  }
+  return `"use client";
 
 ${chalk.green('import * as Sentry from "@sentry/nextjs";')}
 ${chalk.green('import Error from "next/error";')}
@@ -522,5 +522,4 @@ export default function GlobalError(${chalk.green('{ error }')}) {
   );
 }
 `;
-  }
 }

--- a/src/nuxt/sdk-setup.ts
+++ b/src/nuxt/sdk-setup.ts
@@ -1,19 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import * as Sentry from '@sentry/node';
 import chalk from 'chalk';
-import fs from 'fs';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
-import { loadFile, generateCode } from 'magicast';
+import { generateCode, loadFile } from 'magicast';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { addNuxtModule } from 'magicast/helpers';
-import path from 'path';
-import {
-  getConfigBody,
-  getDefaultNuxtConfig,
-  getNuxtModuleFallbackTemplate,
-  getSentryConfigContents,
-} from './templates';
+import opn from 'opn';
+import { type SemVer, lt } from 'semver';
+import { traceStep } from '../telemetry';
 import {
   abortIfCancelled,
   askShouldAddPackageOverride,
@@ -21,13 +18,19 @@ import {
   featureSelectionPrompt,
   installPackage,
   isUsingTypeScript,
-  opn,
 } from '../utils/clack-utils';
-import { traceStep } from '../telemetry';
-import { lt, SemVer } from 'semver';
-import { PackageManager, PNPM } from '../utils/package-manager';
-import { hasPackageInstalled, PackageDotJson } from '../utils/package-json';
-import { deploymentPlatforms, DeploymentPlatform } from './types';
+import {
+  type PackageDotJson,
+  hasPackageInstalled,
+} from '../utils/package-json';
+import { PNPM, type PackageManager } from '../utils/package-manager';
+import {
+  getConfigBody,
+  getDefaultNuxtConfig,
+  getNuxtModuleFallbackTemplate,
+  getSentryConfigContents,
+} from './templates';
+import { type DeploymentPlatform, deploymentPlatforms } from './types';
 
 const possibleNuxtConfig = [
   'nuxt.config.js',

--- a/src/react-native/expo-metro.ts
+++ b/src/react-native/expo-metro.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 // @ts-ignore - magicast is ESM and TS complains about that. It works though
-import { ProxifiedModule } from 'magicast';
+import type { ProxifiedModule } from 'magicast';
 import chalk from 'chalk';
 import * as Sentry from '@sentry/node';
 

--- a/src/react-native/xcode.ts
+++ b/src/react-native/xcode.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';

--- a/src/run.ts
+++ b/src/run.ts
@@ -16,6 +16,7 @@ import { runSourcemapsWizard } from './sourcemaps/sourcemaps-wizard';
 import { readEnvironment } from '../lib/Helper/Env';
 import type { Platform } from '../lib/Constants';
 import type { PackageDotJson } from './utils/package-json';
+import { readFileSync } from 'node:fs';
 
 type WizardIntegration =
   | 'reactNative'
@@ -195,10 +196,16 @@ export async function run(argv: Args) {
  * TODO: replace with rollup replace whenever we switch to rollup
  */
 function tryGetWizardVersion(): string {
-  try {
-    const wizardPkgJson = require('../package.json') as PackageDotJson;
-    return wizardPkgJson.version ?? '';
-  } catch {
-    return '';
+  let version = process.env.npm_package_version;
+  if (!version) {
+    try {
+      const wizardPkgJson = JSON.parse(
+        readFileSync('../package.json', 'utf-8'),
+      ) as PackageDotJson;
+      version = wizardPkgJson.version;
+    } catch {
+      // ignore
+    }
   }
+  return version ?? '';
 }

--- a/src/sourcemaps/tools/nextjs.ts
+++ b/src/sourcemaps/tools/nextjs.ts
@@ -7,9 +7,9 @@ import {
   abortIfCancelled,
   addDotEnvSentryBuildPluginFile,
 } from '../../utils/clack-utils';
-import { WizardOptions } from '../../utils/types';
+import type { WizardOptions } from '../../utils/types';
 
-import { SourceMapUploadToolConfigurationOptions } from './types';
+import type { SourceMapUploadToolConfigurationOptions } from './types';
 
 import * as Sentry from '@sentry/node';
 

--- a/src/sourcemaps/tools/webpack.ts
+++ b/src/sourcemaps/tools/webpack.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
@@ -23,7 +23,7 @@ import {
 } from '../../utils/clack-utils';
 import { hasPackageInstalled } from '../../utils/package-json';
 
-import {
+import type {
   SourceMapUploadToolConfigurationFunction,
   SourceMapUploadToolConfigurationOptions,
 } from './types';

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1,27 +1,26 @@
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { setInterval } from 'node:timers';
+import { URL } from 'node:url';
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import * as Sentry from '@sentry/node';
 import axios from 'axios';
 import chalk from 'chalk';
-import * as childProcess from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
-import { URL } from 'node:url';
 import opn from 'opn';
-import { setInterval } from 'timers';
 import { traceStep } from '../telemetry';
 import { debug } from './debug';
-import { hasPackageInstalled, PackageDotJson } from './package-json';
+import { type PackageDotJson, hasPackageInstalled } from './package-json';
 import {
+  type PackageManager,
   detectPackageManger,
-  PackageManager,
   packageManagers,
 } from './package-manager';
 import { fulfillsVersionRange } from './semver';
-import { Feature, SentryProjectData, WizardOptions } from './types';
+import type { Feature, SentryProjectData, WizardOptions } from './types';
 
-export { opn };
 export const SENTRY_DOT_ENV_FILE = '.env.sentry-build-plugin';
 export const SENTRY_CLI_RC_FILE = '.sentryclirc';
 export const SENTRY_PROPERTIES_FILE = 'sentry.properties';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,6 @@
     "emitDecoratorMetadata": true,
     "sourceMap": true,
     "inlineSources": true,
-    "resolveJsonModule": true,
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
This patch changes all dynamic requires except for a few, 'safe' cases and 'sentry/cli' related ones as it will be removed in a follow up
