### PR TITLE
fix: Fix broken legacy wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - ref: Remove obsolete deps (r2, lodash) ([#799](https://github.com/getsentry/sentry-wizard/pull/799))
 - ref: No more dynamic requires ([#801](https://github.com/getsentry/sentry-wizard/pull/801))
 - ref: Remove @sentry/cli as a dependency ([#802](https://github.com/getsentry/sentry-wizard/pull/802))
+- fix: Fix broken legacy wizard ([#811](https://github.com/getsentry/sentry-wizard/pull/811))
 
 ## 3.42.1
 

--- a/lib/Setup.ts
+++ b/lib/Setup.ts
@@ -36,6 +36,5 @@ export async function run(argv: any): Promise<any> {
   }
   steps.push(Step.ConfigureProject, Step.Result);
 
-  // @ts-ignore
-  return startWizard(args, steps);
+  return startWizard(args, ...steps);
 }


### PR DESCRIPTION
There was an oversight in #799 which changed how `startWizard` was called accidentally breaking all legacy wizard runs.
