### PR TITLE
ci: Avoid building before running unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,9 @@ jobs:
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
-        run: yarn fossilize -n 22 --sign -p linux-x64 -p linux-arm64 -p win-x64 -p darwin-x64 -p darwin-arm64
+        run:
+          yarn fossilize -n 22 --sign -p linux-x64 -p linux-arm64 -p win-x64 -p
+          darwin-x64 -p darwin-arm64
       - name: Pack
         run: yarn pack
       - name: Archive Artifacts
@@ -73,9 +75,8 @@ jobs:
       - name: Run Linter
         run: yarn lint
 
-  job_test:
+  job_unit_test:
     name: Node (${{ matrix.node }}) Unit Tests
-    needs: job_build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "fix": "yarn fix:eslint && yarn fix:prettier",
     "fix:prettier": "prettier --write \"{lib,src,test}/**/*.ts\"",
     "fix:eslint": "eslint . --format stylish --fix",
-    "test": "yarn build && jest",
+    "test": "jest",
     "test:e2e": "yarn build && ./e2e-tests/run.sh",
     "test:e2e:bin": "chmod +x ./dist-bin/* && SENTRY_WIZARD_E2E_TEST_BIN=1 ./e2e-tests/run.sh",
     "try": "ts-node bin.ts",


### PR DESCRIPTION
No need to build (or actually double build) before running unit tests via Jest. This doesn't save a lot of CI time, due to other jobs, but we get feedback via unit tests a bit faster than before.

#skip-changelog