### PR TITLE
feat(sourcemaps): Remove NextJS and Remix flows from sourcemaps wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+## Unreleased
+
 - feat: Add `coming-from` parameter ([#837](https://github.com/getsentry/sentry-wizard/pull/837))
 - ref: Reword Replay feature selection ([#847](https://github.com/getsentry/sentry-wizard/pull/847))
+- feat(sourcemaps): Remove NextJS and Remix flows from sourcemaps wizard ([#849](https://github.com/getsentry/sentry-wizard/pull/849))
+
+The NextJS and Remix flows have been removed when running the wizard with `npx @sentry/wizard -i sourcemaps`.  
+Please use `npx @sentry/wizard -i nextjs` and `npx @sentry/wizard -i remix` instead.
 
 ## 4.2.0
 

--- a/src/sourcemaps/utils/detect-tool.ts
+++ b/src/sourcemaps/utils/detect-tool.ts
@@ -21,13 +21,11 @@ export type SupportedTools =
 export const TOOL_PACKAGE_MAP: Record<string, SupportedTools> = {
   '@angular/core': 'angular',
   'create-react-app': 'create-react-app',
-  next: 'nextjs',
   webpack: 'webpack',
   vite: 'vite',
   esbuild: 'esbuild',
   rollup: 'rollup',
   typescript: 'tsc',
-  remix: 'remix',
 };
 
 export async function detectUsedTool(): Promise<SupportedTools> {


### PR DESCRIPTION
These frameworks have their own wizards, being able to run them from the sourcemaps wizard is not a flow we intend to suggest to users.

Closes: #812 