### PR TITLE
ref(clack-utils): Simplify installation log file writing

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -407,7 +407,7 @@ export async function installPackage({
               process.cwd(),
               `sentry-wizard-installation-error-${Date.now()}.log`,
             ),
-            JSON.stringify(stderr, null, 2),
+            stderr,
             { encoding: 'utf8' },
           );
 


### PR DESCRIPTION
#skip-changelog

just a small oversight as I missed a commiting a change for a review comment in #859 and the last change made JSON stringification obsolete all together
