### PR TITLE
fix: enable debug logs for option --debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - ref(utils): Unify `getPackageManger` and `detectPackageManager` ([#865](https://github.com/getsentry/sentry-wizard/pull/865))
 - feat: add option to ignore git changes ([#898](https://github.com/getsentry/sentry-wizard/pull/898))
 - fix(apple): Add additional types to `xcode.d.ts` ([#900](https://github.com/getsentry/sentry-wizard/pull/900))
+- fix: enable debug logs for option `--debug` ([#902](https://github.com/getsentry/sentry-wizard/pull/902))
 
 ## 4.5.0
 

--- a/lib/Helper/Logging.ts
+++ b/lib/Helper/Logging.ts
@@ -39,6 +39,9 @@ export function cyan(msg: string): void {
   return l(Chalk.cyan(prepareMessage(msg)));
 }
 
+/**
+ * @deprecated Use `debug` from `src/utils/debug.ts` instead.
+ */
 export function debug(msg: any): void {
   return l(Chalk.italic.yellow(prepareMessage(msg)));
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,20 +1,21 @@
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import * as clack from '@clack/prompts';
-import { abortIfCancelled } from './utils/clack-utils';
 import { runReactNativeWizard } from './react-native/react-native-wizard';
+import { abortIfCancelled } from './utils/clack-utils';
 
+import type { Platform } from '../lib/Constants';
+import { readEnvironment } from '../lib/Helper/Env';
 import { run as legacyRun } from '../lib/Setup';
-import type { PreselectedProject, WizardOptions } from './utils/types';
-import { runFlutterWizard } from './flutter/flutter-wizard';
 import { runAndroidWizard } from './android/android-wizard';
 import { runAppleWizard } from './apple/apple-wizard';
+import { runFlutterWizard } from './flutter/flutter-wizard';
 import { runNextjsWizard } from './nextjs/nextjs-wizard';
 import { runNuxtWizard } from './nuxt/nuxt-wizard';
 import { runRemixWizard } from './remix/remix-wizard';
-import { runSvelteKitWizard } from './sveltekit/sveltekit-wizard';
 import { runSourcemapsWizard } from './sourcemaps/sourcemaps-wizard';
-import { readEnvironment } from '../lib/Helper/Env';
-import type { Platform } from '../lib/Constants';
+import { runSvelteKitWizard } from './sveltekit/sveltekit-wizard';
+import { enableDebugLogs } from './utils/debug';
+import type { PreselectedProject, WizardOptions } from './utils/types';
 import { WIZARD_VERSION } from './version';
 
 type WizardIntegration =
@@ -95,6 +96,11 @@ export async function run(argv: Args) {
     ...argv,
     ...readEnvironment(),
   };
+
+  // Enable debug logs if the user has passed the --debug flag
+  if (finalArgs.debug) {
+    enableDebugLogs();
+  }
 
   let integration = finalArgs.integration;
   if (!integration) {


### PR DESCRIPTION
- Discussed this with @Lms24 in-person.
- Adds a deprecation warning for the `debug(...)` logging helper
- Enables debug logging if `--debug` is set. Currently only works for the legacy integrations.
