### PR TITLE
test(nextjs): Catch type errors in `next.config.ts`

### DIFF
--- a/e2e-tests/test-applications/nextjs-test-app/next.config.mjs
+++ b/e2e-tests/test-applications/nextjs-test-app/next.config.mjs
@@ -1,4 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;

--- a/e2e-tests/test-applications/nextjs-test-app/next.config.ts
+++ b/e2e-tests/test-applications/nextjs-test-app/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/e2e-tests/tests/nextjs.test.ts
+++ b/e2e-tests/tests/nextjs.test.ts
@@ -141,7 +141,7 @@ export const onRequestError = Sentry.captureRequestError;`,
   });
 
   test('next.config file contains Sentry wrapper', () => {
-    checkFileContents(`${projectDir}/next.config.mjs`, [
+    checkFileContents(`${projectDir}/next.config.ts`, [
       "import {withSentryConfig} from '@sentry/nextjs'",
       'export default withSentryConfig(nextConfig, {',
     ]);


### PR DESCRIPTION
Our NextJS e2e test used a `next.config.mjs` file which means when building the nextjs app, type errors in this file are not caught. This caused the bug fixed via #798 to slip through. So this PR makes the next config a typescript file which will throw a build error if a type mismatch (like adding an unsupported property to the Sentry build options) is detected. 

#skip-changelog