### PR TITLE
fix: Refactor the wizard version lookup to handle gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - ref: No more dynamic requires ([#801](https://github.com/getsentry/sentry-wizard/pull/801))
 - ref: Remove @sentry/cli as a dependency ([#802](https://github.com/getsentry/sentry-wizard/pull/802))
 - fix: Fix broken legacy wizard ([#811](https://github.com/getsentry/sentry-wizard/pull/811))
+- fix: Refactor the wizard version lookup to handle gracefully ([#816](https://github.com/getsentry/sentry-wizard/pull/816))
 
 ## 3.42.1
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -69,21 +69,23 @@ export async function withTelemetry<F>(
 }
 
 function createSentryInstance(enabled: boolean, integration: string) {
-  let version: string | undefined;
-  try {
-    const pathToPackageJson = join(
-      dirname(require.resolve('@sentry/wizard')),
-      '..',
-      'package.json',
-    );
-    const packageJsonData = readFileSync(pathToPackageJson, 'utf-8');
-    const parsedPackageJson = JSON.parse(packageJsonData) as {
-      version?: string;
-    };
-    version = process.env.npm_package_version ?? parsedPackageJson.version;
-  } catch {
-    // If we fail to read the package.json file, we don't want to crash the wizard
-    // so we just don't set the version
+  let version: string | undefined = process.env.npm_package_version;
+  if (!version) {
+    try {
+      const pathToPackageJson = join(
+        dirname(require.resolve('@sentry/wizard')),
+        '..',
+        'package.json',
+      );
+      const packageJsonData = readFileSync(pathToPackageJson, 'utf-8');
+      const parsedPackageJson = JSON.parse(packageJsonData) as {
+        version?: string;
+      };
+      version = parsedPackageJson.version;
+    } catch {
+      // If we fail to read the package.json file, we don't want to crash the wizard
+      // so we just don't set the version
+    }
   }
 
   const client = new NodeClient({

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,9 +11,9 @@ import {
   setTag,
   startSpan,
 } from '@sentry/node';
-import type { WizardOptions } from './utils/types';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type { WizardOptions } from './utils/types';
 
 export async function withTelemetry<F>(
   options: {
@@ -69,18 +69,22 @@ export async function withTelemetry<F>(
 }
 
 function createSentryInstance(enabled: boolean, integration: string) {
-  const { version } = process.env.npm_package_version
-    ? { version: process.env.npm_package_version }
-    : (JSON.parse(
-        readFileSync(
-          join(
-            dirname(require.resolve('@sentry/wizard')),
-            '..',
-            'package.json',
-          ),
-          'utf-8',
-        ),
-      ) as { version?: string });
+  let version: string | undefined;
+  try {
+    const pathToPackageJson = join(
+      dirname(require.resolve('@sentry/wizard')),
+      '..',
+      'package.json',
+    );
+    const packageJsonData = readFileSync(pathToPackageJson, 'utf-8');
+    const parsedPackageJson = JSON.parse(packageJsonData) as {
+      version?: string;
+    };
+    version = process.env.npm_package_version ?? parsedPackageJson.version;
+  } catch {
+    // If we fail to read the package.json file, we don't want to crash the wizard
+    // so we just don't set the version
+  }
 
   const client = new NodeClient({
     dsn: 'https://8871d3ff64814ed8960c96d1fcc98a27@o1.ingest.sentry.io/4505425820712960',

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -197,6 +197,8 @@ You can turn this off at any time by running ${chalk.cyanBright(
 
 export async function confirmContinueIfNoOrDirtyGitRepo(): Promise<void> {
   return traceStep('check-git-status', async () => {
+    // TODO: add command line to ignore git check
+
     if (!isInGitRepo()) {
       const continueWithoutGit = await abortIfCancelled(
         clack.confirm({

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -197,8 +197,6 @@ You can turn this off at any time by running ${chalk.cyanBright(
 
 export async function confirmContinueIfNoOrDirtyGitRepo(): Promise<void> {
   return traceStep('check-git-status', async () => {
-    // TODO: add command line to ignore git check
-
     if (!isInGitRepo()) {
       const continueWithoutGit = await abortIfCancelled(
         clack.confirm({


### PR DESCRIPTION
The lookup of the `package.json` of the `@sentry/wizard` can throw when used during development outside of the repository. This is especially relevant developing the apple wizard, which is most likely in a project directory unrelated to the wizard.

The current implementation will crash the wizard, rendering it unusable. Ideally we are hard-baking the version on `yarn build`, but until then the dynamic lookup must not throw an error if the package.json is not found.

It is better to have telemetry without a node version, instead of crashing the wizard.