### PR TITLE
telemetry: Set transaction status based on status code when aborting

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -112,7 +112,10 @@ export async function abort(message?: string, status?: number): Promise<never> {
   clack.outro(message ?? 'Wizard setup cancelled.');
   const sentryHub = Sentry.getCurrentHub();
   const sentryTransaction = sentryHub.getScope().getTransaction();
-  sentryTransaction?.setStatus('aborted');
+  // 'cancelled' doesn't increase the `failureRate()` shown in the Sentry UI
+  // 'aborted' increases the failure rate
+  // see: https://docs.sentry.io/product/insights/overview/metrics/#failure-rate
+  sentryTransaction?.setStatus(status === 0 ? 'cancelled' : 'aborted');
   sentryTransaction?.finish();
   const sentrySession = sentryHub.getScope().getSession();
   if (sentrySession) {

--- a/test/utils/clack-utils.test.ts
+++ b/test/utils/clack-utils.test.ts
@@ -16,7 +16,6 @@ import axios from 'axios';
 import * as clack from '@clack/prompts';
 
 import * as Sentry from '@sentry/node';
-import exp from 'node:constants';
 
 jest.mock('node:child_process', () => ({
   __esModule: true,


### PR DESCRIPTION
Distinguish the txn status based on the status code the process exits with when `abort` is called:
- `'cancelled'` doesn't increase the `failureRate()` shown in the Sentry UI
- `'aborted'` increases the failure rate (see: https://docs.sentry.io/product/insights/overview/metrics/#failure-rate)

#skip-changelog
