### PR TITLE
ref(eslint): Fix eslint warnings (part 1)

### DIFF
--- a/src/react-native/xcode.ts
+++ b/src/react-native/xcode.ts
@@ -5,6 +5,7 @@ import * as fs from 'node:fs';
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
+import { Project } from 'xcode';
 
 type BuildPhase = { shellScript: string };
 type BuildPhaseMap = Record<string, BuildPhase>;
@@ -287,8 +288,10 @@ export function findDebugFilesUploadPhase(
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function writeXcodeProject(xcodeProjectPath: string, xcodeProject: any) {
+export function writeXcodeProject(
+  xcodeProjectPath: string,
+  xcodeProject: Project,
+) {
   const newContent = xcodeProject.writeSync();
   const currentContent = fs.readFileSync(xcodeProjectPath, 'utf-8');
   if (newContent === currentContent) {

--- a/src/remix/codemods/handle-error.ts
+++ b/src/remix/codemods/handle-error.ts
@@ -17,6 +17,8 @@ import chalk from 'chalk';
 import { generateCode } from 'magicast';
 
 export function instrumentHandleError(
+  // MagicAst returns `ProxifiedModule<any>` so therefore we have to use `any` here
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   originalEntryServerMod: ProxifiedModule<any>,
   serverEntryFilename: string,
 ): boolean {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -109,7 +109,7 @@ function createSentryInstance(enabled: boolean, integration: string) {
   hub.setTag('platform', process.platform);
 
   try {
-    const sea = require('node:sea');
+    const sea = require('node:sea') as { isSea: () => boolean };
     hub.setTag('is_binary', sea.isSea());
   } catch {
     hub.setTag('is_binary', false);

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -424,7 +424,7 @@ export async function installPackage({
             new Error(
               `Installation command ${chalk.cyan(
                 stringifiedInstallCmd,
-              )} exited with code ${code}.`,
+              )} exited with code ${code ?? 'null'}.`,
               {
                 cause,
               },
@@ -445,8 +445,11 @@ export async function installPackage({
 
         let stderr = '';
 
-        installProcess.stderr.on('data', (data) => {
-          stderr += data.toString();
+        // Defining data as unknown to avoid TS and ESLint errors because of `any` type
+        installProcess.stderr.on('data', (data: unknown) => {
+          if (data && data.toString && typeof data.toString === 'function') {
+            stderr += data.toString();
+          }
         });
 
         installProcess.on('error', (err) => {

--- a/test/apple/cocoapod.test.ts
+++ b/test/apple/cocoapod.test.ts
@@ -12,7 +12,7 @@ import * as bash from '../../src/utils/bash';
 import * as clack from '@clack/prompts';
 jest.mock('@clack/prompts', () => ({
   __esModule: true,
-  ...jest.requireActual('@clack/prompts'),
+  ...jest.requireActual<typeof clack>('@clack/prompts'),
 }));
 
 jest.mock('../../src/utils/bash');

--- a/test/apple/fastfile.test.ts
+++ b/test/apple/fastfile.test.ts
@@ -11,7 +11,7 @@ import * as clack from '@clack/prompts';
 
 jest.mock('@clack/prompts', () => ({
   __esModule: true,
-  ...jest.requireActual('@clack/prompts'),
+  ...jest.requireActual<typeof clack>('@clack/prompts'),
 }));
 
 describe('fastlane', () => {

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -15,8 +15,9 @@ import type { SentryProjectData } from '../../src/utils/types';
 
 jest.mock('node:fs', () => ({
   __esModule: true,
-  ...jest.requireActual('node:fs'),
+  ...jest.requireActual<typeof fs>('node:fs'),
 }));
+
 jest.mock('@clack/prompts', () => ({
   log: {
     info: jest.fn(),

--- a/test/utils/clack-utils.test.ts
+++ b/test/utils/clack-utils.test.ts
@@ -19,7 +19,7 @@ import * as Sentry from '@sentry/node';
 
 jest.mock('node:child_process', () => ({
   __esModule: true,
-  ...jest.requireActual('node:child_process'),
+  ...jest.requireActual<typeof ChildProcess>('node:child_process'),
 }));
 
 jest.mock('@clack/prompts', () => ({
@@ -46,7 +46,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock('opn', () => jest.fn(() => Promise.resolve({ on: jest.fn() })));
 
-function mockUserResponse(fn: jest.Mock, response: any) {
+function mockUserResponse(fn: jest.Mock, response: unknown) {
   fn.mockReturnValueOnce(response);
 }
 
@@ -62,6 +62,7 @@ describe('askForToolConfigPath', () => {
 
     expect(clack.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('have a Webpack config file'),
       }),
     );
@@ -77,12 +78,14 @@ describe('askForToolConfigPath', () => {
 
     expect(clack.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('have a Webpack config file'),
       }),
     );
 
     expect(clack.text).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining(
           'enter the path to your Webpack config file',
         ),
@@ -292,6 +295,7 @@ describe('askForWizardLogin', () => {
 
     expect(clack.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('already have a Sentry account'),
       }),
     );


### PR DESCRIPTION
We have far too many eslint warnings in the wizard repo. Most of these are easily fixable, so let's fix them. 

Goal: Treat eslint warnings as errors so that we don't get into this state again.

This PR is a first part of this initiative, containing around 25 eslint warning fixes. We'll gradually fix all warnigns over time.

Note: Most of these PRs will contain codecov warnings about coverage. I do think we should increase coverage but this is out of scope for the lint refactors (though we can of course always throw in tests if appropriate). So I'll largely ignore codecov in these PRs. 

#skip-changelog

ref: #868 