### PR TITLE
fix: Add dist-bin binaries dir to .npmignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: ${{ github.sha }}
           if-no-files-found: error
+          compression-level: 3
           path: |
             ${{ github.workspace }}/*.tgz
             ${{ github.workspace }}/dist-bin/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           name: ${{ github.sha }}
           if-no-files-found: error
-          compression-level: 3
           path: |
             ${{ github.workspace }}/*.tgz
             ${{ github.workspace }}/dist-bin/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 assets
 examples
 docs
+dist-bin
 .idea
 .vscode
 .travis


### PR DESCRIPTION
Right now we pack the fossilized binaries to npm package on publish. This patch adds the `dist-bin` directory to `.npmignore` to make this impossible.

Follow up to #806.

#skip-changelog
