### PR TITLE
ref(core): Move `clack-utils.ts` to dedicated folder

### DIFF
--- a/src/android/android-wizard.ts
+++ b/src/android/android-wizard.ts
@@ -14,7 +14,7 @@ import {
   getOrAskForProjectData,
   printWelcome,
   propertiesCliSetupConfig,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { WizardOptions } from '../utils/types';
 import * as codetools from './code-tools';
 import * as gradle from './gradle';

--- a/src/android/gradle.ts
+++ b/src/android/gradle.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as fs from 'fs';
-import { abortIfCancelled, askForItemSelection } from '../utils/clack-utils';
+import { abortIfCancelled, askForItemSelection } from '../utils/clack';
 import {
   plugin,
   pluginKts,

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -27,7 +27,7 @@ import {
   confirmContinueIfNoOrDirtyGitRepo,
   getOrAskForProjectData,
   printWelcome,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 
 export async function runAppleWizard(options: WizardOptions): Promise<void> {
   return withTelemetry(

--- a/src/apple/fastlane.ts
+++ b/src/apple/fastlane.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { askForItemSelection } from '../utils/clack-utils';
+import { askForItemSelection } from '../utils/clack';
 import * as templates from './templates';
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';

--- a/src/flutter/code-tools.ts
+++ b/src/flutter/code-tools.ts
@@ -10,7 +10,7 @@ import {
   sentryProperties,
   initSnippet,
 } from './templates';
-import { featureSelectionPrompt } from '../utils/clack-utils';
+import { featureSelectionPrompt } from '../utils/clack';
 
 /**
  * Recursively finds a file per name in subfolders.

--- a/src/flutter/flutter-wizard.ts
+++ b/src/flutter/flutter-wizard.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/node';
 import * as fs from 'fs';
 import * as path from 'path';
-import { showCopyPasteInstructions } from '../utils/clack-utils';
 import { fetchSdkVersion } from '../utils/release-registry';
 import { WizardOptions } from '../utils/types';
 import * as codetools from './code-tools';
@@ -14,7 +13,8 @@ import {
   confirmContinueIfNoOrDirtyGitRepo,
   getOrAskForProjectData,
   printWelcome,
-} from '../utils/clack-utils';
+  showCopyPasteInstructions,
+} from '../utils/clack';
 
 import { traceStep, withTelemetry } from '../telemetry';
 import { findFile } from './code-tools';

--- a/src/flutter/templates.ts
+++ b/src/flutter/templates.ts
@@ -1,4 +1,4 @@
-import { makeCodeSnippet } from '../utils/clack-utils';
+import { makeCodeSnippet } from '../utils/clack';
 
 export const sentryImport = `import 'package:sentry_flutter/sentry_flutter.dart';\n`;
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -28,7 +28,7 @@ import {
   printWelcome,
   runPrettierIfInstalled,
   showCopyPasteInstructions,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import type { SentryProjectData, WizardOptions } from '../utils/types';
 import {

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { makeCodeSnippet } from '../utils/clack-utils';
+import { makeCodeSnippet } from '../utils/clack';
 
 type WithSentryConfigOptions = {
   orgSlug: string;

--- a/src/nuxt/nuxt-wizard.ts
+++ b/src/nuxt/nuxt-wizard.ts
@@ -18,7 +18,7 @@ import {
   installPackage,
   printWelcome,
   runPrettierIfInstalled,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import type { WizardOptions } from '../utils/types';
 import {

--- a/src/nuxt/sdk-example.ts
+++ b/src/nuxt/sdk-example.ts
@@ -8,7 +8,7 @@ import {
   getSentryExamplePageTemplate,
   getSentryErrorButtonTemplate,
 } from './templates';
-import { abort, isUsingTypeScript } from '../utils/clack-utils';
+import { abort, isUsingTypeScript } from '../utils/clack';
 import chalk from 'chalk';
 import * as Sentry from '@sentry/node';
 

--- a/src/nuxt/sdk-setup.ts
+++ b/src/nuxt/sdk-setup.ts
@@ -18,7 +18,7 @@ import {
   featureSelectionPrompt,
   installPackage,
   isUsingTypeScript,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import {
   type PackageDotJson,
   hasPackageInstalled,

--- a/src/nuxt/utils.ts
+++ b/src/nuxt/utils.ts
@@ -3,7 +3,7 @@ import * as clack from '@clack/prompts';
 import { gte, minVersion } from 'semver';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { loadFile } from 'magicast';
-import { abortIfCancelled } from '../utils/clack-utils';
+import { abortIfCancelled } from '../utils/clack';
 
 export async function isNuxtV4(
   nuxtConfig: string,

--- a/src/react-native/expo-metro.ts
+++ b/src/react-native/expo-metro.ts
@@ -7,10 +7,7 @@ import chalk from 'chalk';
 import * as Sentry from '@sentry/node';
 
 import { getLastRequireIndex, hasSentryContent } from '../utils/ast-utils';
-import {
-  makeCodeSnippet,
-  showCopyPasteInstructions,
-} from '../utils/clack-utils';
+import { makeCodeSnippet, showCopyPasteInstructions } from '../utils/clack';
 
 import { metroConfigPath, parseMetroConfig, writeMetroConfig } from './metro';
 

--- a/src/react-native/expo.ts
+++ b/src/react-native/expo.ts
@@ -6,10 +6,7 @@ import { EOL } from 'os';
 
 import { isPlainObject } from '@sentry/utils';
 import * as Sentry from '@sentry/node';
-import {
-  makeCodeSnippet,
-  showCopyPasteInstructions,
-} from '../utils/clack-utils';
+import { makeCodeSnippet, showCopyPasteInstructions } from '../utils/clack';
 import { RNCliSetupConfigContent } from './react-native-wizard';
 import { traceStep } from '../telemetry';
 

--- a/src/react-native/javascript.ts
+++ b/src/react-native/javascript.ts
@@ -8,10 +8,7 @@ import * as fs from 'fs';
 import * as Sentry from '@sentry/node';
 
 import { traceStep } from '../telemetry';
-import {
-  makeCodeSnippet,
-  showCopyPasteInstructions,
-} from '../utils/clack-utils';
+import { makeCodeSnippet, showCopyPasteInstructions } from '../utils/clack';
 import { getFirstMatchedPath } from './glob';
 import { RN_SDK_PACKAGE } from './react-native-wizard';
 

--- a/src/react-native/metro.ts
+++ b/src/react-native/metro.ts
@@ -14,7 +14,7 @@ import {
   abortIfCancelled,
   makeCodeSnippet,
   showCopyPasteInstructions,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 
 import * as recast from 'recast';
 import x = recast.types;

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -22,7 +22,7 @@ import {
   printWelcome,
   propertiesCliSetupConfig,
   runPrettierIfInstalled,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import { fulfillsVersionRange } from '../utils/semver';
 import { getIssueStreamUrl } from '../utils/url';

--- a/src/react-native/uninstall.ts
+++ b/src/react-native/uninstall.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import {
   confirmContinueIfNoOrDirtyGitRepo,
   printWelcome,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { APP_BUILD_GRADLE, XCODE_PROJECT, getFirstMatchedPath } from './glob';
 import {
   doesAppBuildGradleIncludeRNSentryGradlePlugin,

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -19,7 +19,7 @@ import {
   printWelcome,
   rcCliSetupConfig,
   runPrettierIfInstalled,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { debug } from '../utils/debug';
 import { hasPackageInstalled } from '../utils/package-json';
 import type { WizardOptions } from '../utils/types';

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -33,7 +33,7 @@ import {
 import { instrumentRootRouteV1 } from './codemods/root-v1';
 import { instrumentRootRouteV2 } from './codemods/root-v2';
 import { instrumentHandleError } from './codemods/handle-error';
-import { getPackageDotJson } from '../utils/clack-utils';
+import { getPackageDotJson } from '../utils/clack';
 import { findCustomExpressServerImplementation } from './codemods/express-server';
 
 export type PartialRemixConfig = {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
-import { abortIfCancelled } from './utils/clack-utils';
+import { abortIfCancelled } from './utils/clack';
 import { runReactNativeWizard } from './react-native/react-native-wizard';
 
 import { run as legacyRun } from '../lib/Setup';

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -13,7 +13,7 @@ import {
   printWelcome,
   SENTRY_CLI_RC_FILE,
   SENTRY_DOT_ENV_FILE,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { NPM } from '../utils/package-manager';
 import type { WizardOptions } from '../utils/types';
 import { getIssueStreamUrl } from '../utils/url';

--- a/src/sourcemaps/tools/angular.ts
+++ b/src/sourcemaps/tools/angular.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
-import { abortIfCancelled } from '../../utils/clack-utils';
+import { abortIfCancelled } from '../../utils/clack';
 
 const angularJsonTemplate = chalk.gray(`{
   "projects": {

--- a/src/sourcemaps/tools/create-react-app.ts
+++ b/src/sourcemaps/tools/create-react-app.ts
@@ -1,6 +1,6 @@
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
-import { abortIfCancelled } from '../../utils/clack-utils';
+import { abortIfCancelled } from '../../utils/clack';
 
 export async function configureCRASourcemapGenerationFlow(): Promise<void> {
   await abortIfCancelled(

--- a/src/sourcemaps/tools/esbuild.ts
+++ b/src/sourcemaps/tools/esbuild.ts
@@ -6,7 +6,7 @@ import {
   addDotEnvSentryBuildPluginFile,
   getPackageDotJson,
   installPackage,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 import { hasPackageInstalled } from '../../utils/package-json';
 
 import {

--- a/src/sourcemaps/tools/nextjs.ts
+++ b/src/sourcemaps/tools/nextjs.ts
@@ -6,7 +6,7 @@ import { traceStep } from '../../telemetry';
 import {
   abortIfCancelled,
   addDotEnvSentryBuildPluginFile,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 import type { WizardOptions } from '../../utils/types';
 
 import type { SourceMapUploadToolConfigurationOptions } from './types';

--- a/src/sourcemaps/tools/remix.ts
+++ b/src/sourcemaps/tools/remix.ts
@@ -3,7 +3,7 @@ import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { runRemixWizard } from '../../remix/remix-wizard';
 import { traceStep } from '../../telemetry';
-import { abortIfCancelled } from '../../utils/clack-utils';
+import { abortIfCancelled } from '../../utils/clack';
 import type { WizardOptions } from '../../utils/types';
 import type { SourceMapUploadToolConfigurationOptions } from './types';
 

--- a/src/sourcemaps/tools/rollup.ts
+++ b/src/sourcemaps/tools/rollup.ts
@@ -6,7 +6,7 @@ import {
   addDotEnvSentryBuildPluginFile,
   getPackageDotJson,
   installPackage,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 import { hasPackageInstalled } from '../../utils/package-json';
 
 import {

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -10,7 +10,7 @@ import {
   getPackageDotJson,
   getPackageManager,
   installPackage,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 
 import { SourceMapUploadToolConfigurationOptions } from './types';
 import { hasPackageInstalled } from '../../utils/package-json';

--- a/src/sourcemaps/tools/tsc.ts
+++ b/src/sourcemaps/tools/tsc.ts
@@ -14,7 +14,7 @@ import {
   createNewConfigFile,
   makeCodeSnippet,
   showCopyPasteInstructions,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 import {
   findFile,
   getOrSetObjectProperty,

--- a/src/sourcemaps/tools/vite.ts
+++ b/src/sourcemaps/tools/vite.ts
@@ -21,7 +21,7 @@ import {
   installPackage,
   makeCodeSnippet,
   showCopyPasteInstructions,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 import { hasPackageInstalled } from '../../utils/package-json';
 
 import {

--- a/src/sourcemaps/tools/webpack.ts
+++ b/src/sourcemaps/tools/webpack.ts
@@ -20,7 +20,7 @@ import {
   installPackage,
   makeCodeSnippet,
   showCopyPasteInstructions,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 import { hasPackageInstalled } from '../../utils/package-json';
 
 import type {

--- a/src/sourcemaps/utils/detect-tool.ts
+++ b/src/sourcemaps/utils/detect-tool.ts
@@ -1,4 +1,4 @@
-import { getPackageDotJson } from '../../utils/clack-utils';
+import { getPackageDotJson } from '../../utils/clack';
 import { findInstalledPackageFromList } from '../../utils/package-json';
 
 export type SupportedTools =

--- a/src/sourcemaps/utils/other-wizards.ts
+++ b/src/sourcemaps/utils/other-wizards.ts
@@ -3,11 +3,7 @@ import clack from '@clack/prompts';
 import chalk from 'chalk';
 import { runSvelteKitWizard } from '../../sveltekit/sveltekit-wizard';
 
-import {
-  abort,
-  abortIfCancelled,
-  getPackageDotJson,
-} from '../../utils/clack-utils';
+import { abort, abortIfCancelled, getPackageDotJson } from '../../utils/clack';
 import {
   findInstalledPackageFromList,
   hasPackageInstalled,

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -6,7 +6,7 @@ import {
   abortIfCancelled,
   getPackageDotJson,
   installPackage,
-} from '../../utils/clack-utils';
+} from '../../utils/clack';
 
 import * as Sentry from '@sentry/node';
 import { findInstalledPackageFromList } from '../../utils/package-json';

--- a/src/sveltekit/sdk-setup.ts
+++ b/src/sveltekit/sdk-setup.ts
@@ -19,7 +19,7 @@ import {
   abortIfCancelled,
   featureSelectionPrompt,
   isUsingTypeScript,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { debug } from '../utils/debug';
 import { findFile, hasSentryContent } from '../utils/ast-utils';
 

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -18,7 +18,7 @@ import {
   installPackage,
   printWelcome,
   runPrettierIfInstalled,
-} from '../utils/clack-utils';
+} from '../utils/clack';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import { NPM } from '../utils/package-manager';
 import type { WizardOptions } from '../utils/types';

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -10,17 +10,17 @@ import * as Sentry from '@sentry/node';
 import axios from 'axios';
 import chalk from 'chalk';
 import opn from 'opn';
-import { traceStep } from '../telemetry';
-import { WIZARD_VERSION } from '../version';
-import { debug } from './debug';
-import { type PackageDotJson, hasPackageInstalled } from './package-json';
+import { traceStep } from '../../telemetry';
+import { WIZARD_VERSION } from '../../version';
+import { debug } from '../debug';
+import { type PackageDotJson, hasPackageInstalled } from '../package-json';
 import {
   type PackageManager,
   _detectPackageManger,
   packageManagers,
-} from './package-manager';
-import { fulfillsVersionRange } from './semver';
-import type { Feature, SentryProjectData, WizardOptions } from './types';
+} from '../package-manager';
+import { fulfillsVersionRange } from '../semver';
+import type { Feature, SentryProjectData, WizardOptions } from '../types';
 
 export const SENTRY_DOT_ENV_FILE = '.env.sentry-build-plugin';
 export const SENTRY_CLI_RC_FILE = '.sentryclirc';

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 
 import * as Sentry from '@sentry/node';
 import { traceStep } from '../telemetry';
-import { getPackageDotJson, updatePackageDotJson } from './clack-utils';
+import { getPackageDotJson, updatePackageDotJson } from './clack';
 
 export interface PackageManager {
   name: string;

--- a/test/sourcemaps/tools/sentry-cli.test.ts
+++ b/test/sourcemaps/tools/sentry-cli.test.ts
@@ -20,8 +20,8 @@ jest.mock('@clack/prompts', () => {
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-jest.mock('../../../src/utils/clack-utils', () => ({
-  ...jest.requireActual('../../../src/utils/clack-utils'),
+jest.mock('../../../src/utils/clack', () => ({
+  ...jest.requireActual('../../../src/utils/clack'),
   getPackageDotJson: jest.fn().mockResolvedValue({
     scripts: {
       build: 'tsc',

--- a/test/sourcemaps/tools/sentry-cli.test.ts
+++ b/test/sourcemaps/tools/sentry-cli.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { addSentryCommandToBuildCommand } from '../../../src/sourcemaps/tools/sentry-cli';
 
 import * as packageManagerHelpers from '../../../src/utils/package-manager';
-import { getPackageDotJson } from '../../../src/utils/clack-utils';
+import { getPackageDotJson } from '../../../src/utils/clack';
 const writeFileSpy = jest
   .spyOn(fs.promises, 'writeFile')
   .mockImplementation(() => Promise.resolve());

--- a/test/utils/clack/index.test.ts
+++ b/test/utils/clack/index.test.ts
@@ -5,14 +5,19 @@ import {
   createNewConfigFile,
   getPackageManager,
   installPackage,
-} from '../../src/utils/clack-utils';
+} from '../../../src/utils/clack/';
 
 import * as fs from 'node:fs';
 import * as ChildProcess from 'node:child_process';
-import type { PackageManager } from '../../src/utils/package-manager';
-import * as PackageManagerUtils from '../../src/utils/package-manager';
+import type { PackageManager } from '../../../src/utils/package-manager';
+import * as PackageManagerUtils from '../../../src/utils/package-manager';
 
-import { NPM, PNPM, YARN_V1, YARN_V2 } from '../../src/utils/package-manager';
+import {
+  NPM,
+  PNPM,
+  YARN_V1,
+  YARN_V2,
+} from '../../../src/utils/package-manager';
 
 import axios from 'axios';
 


### PR DESCRIPTION
Our `clack-utils` file has grown a lot in the past years and is now a massive collection of different clack prompts that are reused by multiple wizards. No complaints to this (on the contrary!) but In some more recent PRs I noticed that this makes it quite hard to test individual exports from this file and it's super easy to get lost in it when working on changes (admittedly that's subjective, so feel free to challenge it ;) )

This PR therefore moves `src/utils/clack-utils` into `src/utils/clack/index` as prework to for a couple of eventual goals:
- we can split out some exports from index into dedicated files whenever we want
- we can more easily test individual exports without having to care as much about mocking, mock resetting and other side effects
- we can add some lint rules to ensure that wizards only import from `./utils/clack` to provide a better "API surface" of our  helper functions. Not sure if we actually want go down this road now but it would at least be possible.

#skip-changelog