### PR TITLE
ref(eslint): Set `no-unsafe-return` and `no-var-requires` to `error` 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,8 +61,8 @@ module.exports = {
     '@typescript-eslint/no-unsafe-member-access': 'warn',
     '@typescript-eslint/no-unsafe-assignment': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',
-    '@typescript-eslint/no-unsafe-return': 'warn',
-    '@typescript-eslint/no-var-requires': 'off',
+    '@typescript-eslint/no-unsafe-return': 'error',
+    '@typescript-eslint/no-var-requires': 'error',
     // '@typescript-eslint/restrict-template-expressions': 'warn',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/lib/Helper/File.ts
+++ b/lib/Helper/File.ts
@@ -5,8 +5,8 @@ const IGNORE_PATTERN = ['node_modules/**', 'ios/Pods/**', '**/Pods/**'];
 
 export function patchMatchingFile(
   globPattern: string,
-  func: any,
-  ...args: any[]
+  func: (content: string, match: string, ...args: unknown[]) => void,
+  ...args: unknown[]
 ): Promise<void> {
   const matches = glob.sync(globPattern, {
     ignore: IGNORE_PATTERN,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -109,6 +109,10 @@ function createSentryInstance(enabled: boolean, integration: string) {
   hub.setTag('platform', process.platform);
 
   try {
+    // The `require` call here is fine because the binary node versions
+    // support `require` and we try/catch the call anyway for any other
+    // version of node.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const sea = require('node:sea') as { isSea: () => boolean };
     hub.setTag('is_binary', sea.isSea());
   } catch {


### PR DESCRIPTION
Two rules in one because `no-unsafe-return` required no changes as the only violation is already fixed in #870.

#skip-changelog

closes #875 
closes #876 