### PR TITLE
refactor(apple-wizard): move lookup Xcode project logic to custom file

### DIFF
--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -7,27 +7,23 @@
 import clack from '@clack/prompts';
 import * as Sentry from '@sentry/node';
 import chalk from 'chalk';
-import * as fs from 'fs';
-import * as path from 'path';
 import { traceStep, withTelemetry } from '../telemetry';
 import * as bash from '../utils/bash';
 import * as SentryUtils from '../utils/sentrycli-utils';
-import { SentryProjectData, WizardOptions } from '../utils/types';
 import * as cocoapod from './cocoapod';
 import * as codeTools from './code-tools';
 import * as fastlane from './fastlane';
-import { XcodeProject } from './xcode-manager';
 
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 import {
-  abort,
   askForItemSelection,
   askToInstallSentryCLI,
   confirmContinueIfNoOrDirtyGitRepo,
   getOrAskForProjectData,
   printWelcome,
 } from '../utils/clack';
+import { lookupXcodeProject } from './lookup-xcode-project';
 import { AppleWizardOptions } from './options';
 
 export async function runAppleWizard(
@@ -74,66 +70,19 @@ async function runAppleWizardWithTelementry(
     }
   }
 
-  const xcodeProjFiles = searchXcodeProject(projectDir);
-  if (!xcodeProjFiles || xcodeProjFiles.length === 0) {
-    clack.log.error(
-      'No Xcode project found. Please run this command from the root of your project.',
-    );
-    await abort();
-    return;
-  }
+  // Step - Xcode Project Lookup
+  // This step should be run before the Sentry Project and API Key step
+  // because it can abort the wizard if no Xcode project is found.
+  const { xcProject, target } = await lookupXcodeProject({
+    projectDir,
+  });
 
-  let xcodeProjFile;
-
-  if (xcodeProjFiles.length === 1) {
-    xcodeProjFile = xcodeProjFiles[0];
-    Sentry.setTag('multiple-projects', false);
-  } else {
-    Sentry.setTag('multiple-projects', true);
-    xcodeProjFile = (
-      await traceStep('Choose Xcode project', () =>
-        askForItemSelection(
-          xcodeProjFiles,
-          'Which project do you want to add Sentry to?',
-        ),
-      )
-    ).value;
-  }
-
-  const pbxproj = path.join(projectDir, xcodeProjFile, 'project.pbxproj');
-
-  if (!fs.existsSync(pbxproj)) {
-    clack.log.error(`No pbxproj found at ${xcodeProjFile}`);
-    await abort();
-    return;
-  }
-
-  const { project, apiKey } = await getSentryProjectAndApiKey(options);
-
-  const xcProject = new XcodeProject(pbxproj);
-
-  const availableTargets = xcProject.getAllTargets();
-
-  if (availableTargets.length == 0) {
-    clack.log.error(`No suitable target found in ${xcodeProjFile}`);
-    Sentry.setTag('No-Target', true);
-    await abort();
-    return;
-  }
-
-  const target =
-    availableTargets.length == 1
-      ? availableTargets[0]
-      : (
-          await traceStep('Choose target', () =>
-            askForItemSelection(
-              availableTargets,
-              'Which target do you want to add Sentry to?',
-            ),
-          )
-        ).value;
-
-  SentryUtils.createSentryCLIRC(projectDir, { auth_token: apiKey.token });
+  // Step - Sentry Project and API Key
+  const { selectedProject, authToken } = await getOrAskForProjectData(
+    options,
+    'apple-ios',
+  );
+  SentryUtils.createSentryCLIRC(projectDir, { auth_token: authToken });
   clack.log.info(
     `Created a ${chalk.cyan(
       '.sentryclirc',
@@ -174,7 +123,7 @@ Set the ${chalk.cyan(
 
   Sentry.setTag('package-manager', hasCocoa ? 'cocoapods' : 'SPM');
   traceStep('Update Xcode project', () => {
-    xcProject.updateXcodeProject(project, target, !hasCocoa, true);
+    xcProject.updateXcodeProject(selectedProject, target, !hasCocoa, true);
   });
 
   const codeAdded = traceStep('Add code snippet', () => {
@@ -184,7 +133,7 @@ Set the ${chalk.cyan(
     return codeTools.addCodeSnippetToProject(
       projectDir,
       files,
-      project.keys[0].dsn.public,
+      selectedProject.keys[0].dsn.public,
     );
   });
 
@@ -208,8 +157,8 @@ Set the ${chalk.cyan(
       const added = await traceStep('Configure fastlane', () =>
         fastlane.addSentryToFastlane(
           projectDir,
-          project.organization.slug,
-          project.slug,
+          selectedProject.organization.slug,
+          selectedProject.slug,
         ),
       );
       Sentry.setTag('fastlane-added', added);
@@ -228,56 +177,4 @@ Set the ${chalk.cyan(
   clack.log.success(
     'Sentry was successfully added to your project! Run your project to send your first event to Sentry. Go to Sentry.io to see whether everything is working fine.',
   );
-}
-
-//Prompt for Sentry project and API key
-async function getSentryProjectAndApiKey(
-  options: WizardOptions,
-): Promise<{ project: SentryProjectData; apiKey: { token: string } }> {
-  const { selectedProject, authToken } = await getOrAskForProjectData(options);
-  return { project: selectedProject, apiKey: { token: authToken } };
-}
-
-function searchXcodeProject(at: string): string[] {
-  const projs = findFilesWithExtension(at, '.xcodeproj');
-  if (projs.length > 0) {
-    return projs;
-  }
-
-  const workspace = findFilesWithExtension(at, '.xcworkspace');
-  if (workspace.length == 0) {
-    return [];
-  }
-
-  const xsworkspacedata = path.join(
-    at,
-    workspace[0],
-    'contents.xcworkspacedata',
-  );
-  if (!fs.existsSync(xsworkspacedata)) {
-    return [];
-  }
-  const groupRegex = /location *= *"group:([^"]+)"/gim;
-  const content = fs.readFileSync(xsworkspacedata, 'utf8');
-  let matches = groupRegex.exec(content);
-
-  while (matches) {
-    const group = matches[1];
-    const groupPath = path.join(at, group);
-    if (
-      !group.endsWith('Pods.xcodeproj') &&
-      group.endsWith('.xcodeproj') &&
-      fs.existsSync(groupPath)
-    ) {
-      projs.push(group);
-    }
-    matches = groupRegex.exec(content);
-  }
-  return projs;
-}
-
-//find files with the given extension
-function findFilesWithExtension(dir: string, extension: string): string[] {
-  const files = fs.readdirSync(dir);
-  return files.filter((file) => file.endsWith(extension));
 }

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -1,0 +1,103 @@
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import * as Sentry from '@sentry/node';
+import chalk from 'chalk';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { traceStep } from '../telemetry';
+import { abort, askForItemSelection } from '../utils/clack';
+import { debug } from '../utils/debug';
+import { searchXcodeProjectAtPath } from './search-xcode-project-at-path';
+import { XcodeProject } from './xcode-manager';
+
+export async function lookupXcodeProject({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<{
+  xcProject: XcodeProject;
+  target: string;
+}> {
+  debug(`Looking for Xcode project in directory: ${chalk.cyan(projectDir)}`);
+  const xcodeProjFiles = searchXcodeProjectAtPath(projectDir);
+  if (xcodeProjFiles.length === 0) {
+    clack.log.error(
+      'No Xcode project found. Please run this command from the root of your project.',
+    );
+    Sentry.setTag('no-xcode-project', true);
+    return await abort();
+  }
+  debug(
+    `Found ${chalk.cyan(
+      xcodeProjFiles.length.toString(),
+    )} candidates for Xcode project`,
+  );
+
+  // In case there is only one Xcode project, we can use that one.
+  // Otherwise, we need to ask the user which one they want to use.
+  let xcodeProjFile: string;
+  if (xcodeProjFiles.length === 1) {
+    debug(`Found exactly one Xcode project, using it`);
+    Sentry.setTag('multiple-projects', false);
+    xcodeProjFile = xcodeProjFiles[0];
+  } else {
+    debug(`Found multiple Xcode projects, asking user to choose one`);
+    Sentry.setTag('multiple-projects', true);
+    xcodeProjFile = (
+      await traceStep('Choose Xcode project', () =>
+        askForItemSelection(
+          xcodeProjFiles,
+          'Which project do you want to add Sentry to?',
+        ),
+      )
+    ).value;
+  }
+
+  // Load the pbxproj file
+  const pathToPbxproj = path.join(projectDir, xcodeProjFile, 'project.pbxproj');
+  debug(`Loading Xcode project pbxproj at path: ${chalk.cyan(pathToPbxproj)}`);
+  if (!fs.existsSync(pathToPbxproj)) {
+    clack.log.error(`No pbxproj found at ${xcodeProjFile}`);
+    Sentry.setTag('pbxproj-not-found', true);
+    return await abort();
+  }
+
+  const xcProject = new XcodeProject(pathToPbxproj);
+  const availableTargets = xcProject.getAllTargets();
+  if (availableTargets.length == 0) {
+    clack.log.error(`No suitable Xcode target found in ${xcodeProjFile}`);
+    Sentry.setTag('No-Target', true);
+    return await abort();
+  }
+  debug(
+    `Found ${chalk.cyan(
+      availableTargets.length.toString(),
+    )} targets in Xcode project`,
+  );
+
+  // Step - Lookup Xcode Target
+  let target: string;
+  if (availableTargets.length == 1) {
+    debug(`Found exactly one target, using it`);
+    Sentry.setTag('multiple-targets', false);
+    target = availableTargets[0];
+  } else {
+    debug(`Found multiple targets, asking user to choose one`);
+    Sentry.setTag('multiple-targets', true);
+    target = (
+      await traceStep('Choose target', () =>
+        askForItemSelection(
+          availableTargets,
+          'Which target do you want to add Sentry to?',
+        ),
+      )
+    ).value;
+  }
+  debug(`Selected target: ${chalk.cyan(target)}`);
+
+  return {
+    xcProject,
+    target,
+  };
+}

--- a/src/apple/search-xcode-project-at-path.ts
+++ b/src/apple/search-xcode-project-at-path.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { debug } from '../utils/debug';
+import { findFilesWithExtension } from '../utils/find-files-with-extension';
+
+export function searchXcodeProjectAtPath(searchPath: string): string[] {
+  debug('Searching for Xcode project at path: ' + searchPath);
+  const projs = findFilesWithExtension(searchPath, '.xcodeproj');
+  if (projs.length > 0) {
+    debug('Found Xcode project at paths:');
+    projs.forEach((proj) => debug('  ' + proj));
+    return projs;
+  }
+
+  debug('Searching for Xcode workspace at path: ' + searchPath);
+  const workspace = findFilesWithExtension(searchPath, '.xcworkspace');
+  if (workspace.length == 0) {
+    debug('No Xcode workspace found at path: ' + searchPath);
+    return [];
+  }
+
+  debug('Found Xcode workspace at path: ' + workspace[0]);
+  const xsworkspacedata = path.join(
+    searchPath,
+    workspace[0],
+    'contents.xcworkspacedata',
+  );
+  if (!fs.existsSync(xsworkspacedata)) {
+    debug('No Xcode workspace data found at path: ' + xsworkspacedata);
+    return [];
+  }
+
+  debug('Parsing Xcode workspace data at path: ' + xsworkspacedata);
+  const groupRegex = /location *= *"group:([^"]+)"/gim;
+  const content = fs.readFileSync(xsworkspacedata, 'utf8');
+  let matches = groupRegex.exec(content);
+
+  while (matches) {
+    const group = matches[1];
+    const groupPath = path.join(searchPath, group);
+    if (
+      !group.endsWith('Pods.xcodeproj') &&
+      group.endsWith('.xcodeproj') &&
+      fs.existsSync(groupPath)
+    ) {
+      projs.push(group);
+    }
+    matches = groupRegex.exec(content);
+  }
+
+  debug('Found Xcode project at paths:');
+  projs.forEach((proj) => debug('  ' + proj));
+  return projs;
+}

--- a/src/utils/find-files-with-extension.ts
+++ b/src/utils/find-files-with-extension.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+
+import { debug } from '../utils/debug';
+
+export function findFilesWithExtension(
+  dir: string,
+  extension: string,
+): string[] {
+  debug(`Searching for files with extension: ${extension} at path: ${dir}`);
+  const files = fs.readdirSync(dir);
+  debug(`Found ${files.length} files in ${dir}`);
+  const found = files.filter((file) => file.endsWith(extension));
+  debug(`Found ${found.length} files with extension ${extension}`);
+  found.forEach((file) => debug(`  ${file}`));
+  return found;
+}


### PR DESCRIPTION
This is one of multiple commits to refactor the apple wizard into individual steps with the goal of improving maintainability and testability further down the line.

#skip-changelog