### PR TITLE
ci: Limit signing to release/* and master branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
         run:
-          yarn fossilize -n 22 --sign -p linux-x64 -p linux-arm64 -p win-x64 -p
+          yarn fossilize -n 22${{ github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) && ' --sign' || '' }} -p linux-x64 -p linux-arm64 -p win-x64 -p
           darwin-x64 -p darwin-arm64
       - name: Pack
         run: yarn pack


### PR DESCRIPTION
We don't get signing secrets for external contributeros (and we shouldn't!) and we also don't really need to sign the binaries built on PRs. This PR limits signing to master branch and release/** branches.

#skip-changelog
