### PR TITLE
ref(eslint): Set `@typescript-eslint/restrict-template-expressions` rule to  `error`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,7 @@ module.exports = {
   },
   rules: {
     'no-console': 'error',
-    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/no-unsafe-call': 'warn',
     '@typescript-eslint/restrict-template-expressions': 'warn',
     '@typescript-eslint/no-unsafe-member-access': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,7 @@ module.exports = {
     'no-console': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/no-unsafe-call': 'warn',
-    '@typescript-eslint/restrict-template-expressions': 'warn',
+    '@typescript-eslint/restrict-template-expressions': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'warn',
     '@typescript-eslint/no-unsafe-assignment': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -101,7 +101,9 @@ export class WizardTestEnv {
     return new Promise<boolean>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         this.kill();
-        reject(new Error(`Timeout waiting for status code: ${statusCode}`));
+        reject(
+          new Error(`Timeout waiting for status code: ${statusCode || 'null'}`),
+        );
       }, timeout);
 
       this.taskHandle.on('error', (err: Error) => {

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -102,7 +102,7 @@ export class WizardTestEnv {
       const timeoutId = setTimeout(() => {
         this.kill();
         reject(
-          new Error(`Timeout waiting for status code: ${statusCode || 'null'}`),
+          new Error(`Timeout waiting for status code: ${statusCode ?? 'null'}`),
         );
       }, timeout);
 

--- a/lib/Helper/Wizard.ts
+++ b/lib/Helper/Wizard.ts
@@ -6,20 +6,16 @@ import type { BaseIntegration } from '../Steps/Integrations/BaseIntegration';
 import { BottomBar } from './BottomBar';
 import { debug, dim, nl, red } from './Logging';
 
-function sanitizeAndValidateArgs(argv: Args): void {
+function sanitizeAndValidateArgs(argv: Args & Record<string, unknown>): void {
   if (argv.quiet === undefined) {
     argv.quiet = true;
     dim('will activate quiet mode for you');
   }
-  // @ts-ignore skip-connect does not exist on args
   if (argv['skip-connect']) {
-    // @ts-ignore skip-connect does not exist on args
-    argv.skipConnect = argv['skip-connect'];
-    // @ts-ignore skip-connect does not exist on args
+    argv.skipConnect = argv['skip-connect'] as Args['skipConnect'];
     delete argv['skip-connect'];
   }
-  // @ts-ignore skip-connect does not exist on args
-  argv.promoCode = argv['promo-code'];
+  argv.promoCode = argv['promo-code'] as Args['promoCode'];
 }
 
 export function getCurrentIntegration(answers: Answers): BaseIntegration {
@@ -31,7 +27,7 @@ export async function startWizard<M extends IStep>(
   ...steps: Array<{ new (debug: Args): M }>
 ): Promise<Answers> {
   try {
-    sanitizeAndValidateArgs(argv);
+    sanitizeAndValidateArgs(argv as Args & Record<string, unknown>);
     if (argv.debug) {
       debug(argv);
     }

--- a/lib/Steps/Integrations/BaseIntegration.ts
+++ b/lib/Steps/Integrations/BaseIntegration.ts
@@ -9,8 +9,7 @@ export abstract class BaseIntegration extends BaseStep {
 
   public constructor(protected _argv: Args) {
     super(_argv);
-    // @ts-ignore property construct does not exist on BaseIntegration
-    this.type = this.construct;
+    this.type = this.constructor.name;
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/lib/Steps/SentryProjectSelector.ts
+++ b/lib/Steps/SentryProjectSelector.ts
@@ -18,12 +18,28 @@ type Project = {
   }[];
 };
 
+type Wizard = {
+  projects: Project[];
+  apiKeys: {
+    token: string;
+  };
+};
+
+type Config = {
+  organization?: { slug?: string | null };
+  project?: { id?: string | null; slug?: string | null };
+  dsn?: { public?: string | null; private?: string | null };
+  auth?: { token?: string | null };
+};
+
 function sleep(n: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, n));
 }
 
 export class SentryProjectSelector extends BaseStep {
-  public async emit(answers: Answers): Promise<any> {
+  public async emit(
+    answers: Answers & { wizard?: Wizard },
+  ): Promise<{ config?: Config }> {
     this.debug(answers);
 
     if (!answers.wizard) {
@@ -40,7 +56,7 @@ export class SentryProjectSelector extends BaseStep {
     let selectedProject: { selectedProject: Project } | null = null;
     if (answers.wizard.projects.length === 1) {
       selectedProject = {
-        selectedProject: answers.wizard.projects[0] as Project,
+        selectedProject: answers.wizard.projects[0],
       };
       // the wizard CLI closes too quickly when we skip the prompt
       // as it will cause the UI to be stuck saying Waiting for wizard to connect
@@ -48,9 +64,9 @@ export class SentryProjectSelector extends BaseStep {
     } else {
       selectedProject = await prompt([
         {
-          choices: answers.wizard.projects.map((project: any) => {
+          choices: answers.wizard.projects.map((project: Project) => {
             return {
-              name: `${project.organization.name} / ${project.slug}`,
+              name: `${project.organization?.name ?? ''} / ${project.slug}`,
               value: project,
             };
           }),

--- a/lib/__tests__/Env.ts
+++ b/lib/__tests__/Env.ts
@@ -2,20 +2,14 @@ import { readEnvironment } from '../Helper/Env';
 
 describe('read-env', () => {
   test('transform', () => {
-    // @ts-ignore: true not assignable to string/undefined
-    process.env.SENTRY_WIZARD_DEBUG = true;
-    // @ts-ignore: true not assignable to string/undefined
-    process.env.SENTRY_WIZARD_UNINSTALL = false;
-    // @ts-ignore: true not assignable to string/undefined
-    process.env.SENTRY_WIZARD_SKIP_CONNECT = true;
-    // @ts-ignore: true not assignable to string/undefined
-    process.env.SENTRY_WIZARD_QUIET = true;
-    // @ts-ignore: true not assignable to string/undefined
-    process.env.SENTRY_WIZARD_INTEGRATION = ['reactNative', 'electron'];
-    // @ts-ignore: true not assignable to string/undefined
-    process.env.SENTRY_WIZARD_PLATFORM = ['ios', 'android'];
-    // @ts-ignore: true not assignable to string/undefined
+    process.env.SENTRY_WIZARD_DEBUG = 'true';
+    process.env.SENTRY_WIZARD_UNINSTALL = 'false';
+    process.env.SENTRY_WIZARD_SKIP_CONNECT = 'true';
+    process.env.SENTRY_WIZARD_QUIET = 'true';
+    process.env.SENTRY_WIZARD_INTEGRATION = 'reactNative,electron';
+    process.env.SENTRY_WIZARD_PLATFORM = 'ios,android';
     process.env.SENTRY_WIZARD_URL = 'https://sentry.io';
+
     expect(readEnvironment()).toEqual({
       debug: true,
       integration: 'reactNative,electron',

--- a/src/android/android-wizard.ts
+++ b/src/android/android-wizard.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as fs from 'fs';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import * as path from 'path';
 import * as Sentry from '@sentry/node';

--- a/src/android/code-tools.ts
+++ b/src/android/code-tools.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as Sentry from '@sentry/node';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import {

--- a/src/android/gradle.ts
+++ b/src/android/gradle.ts
@@ -11,7 +11,7 @@ import {
 } from './templates';
 import * as bash from '../utils/bash';
 import * as Sentry from '@sentry/node';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { fetchSdkVersion } from '../utils/release-registry';

--- a/src/android/manifest.ts
+++ b/src/android/manifest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as fs from 'fs';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import * as Sentry from '@sentry/node';
 import { manifest } from './templates';

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as fs from 'fs';

--- a/src/apple/cocoapod.ts
+++ b/src/apple/cocoapod.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as bash from '../utils/bash';
 import * as Sentry from '@sentry/node';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/apple/code-tools.ts
+++ b/src/apple/code-tools.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as templates from './templates';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 
 const swiftAppLaunchRegex =

--- a/src/apple/fastlane.ts
+++ b/src/apple/fastlane.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { askForItemSelection } from '../utils/clack-utils';
 import * as templates from './templates';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 
 export function fastFile(projectPath: string): string | null {

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/flutter/code-tools.ts
+++ b/src/flutter/code-tools.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as Sentry from '@sentry/node';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import {

--- a/src/flutter/flutter-wizard.ts
+++ b/src/flutter/flutter-wizard.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { showCopyPasteInstructions } from '../utils/clack-utils';
 import { pubspecSnippetColored, initSnippetColored } from './templates';
 import { fetchSdkVersion } from '../utils/release-registry';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines */
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as fs from 'fs';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { builders, generateCode, parseModule } from 'magicast';
 import * as path from 'path';
 

--- a/src/nuxt/nuxt-wizard.ts
+++ b/src/nuxt/nuxt-wizard.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import * as Sentry from '@sentry/node';
 import chalk from 'chalk';

--- a/src/nuxt/utils.ts
+++ b/src/nuxt/utils.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import { gte, minVersion } from 'semver';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though

--- a/src/react-native/expo-env-file.ts
+++ b/src/react-native/expo-env-file.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import fs from 'fs';

--- a/src/react-native/expo-metro.ts
+++ b/src/react-native/expo-metro.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import type { ProxifiedModule } from 'magicast';
 import chalk from 'chalk';
 import * as Sentry from '@sentry/node';

--- a/src/react-native/expo.ts
+++ b/src/react-native/expo.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as fs from 'fs';

--- a/src/react-native/javascript.ts
+++ b/src/react-native/javascript.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as path from 'path';
@@ -15,7 +15,7 @@ import {
 import { getFirstMatchedPath } from './glob';
 import { RN_SDK_PACKAGE } from './react-native-wizard';
 
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { generateCode, ProxifiedModule, parseModule } from 'magicast';
 import * as t from '@babel/types';
 

--- a/src/react-native/metro.ts
+++ b/src/react-native/metro.ts
@@ -1,6 +1,6 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { ProxifiedModule, parseModule, writeFile } from 'magicast';
 import * as fs from 'fs';
 import * as Sentry from '@sentry/node';

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as fs from 'fs';

--- a/src/react-native/uninstall.ts
+++ b/src/react-native/uninstall.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/react-native/xcode.ts
+++ b/src/react-native/xcode.ts
@@ -5,6 +5,7 @@ import * as fs from 'node:fs';
 // @ts-ignore - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
+import { Project } from 'xcode';
 
 type BuildPhase = { shellScript: string };
 type BuildPhaseMap = Record<string, BuildPhase>;
@@ -287,8 +288,10 @@ export function findDebugFilesUploadPhase(
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function writeXcodeProject(xcodeProjectPath: string, xcodeProject: any) {
+export function writeXcodeProject(
+  xcodeProjectPath: string,
+  xcodeProject: Project,
+) {
   const newContent = xcodeProject.writeSync();
   const currentContent = fs.readFileSync(xcodeProjectPath, 'utf-8');
   if (newContent === currentContent) {

--- a/src/react-native/xcode.ts
+++ b/src/react-native/xcode.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import * as fs from 'node:fs';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import { Project } from 'xcode';

--- a/src/remix/codemods/handle-error.ts
+++ b/src/remix/codemods/handle-error.ts
@@ -17,6 +17,8 @@ import chalk from 'chalk';
 import { generateCode } from 'magicast';
 
 export function instrumentHandleError(
+  // MagicAst returns `ProxifiedModule<any>` so therefore we have to use `any` here
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   originalEntryServerMod: ProxifiedModule<any>,
   serverEntryFilename: string,
 ): boolean {

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 
 /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import { abortIfCancelled } from './utils/clack-utils';
 import { runReactNativeWizard } from './react-native/react-native-wizard';

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as Sentry from '@sentry/node';

--- a/src/sourcemaps/tools/angular.ts
+++ b/src/sourcemaps/tools/angular.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import { abortIfCancelled } from '../../utils/clack-utils';

--- a/src/sourcemaps/tools/create-react-app.ts
+++ b/src/sourcemaps/tools/create-react-app.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import { abortIfCancelled } from '../../utils/clack-utils';
 

--- a/src/sourcemaps/tools/esbuild.ts
+++ b/src/sourcemaps/tools/esbuild.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack, { select } from '@clack/prompts';
 import chalk from 'chalk';
 import {

--- a/src/sourcemaps/tools/nextjs.ts
+++ b/src/sourcemaps/tools/nextjs.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { runNextjsWizard } from '../../nextjs/nextjs-wizard';

--- a/src/sourcemaps/tools/remix.ts
+++ b/src/sourcemaps/tools/remix.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { runRemixWizard } from '../../remix/remix-wizard';

--- a/src/sourcemaps/tools/rollup.ts
+++ b/src/sourcemaps/tools/rollup.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack, { select } from '@clack/prompts';
 import chalk from 'chalk';
 import {

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as Sentry from '@sentry/node';

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -5,7 +5,7 @@ import * as recast from 'recast';
 
 import * as Sentry from '@sentry/node';
 
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/sourcemaps/tools/vite.ts
+++ b/src/sourcemaps/tools/vite.ts
@@ -1,8 +1,8 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { generateCode, parseModule } from 'magicast';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { addVitePlugin } from 'magicast/helpers';
 
 import type { namedTypes as t } from 'ast-types';

--- a/src/sourcemaps/tools/webpack.ts
+++ b/src/sourcemaps/tools/webpack.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/sourcemaps/utils/other-wizards.ts
+++ b/src/sourcemaps/utils/other-wizards.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import { runSvelteKitWizard } from '../../sveltekit/sveltekit-wizard';

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
 import { minVersion, satisfies } from 'semver';

--- a/src/sveltekit/sdk-example.ts
+++ b/src/sveltekit/sdk-example.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 
 import { PartialSvelteConfig } from './sdk-setup';

--- a/src/sveltekit/sdk-setup.ts
+++ b/src/sveltekit/sdk-setup.ts
@@ -6,13 +6,13 @@ import chalk from 'chalk';
 
 import * as Sentry from '@sentry/node';
 
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+//@ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import type { ProxifiedModule } from 'magicast';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { builders, generateCode, loadFile, parseModule } from 'magicast';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { addVitePlugin } from 'magicast/helpers';
 import { getClientHooksTemplate, getServerHooksTemplate } from './templates';
 import {
@@ -319,7 +319,7 @@ function insertClientInitCall(
   originalHooksModAST.body.splice(
     initCallInsertionIndex,
     0,
-    // @ts-ignore - string works here because the AST is proxified by magicast
+    // @ts-expect-error - string works here because the AST is proxified by magicast
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     generateCode(initCallWithComment).code,
   );
@@ -355,7 +355,7 @@ function insertServerInitCall(
   originalHooksModAST.body.splice(
     initCallInsertionIndex,
     0,
-    // @ts-ignore - string works here because the AST is proxified by magicast
+    // @ts-expect-error - string works here because the AST is proxified by magicast
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     generateCode(initCall).code,
   );
@@ -393,14 +393,14 @@ function wrapHandleError(mod: ProxifiedModule<any>): void {
     } else if (declaration.type === 'VariableDeclaration') {
       const declarations = declaration.declarations;
       declarations.forEach((declaration) => {
-        // @ts-ignore - id should always have a name in this case
+        // @ts-expect-error - id should always have a name in this case
         if (!declaration.id || declaration.id.name !== 'handleError') {
           return;
         }
         foundHandleError = true;
         const userCode = declaration.init;
         const stringifiedUserCode = userCode ? generateCode(userCode).code : '';
-        // @ts-ignore - we can just place a string here, magicast will convert it to a node
+        // @ts-expect-error - we can just place a string here, magicast will convert it to a node
         declaration.init = `Sentry.handleErrorWithSentry(${stringifiedUserCode})`;
       });
     }
@@ -446,13 +446,16 @@ function wrapHandle(mod: ProxifiedModule<any>): void {
     } else if (declaration.type === 'VariableDeclaration') {
       const declarations = declaration.declarations;
       declarations.forEach((declaration) => {
-        // @ts-ignore - id should always have a name in this case
-        if (!declaration.id || declaration.id.name !== 'handle') {
+        if (
+          !declaration.id ||
+          declaration.id.type !== 'Identifier' ||
+          (declaration.id.name && declaration.id.name !== 'handle')
+        ) {
           return;
         }
         const userCode = declaration.init;
         const stringifiedUserCode = userCode ? generateCode(userCode).code : '';
-        // @ts-ignore - we can just place a string here, magicast will convert it to a node
+        // @ts-expect-error - we can just place a string here, magicast will convert it to a node
         declaration.init = `sequence(Sentry.sentryHandle(), ${stringifiedUserCode})`;
         foundHandle = true;
       });

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -109,7 +109,7 @@ function createSentryInstance(enabled: boolean, integration: string) {
   hub.setTag('platform', process.platform);
 
   try {
-    const sea = require('node:sea');
+    const sea = require('node:sea') as { isSea: () => boolean };
     hub.setTag('is_binary', sea.isSea());
   } catch {
     hub.setTag('is_binary', false);

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import { basename, isAbsolute, join, relative } from 'node:path';
 import { setInterval } from 'node:timers';
 import { URL } from 'node:url';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import * as Sentry from '@sentry/node';
 import axios from 'axios';

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -424,7 +424,7 @@ export async function installPackage({
             new Error(
               `Installation command ${chalk.cyan(
                 stringifiedInstallCmd,
-              )} exited with code ${code}.`,
+              )} exited with code ${code ?? 'null'}.`,
               {
                 cause,
               },
@@ -445,8 +445,11 @@ export async function installPackage({
 
         let stderr = '';
 
-        installProcess.stderr.on('data', (data) => {
-          stderr += data.toString();
+        // Defining data as unknown to avoid TS and ESLint errors because of `any` type
+        installProcess.stderr.on('data', (data: unknown) => {
+          if (data && data.toString && typeof data.toString === 'function') {
+            stderr += data.toString();
+          }
         });
 
         installProcess.on('error', (err) => {

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { prepareMessage } from '../../lib/Helper/Logging';

--- a/src/utils/sentrycli-utils.ts
+++ b/src/utils/sentrycli-utils.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - clack is ESM and TS complains about that. It works though
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/test/android/code-tools.test.ts
+++ b/test/android/code-tools.test.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { getLastImportLineLocation } from '../../src/android/code-tools';
 
 describe('code-tools', () => {

--- a/test/apple/cocoapod.test.ts
+++ b/test/apple/cocoapod.test.ts
@@ -8,7 +8,7 @@ import {
   usesCocoaPod,
 } from '../../src/apple/cocoapod';
 import * as bash from '../../src/utils/bash';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 jest.mock('@clack/prompts', () => ({
   __esModule: true,

--- a/test/apple/cocoapod.test.ts
+++ b/test/apple/cocoapod.test.ts
@@ -12,7 +12,7 @@ import * as bash from '../../src/utils/bash';
 import * as clack from '@clack/prompts';
 jest.mock('@clack/prompts', () => ({
   __esModule: true,
-  ...jest.requireActual('@clack/prompts'),
+  ...jest.requireActual<typeof clack>('@clack/prompts'),
 }));
 
 jest.mock('../../src/utils/bash');

--- a/test/apple/code-tools.test.ts
+++ b/test/apple/code-tools.test.ts
@@ -6,7 +6,7 @@ import {
   addCodeSnippetToProject,
   exportForTesting,
 } from '../../src/apple/code-tools';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 
 // Test Constants

--- a/test/apple/fastfile.test.ts
+++ b/test/apple/fastfile.test.ts
@@ -11,7 +11,7 @@ import * as clack from '@clack/prompts';
 
 jest.mock('@clack/prompts', () => ({
   __esModule: true,
-  ...jest.requireActual('@clack/prompts'),
+  ...jest.requireActual<typeof clack>('@clack/prompts'),
 }));
 
 describe('fastlane', () => {

--- a/test/apple/fastfile.test.ts
+++ b/test/apple/fastfile.test.ts
@@ -6,7 +6,7 @@ import {
   exportForTesting,
   fastFile,
 } from '../../src/apple/fastlane';
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 
 jest.mock('@clack/prompts', () => ({

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -15,8 +15,9 @@ import type { SentryProjectData } from '../../src/utils/types';
 
 jest.mock('node:fs', () => ({
   __esModule: true,
-  ...jest.requireActual('node:fs'),
+  ...jest.requireActual<typeof fs>('node:fs'),
 }));
+
 jest.mock('@clack/prompts', () => ({
   log: {
     info: jest.fn(),

--- a/test/flutter/code-tools.test.ts
+++ b/test/flutter/code-tools.test.ts
@@ -1,11 +1,9 @@
-//@ts-ignore
 import {
   patchMainContent,
   getDependenciesLocation,
   getDevDependenciesLocation,
   getLastImportLineLocation,
 } from '../../src/flutter/code-tools';
-//@ts-ignore
 import { initSnippet } from '../../src/flutter/templates';
 
 describe('code-tools', () => {

--- a/test/react-native/expo-metro.test.ts
+++ b/test/react-native/expo-metro.test.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { generateCode, parseModule } from 'magicast';
 import { patchMetroInMemory } from '../../src/react-native/expo-metro';
 

--- a/test/react-native/javascript.test.ts
+++ b/test/react-native/javascript.test.ts
@@ -5,7 +5,7 @@ import {
   doesJsCodeIncludeSdkSentryImport,
   SentryWrapResult,
 } from '../../src/react-native/javascript';
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { generateCode, parseModule } from 'magicast';
 import * as t from '@babel/types';
 

--- a/test/react-native/metro.test.ts
+++ b/test/react-native/metro.test.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - magicast is ESM and TS complains about that. It works though
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { generateCode, type ProxifiedModule, parseModule } from 'magicast';
 
 import * as recast from 'recast';

--- a/test/utils/clack-utils.test.ts
+++ b/test/utils/clack-utils.test.ts
@@ -19,7 +19,7 @@ import * as Sentry from '@sentry/node';
 
 jest.mock('node:child_process', () => ({
   __esModule: true,
-  ...jest.requireActual('node:child_process'),
+  ...jest.requireActual<typeof ChildProcess>('node:child_process'),
 }));
 
 jest.mock('@clack/prompts', () => ({
@@ -46,7 +46,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock('opn', () => jest.fn(() => Promise.resolve({ on: jest.fn() })));
 
-function mockUserResponse(fn: jest.Mock, response: any) {
+function mockUserResponse(fn: jest.Mock, response: unknown) {
   fn.mockReturnValueOnce(response);
 }
 
@@ -62,6 +62,7 @@ describe('askForToolConfigPath', () => {
 
     expect(clack.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('have a Webpack config file'),
       }),
     );
@@ -77,12 +78,14 @@ describe('askForToolConfigPath', () => {
 
     expect(clack.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('have a Webpack config file'),
       }),
     );
 
     expect(clack.text).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining(
           'enter the path to your Webpack config file',
         ),
@@ -292,6 +295,7 @@ describe('askForWizardLogin', () => {
 
     expect(clack.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('already have a Sentry account'),
       }),
     );

--- a/test/utils/clack-utils.test.ts
+++ b/test/utils/clack-utils.test.ts
@@ -12,7 +12,7 @@ import type { PackageManager } from '../../src/utils/package-manager';
 
 import axios from 'axios';
 
-// @ts-ignore - clack is ESM and TS complains about that. It works though
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
 
 import * as Sentry from '@sentry/node';
@@ -352,7 +352,7 @@ describe('abort', () => {
   jest.spyOn(Sentry, 'flush').mockImplementation(flushSpy);
 
   it('ends the process with an error exit code by default', async () => {
-    // @ts-ignore - jest doesn't like the empty function
+    // @ts-expect-error - jest doesn't like the empty function
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
@@ -370,7 +370,7 @@ describe('abort', () => {
   });
 
   it('ends the process with a custom exit code and message if provided', async () => {
-    // @ts-ignore - jest doesn't like the empty function
+    // @ts-expect-error - jest doesn't like the empty function
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
 


### PR DESCRIPTION
Depends on: https://github.com/getsentry/sentry-wizard/pull/879

#skip-changelog