### PR TITLE
test: fix path of temporary Xcode projects

### DIFF
--- a/test/apple/cocoapod.test.ts
+++ b/test/apple/cocoapod.test.ts
@@ -39,9 +39,8 @@ describe('cocoapod', () => {
     describe('Podfile exists', () => {
       it('should return true', () => {
         // -- Arrange --
-        const tempDir = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'test-project-with-podfile'),
-        );
+        const projPath = path.join(os.tmpdir(), 'test-project-with-podfile');
+        const tempDir = fs.mkdtempSync(projPath);
 
         const podfile = path.join(tempDir, 'Podfile');
         fs.writeFileSync(podfile, '');
@@ -57,9 +56,8 @@ describe('cocoapod', () => {
     describe('Podfile does not exist', () => {
       it('should return false', () => {
         // -- Arrange --
-        const tempDir = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'test-project-without-podfile'),
-        );
+        const projPath = path.join(os.tmpdir(), 'test-project-without-podfile');
+        const tempDir = fs.mkdtempSync(projPath);
 
         // -- Act --
         const result = usesCocoaPod(tempDir);
@@ -74,9 +72,8 @@ describe('cocoapod', () => {
     describe('Podfile does not exist', () => {
       it('should throw an error', async () => {
         // -- Arrange --
-        const tempDir = fs.mkdtempSync(
-          path.join(os.tmpdir(), 'test-project-without-podfile'),
-        );
+        const projPath = path.join(os.tmpdir(), 'test-project-without-podfile');
+        const tempDir = fs.mkdtempSync(projPath);
 
         // -- Act & Assert --
         await expect(addCocoaPods(tempDir)).rejects.toThrow(

--- a/test/apple/cocoapod.test.ts
+++ b/test/apple/cocoapod.test.ts
@@ -39,8 +39,9 @@ describe('cocoapod', () => {
     describe('Podfile exists', () => {
       it('should return true', () => {
         // -- Arrange --
-        const projPath = path.join(os.tmpdir(), 'test-project-with-podfile');
-        const tempDir = fs.mkdtempSync(projPath);
+        const tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'test-project-with-podfile'),
+        );
 
         const podfile = path.join(tempDir, 'Podfile');
         fs.writeFileSync(podfile, '');
@@ -56,8 +57,9 @@ describe('cocoapod', () => {
     describe('Podfile does not exist', () => {
       it('should return false', () => {
         // -- Arrange --
-        const projPath = path.join(os.tmpdir(), 'test-project-without-podfile');
-        const tempDir = fs.mkdtempSync(projPath);
+        const tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'test-project-without-podfile'),
+        );
 
         // -- Act --
         const result = usesCocoaPod(tempDir);
@@ -72,8 +74,9 @@ describe('cocoapod', () => {
     describe('Podfile does not exist', () => {
       it('should throw an error', async () => {
         // -- Arrange --
-        const projPath = path.join(os.tmpdir(), 'test-project-without-podfile');
-        const tempDir = fs.mkdtempSync(projPath);
+        const tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'test-project-without-podfile'),
+        );
 
         // -- Act & Assert --
         await expect(addCocoaPods(tempDir)).rejects.toThrow(

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -122,11 +122,9 @@ describe('XcodeManager', () => {
       let xcodeProject: XcodeProject;
 
       beforeEach(() => {
-        const tempDir = path.join(
-          os.tmpdir(),
-          fs.mkdtempSync('update-xcode-project'),
+        const tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'update-xcode-project'),
         );
-        fs.mkdirSync(tempDir);
 
         sourceProjectPath = singleTargetProjectPath;
         tempProjectPath = path.resolve(tempDir, 'project.pbxproj');


### PR DESCRIPTION
Running the full test suite locally spawns ignored folders named `update-xcode-project-<HASH>` in the project directory. This is caused by invalid order of `mkdirSync` and `mkdtempSync`.

These generated projects directories are safe to be discarded and should be written to an actually temporary path.

#skip-changelog