### PR TITLE
refactor(apple): move check-installed-cli to separate file

### DIFF
--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -28,6 +28,7 @@ import {
   getOrAskForProjectData,
   printWelcome,
 } from '../utils/clack';
+import { checkInstalledCLI } from './check-installed-cli';
 import { AppleWizardOptions } from './options';
 
 export async function runAppleWizard(
@@ -46,33 +47,23 @@ export async function runAppleWizard(
 async function runAppleWizardWithTelementry(
   options: AppleWizardOptions,
 ): Promise<void> {
+  // Define options with defaults
   const projectDir = options.projectDir ?? process.cwd();
 
+  // Step - Welcome Message
   printWelcome({
     wizardName: 'Sentry Apple Wizard',
     promoCode: options.promoCode,
   });
 
+  // Step - Git Status Check
   await confirmContinueIfNoOrDirtyGitRepo({
     ignoreGitChanges: options.ignoreGitChanges,
     cwd: projectDir,
   });
 
-  const hasCli = bash.hasSentryCLI();
-  Sentry.setTag('has-cli', hasCli);
-  if (!hasCli) {
-    if (
-      !(await traceStep('Ask for SentryCLI', () => askToInstallSentryCLI()))
-    ) {
-      clack.log.warn(
-        "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
-      );
-      Sentry.setTag('CLI-Installed', false);
-    } else {
-      await bash.installSentryCLI();
-      Sentry.setTag('CLI-Installed', true);
-    }
-  }
+  // Step - Sentry CLI Check
+  await checkInstalledCLI();
 
   const xcodeProjFiles = searchXcodeProject(projectDir);
   if (!xcodeProjFiles || xcodeProjFiles.length === 0) {

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -10,7 +10,6 @@ import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 import { traceStep, withTelemetry } from '../telemetry';
-import * as bash from '../utils/bash';
 import * as SentryUtils from '../utils/sentrycli-utils';
 import { SentryProjectData, WizardOptions } from '../utils/types';
 import * as cocoapod from './cocoapod';
@@ -23,7 +22,6 @@ import { XcodeProject } from './xcode-manager';
 import {
   abort,
   askForItemSelection,
-  askToInstallSentryCLI,
   confirmContinueIfNoOrDirtyGitRepo,
   getOrAskForProjectData,
   printWelcome,

--- a/src/apple/check-installed-cli.ts
+++ b/src/apple/check-installed-cli.ts
@@ -1,0 +1,34 @@
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import * as Sentry from '@sentry/node';
+import { traceStep } from '../telemetry';
+import * as bash from '../utils/bash';
+import { askToInstallSentryCLI } from '../utils/clack';
+import { debug } from '../utils/debug';
+
+export async function checkInstalledCLI() {
+  debug(`Checking if sentry-cli is installed`);
+  const hasCli = bash.hasSentryCLI();
+  Sentry.setTag('has-cli', hasCli);
+  if (hasCli) {
+    // If the CLI is installed, we don't need to ask the user to install it and can exit early.
+    debug(`sentry-cli is installed`);
+    return;
+  }
+
+  debug(`sentry-cli is not installed, asking user to install it`);
+  const shouldInstallCLI = await traceStep('Ask for SentryCLI', () =>
+    askToInstallSentryCLI(),
+  );
+  if (shouldInstallCLI) {
+    debug(`User agreed to install sentry-cli`);
+    await bash.installSentryCLI();
+    Sentry.setTag('CLI-Installed', true);
+  } else {
+    debug(`User declined to install sentry-cli`);
+    clack.log.warn(
+      "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+    );
+    Sentry.setTag('CLI-Installed', false);
+  }
+}


### PR DESCRIPTION
Derived from #903 for easier review.

This is one of multiple commits to refactor the apple wizard into individual steps with the goal of improving maintainability and testability further down the line.

#skip-changelog