### PR TITLE
ref: Set wizard version at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- ref: Set wizard version at build time ([#827](https://github.com/getsentry/sentry-wizard/pull/827))
+
 ## 4.0.1
 
-- fix: Remove bulk from npm ([#825](https://github.com/getsentry/sentry-wizard/pull/825)])
+- fix: Remove bulk from npm ([#825](https://github.com/getsentry/sentry-wizard/pull/825))
 
 ## 4.0.0
 

--- a/bin.ts
+++ b/bin.ts
@@ -18,6 +18,7 @@ if (!satisfies(process.version, NODE_VERSION_RANGE)) {
 
 import { Integration, Platform } from './lib/Constants';
 import { run } from './src/run';
+import { WIZARD_VERSION } from './src/version';
 
 export * from './lib/Setup';
 
@@ -135,7 +136,7 @@ const argv = yargs(hideBin(process.argv), process.cwd())
   })
   // This prevents `yargs` from trying to read the local package.json
   // as it's not available in the Node Single Executable Binary artifacts versions
-  .version(process.env.npm_package_version as string).argv;
+  .version(WIZARD_VERSION).argv;
 
 // @ts-expect-error - for some reason TS doesn't recognize the aliases as valid properties
 // meaning it only knows e.g. u but not url. Maybe a bug in this old version of yargs?

--- a/lib/Steps/Initial.ts
+++ b/lib/Steps/Initial.ts
@@ -1,35 +1,14 @@
 import type { Answers } from 'inquirer';
-import { join, dirname } from 'node:path';
 
 import { dim } from '../Helper/Logging';
 import { BaseStep } from './BaseStep';
-import { readFileSync } from 'node:fs';
-
-type PackageJSON = { version?: string };
-let wizardPackage: PackageJSON = {};
-
-try {
-  wizardPackage = process.env.npm_package_version
-    ? { version: process.env.npm_package_version }
-    : (JSON.parse(
-        readFileSync(
-          join(
-            dirname(require.resolve('@sentry/wizard')),
-            '..',
-            'package.json',
-          ),
-          'utf-8',
-        ),
-      ) as PackageJSON);
-} catch {
-  // We don't need to have this
-}
+import { WIZARD_VERSION } from '../../src/version';
 
 export class Initial extends BaseStep {
   // eslint-disable-next-line @typescript-eslint/require-await
   public async emit(_answers: Answers): Promise<Answers> {
     dim('Running Sentry Wizard...');
-    dim(`version: ${wizardPackage.version ?? 'DEV'}`);
+    dim(`version: ${WIZARD_VERSION}`);
     return {};
   }
 }

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,14 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 
-const newVersion = process.argv[2];
-console.log(`Updating \`version.ts\` to ${newVersion}`);
-
 const getVersionFileContent = (version) => `// DO NOT modify this file manually!
 // This is file is updated at release time.
 
 export const WIZARD_VERSION = '${version}';
 `;
+
+const newVersion = process.argv[2];
+
+if (typeof newVersion !== 'string' || !newVersion.match(/^\d+\.\d+\.\d+.*$/)) {
+  console.error(
+    `Invalid version provided (${newVersion}). Please provide a valid semver version.`,
+  );
+  process.exit(1);
+}
+
+console.log(`Updating \`version.ts\` to ${newVersion}`);
 
 const versionFilePath = path.join(__dirname, '..', 'src', 'version.ts');
 

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const newVersion = process.argv[2];
+console.log(`Updating \`version.ts\` to ${newVersion}`);
+
+const getVersionFileContent = (version) => `// DO NOT modify this file manually!
+// This is file is updated at release time.
+
+export const WIZARD_VERSION = '${version}';
+`;
+
+const versionFilePath = path.join(__dirname, '..', 'src', 'version.ts');
+
+try {
+  fs.writeFileSync(versionFilePath, getVersionFileContent(newVersion));
+} catch (e) {
+  console.error('Failed to update `version.ts` file', e);
+  process.exit(1);
+}

--- a/scripts/craft-pre-release.sh
+++ b/scripts/craft-pre-release.sh
@@ -8,3 +8,5 @@ NEW_VERSION="${2}"
  # Do not tag and commit changes made by "npm version"
 export npm_config_git_tag_version=false
 npm version "${NEW_VERSION}"
+
+node $SCRIPT_DIR/bump-version.js "${NEW_VERSION}"

--- a/src/run.ts
+++ b/src/run.ts
@@ -15,8 +15,7 @@ import { runSvelteKitWizard } from './sveltekit/sveltekit-wizard';
 import { runSourcemapsWizard } from './sourcemaps/sourcemaps-wizard';
 import { readEnvironment } from '../lib/Helper/Env';
 import type { Platform } from '../lib/Constants';
-import type { PackageDotJson } from './utils/package-json';
-import { readFileSync } from 'node:fs';
+import { WIZARD_VERSION } from './version';
 
 type WizardIntegration =
   | 'reactNative'
@@ -97,7 +96,7 @@ export async function run(argv: Args) {
 
   let integration = finalArgs.integration;
   if (!integration) {
-    clack.intro(`Sentry Wizard ${tryGetWizardVersion()}`);
+    clack.intro(`Sentry Wizard ${WIZARD_VERSION}`);
 
     integration = await abortIfCancelled(
       clack.select({
@@ -190,22 +189,4 @@ export async function run(argv: Args) {
     default:
       clack.log.error('No setup wizard selected!');
   }
-}
-
-/**
- * TODO: replace with rollup replace whenever we switch to rollup
- */
-function tryGetWizardVersion(): string {
-  let version = process.env.npm_package_version;
-  if (!version) {
-    try {
-      const wizardPkgJson = JSON.parse(
-        readFileSync('../package.json', 'utf-8'),
-      ) as PackageDotJson;
-      version = wizardPkgJson.version;
-    } catch {
-      // ignore
-    }
-  }
-  return version ?? '';
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,8 +11,6 @@ import {
   setTag,
   startSpan,
 } from '@sentry/node';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
 import type { WizardOptions } from './utils/types';
 import { WIZARD_VERSION } from './version';
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -14,6 +14,7 @@ import {
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { WizardOptions } from './utils/types';
+import { WIZARD_VERSION } from './version';
 
 export async function withTelemetry<F>(
   options: {
@@ -69,25 +70,6 @@ export async function withTelemetry<F>(
 }
 
 function createSentryInstance(enabled: boolean, integration: string) {
-  let version: string | undefined = process.env.npm_package_version;
-  if (!version) {
-    try {
-      const pathToPackageJson = join(
-        dirname(require.resolve('@sentry/wizard')),
-        '..',
-        'package.json',
-      );
-      const packageJsonData = readFileSync(pathToPackageJson, 'utf-8');
-      const parsedPackageJson = JSON.parse(packageJsonData) as {
-        version?: string;
-      };
-      version = parsedPackageJson.version;
-    } catch {
-      // If we fail to read the package.json file, we don't want to crash the wizard
-      // so we just don't set the version
-    }
-  }
-
   const client = new NodeClient({
     dsn: 'https://8871d3ff64814ed8960c96d1fcc98a27@o1.ingest.sentry.io/4505425820712960',
     enabled: enabled,
@@ -97,7 +79,7 @@ function createSentryInstance(enabled: boolean, integration: string) {
     tracesSampleRate: 1,
     sampleRate: 1,
 
-    release: version,
+    release: WIZARD_VERSION,
     integrations: [new Integrations.Http()],
     tracePropagationTargets: [/^https:\/\/sentry.io\//],
 

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -20,6 +20,7 @@ import {
 } from './package-manager';
 import { fulfillsVersionRange } from './semver';
 import type { Feature, SentryProjectData, WizardOptions } from './types';
+import { WIZARD_VERSION } from '../version';
 
 export const SENTRY_DOT_ENV_FILE = '.env.sentry-build-plugin';
 export const SENTRY_CLI_RC_FILE = '.sentryclirc';
@@ -139,34 +140,12 @@ export async function abortIfCancelled<T>(
   }
 }
 
-type PackageJSON = { version?: string };
-
 export function printWelcome(options: {
   wizardName: string;
   promoCode?: string;
   message?: string;
   telemetryEnabled?: boolean;
 }): void {
-  let wizardVersion = process.env.npm_package_version;
-  if (!wizardVersion) {
-    try {
-      wizardVersion = (
-        JSON.parse(
-          fs.readFileSync(
-            join(
-              dirname(require.resolve('@sentry/wizard')),
-              '..',
-              'package.json',
-            ),
-            'utf-8',
-          ),
-        ) as PackageJSON
-      ).version;
-    } catch {
-      // We don't need to have this
-    }
-  }
-
   // eslint-disable-next-line no-console
   console.log('');
   clack.intro(chalk.inverse(` ${options.wizardName} `));
@@ -179,9 +158,7 @@ export function printWelcome(options: {
     welcomeText = `${welcomeText}\n\nUsing promo-code: ${options.promoCode}`;
   }
 
-  if (wizardVersion) {
-    welcomeText = `${welcomeText}\n\nVersion: ${wizardVersion}`;
-  }
+  welcomeText = `${welcomeText}\n\nVersion: ${WIZARD_VERSION}`;
 
   if (options.telemetryEnabled) {
     welcomeText = `${welcomeText}

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -1,7 +1,7 @@
 import * as childProcess from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
 import { setInterval } from 'node:timers';
 import { URL } from 'node:url';
 // @ts-ignore - clack is ESM and TS complains about that. It works though

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+// DO NOT modify this file manually!
+// This is file is updated at release time.
+
+export const WIZARD_VERSION = '4.0.1';


### PR DESCRIPTION
While checking for regressions captured after the 4.x releases in Sentry, I noticed that we seem to [pick up random, incorrect](https://sentry.sentry.io/releases/?project=4505425820712960&statsPeriod=7d) `release` values instead of the wizard version in our telemetry setup. My best guess is that the previous method of preferring `process.env.npm_package_version` over reading the `package.json` somehow must have given us wrong versions in a couple of instances ( have no proof though, it could have been the package.json lookup as well). 

This likely showed a wrong version number to wizard users a startup and it reported wrong versions to Sentry.

This PR refactors how we set the wizard version by reading the version  from a `version.ts` file at build time and updating this file at release time. Ideally, we could throw in Rollup or some other proper bundler and use a magic string based approach like in the JS SDK repo. For time reasons, I opted to write a small node script which replaces the version file contents with the new version on release. The script is executed by the `craft-pre-release.sh` script.

