### PR TITLE
ref(eslint): Set `@typescript-eslint/no-unsafe-call` to `error`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
   rules: {
     'no-console': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',
-    '@typescript-eslint/no-unsafe-call': 'warn',
+    '@typescript-eslint/no-unsafe-call': 'error',
     '@typescript-eslint/restrict-template-expressions': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'warn',
     '@typescript-eslint/no-unsafe-assignment': 'warn',

--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -188,7 +188,6 @@ export class Cordova extends BaseIntegration {
       [],
       'PBXShellScriptBuildPhase',
       'Upload Debug Symbols to Sentry',
-      // @ts-expect-error - xcode project type expects a string for the target param but we pass null (not sure why but this wasn't changed)
       null,
       {
         shellPath: '/bin/sh',
@@ -240,7 +239,6 @@ export class Cordova extends BaseIntegration {
       [],
       'PBXShellScriptBuildPhase',
       'Sentry strip unused archs from Framework',
-      // @ts-expect-error - xcode project type expects a string for the target param but we pass null (not sure why but this wasn't changed)
       null,
       {
         shellPath: '/bin/sh',

--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -9,7 +9,7 @@ import { SentryCli } from '../../Helper/SentryCli';
 import { BaseIntegration } from './BaseIntegration';
 
 import xcode from 'xcode';
-import type { PBXShellScriptBuildPhase } from 'xcode';
+import type { PBXShellScriptBuildPhase, Project } from 'xcode';
 
 export class Cordova extends BaseIntegration {
   protected _sentryCli: SentryCli;
@@ -94,9 +94,11 @@ export class Cordova extends BaseIntegration {
     });
   }
 
-  private _unpatchXcodeBuildScripts(proj: any): void {
+  private _unpatchXcodeBuildScripts(proj: Project): void {
     const scripts = proj.hash.project.objects.PBXShellScriptBuildPhase || {};
-    const firstTarget = proj.getFirstTarget().uuid;
+
+    const firstTarget = proj.getFirstTarget()?.uuid || '';
+
     const nativeTargets = proj.hash.project.objects.PBXNativeTarget;
 
     // scripts to kill entirely.
@@ -109,14 +111,15 @@ export class Cordova extends BaseIntegration {
       }
 
       if (
-        script.shellScript.match(/SENTRY_PROPERTIES/) ||
-        script.shellScript.match(/SENTRY_FRAMEWORK_PATCH/)
+        script.shellScript?.match(/SENTRY_PROPERTIES/) ||
+        script.shellScript?.match(/SENTRY_FRAMEWORK_PATCH/)
       ) {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete scripts[key];
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete scripts[`${key}_comment`];
-        const phases = nativeTargets[firstTarget].buildPhases;
+        const target = nativeTargets && nativeTargets[firstTarget];
+        const phases = typeof target === 'object' && target.buildPhases;
         if (phases) {
           for (let i = 0; i < phases.length; i++) {
             if (phases[i].value === key) {
@@ -168,9 +171,15 @@ export class Cordova extends BaseIntegration {
     });
   }
 
-  private _addNewXcodeBuildPhaseForSymbols(buildScripts: any, proj: any): void {
+  private _addNewXcodeBuildPhaseForSymbols(
+    buildScripts: Array<{ shellScript: string } | string>,
+    proj: Project,
+  ): void {
     for (const script of buildScripts) {
-      if (script.shellScript.match(/SENTRY_PROPERTIES/)) {
+      if (
+        typeof script === 'object' &&
+        script.shellScript.match(/SENTRY_PROPERTIES/)
+      ) {
         return;
       }
     }
@@ -179,6 +188,7 @@ export class Cordova extends BaseIntegration {
       [],
       'PBXShellScriptBuildPhase',
       'Upload Debug Symbols to Sentry',
+      // @ts-expect-error - xcode project type expects a string for the target param but we pass null (not sure why but this wasn't changed)
       null,
       {
         shellPath: '/bin/sh',
@@ -214,11 +224,14 @@ export class Cordova extends BaseIntegration {
   }
 
   private _addNewXcodeBuildPhaseForStripping(
-    buildScripts: any,
-    proj: any,
+    buildScripts: Array<{ shellScript: string } | string>,
+    proj: Project,
   ): void {
     for (const script of buildScripts) {
-      if (script.shellScript.match(/SENTRY_FRAMEWORK_PATCH/)) {
+      if (
+        typeof script === 'object' &&
+        script.shellScript.match(/SENTRY_FRAMEWORK_PATCH/)
+      ) {
         return;
       }
     }
@@ -227,6 +240,7 @@ export class Cordova extends BaseIntegration {
       [],
       'PBXShellScriptBuildPhase',
       'Sentry strip unused archs from Framework',
+      // @ts-expect-error - xcode project type expects a string for the target param but we pass null (not sure why but this wasn't changed)
       null,
       {
         shellPath: '/bin/sh',

--- a/types/xcode.d.ts
+++ b/types/xcode.d.ts
@@ -375,13 +375,13 @@ declare module 'xcode' {
       filePathsArray: string[],
       buildPhaseType: 'PBXShellScriptBuildPhase',
       comment: string,
-      target: string,
+      target: string | null,
       optionsOrFolderType:
         | {
-            inputPaths: string[];
+            inputPaths?: string[];
             outputPaths?: string[];
-            inputFileListPaths: string[];
-            outputFileListPaths: string[];
+            inputFileListPaths?: string[];
+            outputFileListPaths?: string[];
             shellPath: string;
             shellScript: string;
           }


### PR DESCRIPTION
This surfaced some weird type issue in the cordova wizard (see comment)

#skip-changelog

closes #870 