### PR TITLE
Improve Next Steps for Flutter Outro

### DIFF
--- a/src/flutter/flutter-wizard.ts
+++ b/src/flutter/flutter-wizard.ts
@@ -157,12 +157,14 @@ Set the ${chalk.cyan(
   clack.outro(`
     ${chalk.greenBright('Successfully installed the Sentry Flutter SDK!')}
     
-    ${chalk.cyan(
-      `You can validate your setup by launching your application and checking Sentry issues page afterwards
-    ${issuesPageLink}`,
-    )}
+    ${chalk.cyan('Next steps:')}
+    1. Run ${chalk.bold('flutter run')} to test the setup - we've added a test error that will trigger on app start
+    2. For production builds, run ${chalk.bold('flutter build ios --obfuscate --split-debug-info=build/debug-info')} (or android/macos) then ${chalk.bold('flutter pub run sentry_dart_plugin')} to upload debug symbols
+    3. View your test error and transaction data at ${issuesPageLink}
     
-    Check out the SDK documentation for further configuration:
-    https://docs.sentry.io/platforms/flutter/
+    ${chalk.cyan('Learn more:')}
+    • Debug Symbols: https://docs.sentry.io/platforms/dart/guides/flutter/debug-symbols/
+    • Performance Monitoring: https://docs.sentry.io/platforms/dart/guides/flutter/performance/
+    • Integrations: https://docs.sentry.io/platforms/dart/guides/flutter/integrations/
   `);
 }


### PR DESCRIPTION
Adding something more concrete to the end of the flutter wizard to tell users

1. how to confirm/test setup
2. what more they can do

https://github.com/getsentry/sentry-wizard/issues/809