### PR TITLE
feat(sveltekit): New example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(sveltekit): New Sveltekit example page ([#913](https://github.com/getsentry/sentry-wizard/pull/913))
 - feat(nextjs): New NextJS example page ([#899](https://github.com/getsentry/sentry-wizard/pull/899))
 - feat(telemetry): Add `is_binary` tag to distinguish fossilized binaries ([#857](https://github.com/getsentry/sentry-wizard/pull/857))
 - fix(utils): Bail package manager detection if multiple candidates are detected ([#864](https://github.com/getsentry/sentry-wizard/pull/864))

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -90,6 +90,8 @@ Feel free to delete this file and the entire sentry route.
 
 <script>
   import * as Sentry from '@sentry/sveltekit';
+  
+  let hasSentError = false;
 
   function getSentryData() {
     Sentry.startSpan(
@@ -100,6 +102,7 @@ Feel free to delete this file and the entire sentry route.
       async () => {
         const res = await fetch('/sentry-example');
         if (!res.ok) {
+          hasSentError = true;
           throw new Error('Sentry Example Frontend Error');
         }
       }
@@ -107,68 +110,152 @@ Feel free to delete this file and the entire sentry route.
   }
 </script>
 
-<title>Sentry Onboarding</title>
+<title>sentry-example-page</title>
 
 <div>
   <main>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 44">
-      <path
-        fill="currentColor"
-        d="M124.32,28.28,109.56,9.22h-3.68V34.77h3.73V15.19l15.18,19.58h3.26V9.22h-3.73ZM87.15,23.54h13.23V20.22H87.14V12.53h14.93V9.21H83.34V34.77h18.92V31.45H87.14ZM71.59,20.3h0C66.44,19.06,65,18.08,65,15.7c0-2.14,1.89-3.59,4.71-3.59a12.06,12.06,0,0,1,7.07,2.55l2-2.83a14.1,14.1,0,0,0-9-3c-5.06,0-8.59,3-8.59,7.27,0,4.6,3,6.19,8.46,7.52C74.51,24.74,76,25.78,76,28.11s-2,3.77-5.09,3.77a12.34,12.34,0,0,1-8.3-3.26l-2.25,2.69a15.94,15.94,0,0,0,10.42,3.85c5.48,0,9-2.95,9-7.51C79.75,23.79,77.47,21.72,71.59,20.3ZM195.7,9.22l-7.69,12-7.64-12h-4.46L186,24.67V34.78h3.84V24.55L200,9.22Zm-64.63,3.46h8.37v22.1h3.84V12.68h8.37V9.22H131.08ZM169.41,24.8c3.86-1.07,6-3.77,6-7.63,0-4.91-3.59-8-9.38-8H154.67V34.76h3.8V25.58h6.45l6.48,9.2h4.44l-7-9.82Zm-10.95-2.5V12.6h7.17c3.74,0,5.88,1.77,5.88,4.84s-2.29,4.86-5.84,4.86Z M29,2.26a4.67,4.67,0,0,0-8,0L14.42,13.53A32.21,32.21,0,0,1,32.17,40.19H27.55A27.68,27.68,0,0,0,12.09,17.47L6,28a15.92,15.92,0,0,1,9.23,12.17H4.62A.76.76,0,0,1,4,39.06l2.94-5a10.74,10.74,0,0,0-3.36-1.9l-2.91,5a4.54,4.54,0,0,0,1.69,6.24A4.66,4.66,0,0,0,4.62,44H19.15a19.4,19.4,0,0,0-8-17.31l2.31-4A23.87,23.87,0,0,1,23.76,44H36.07a35.88,35.88,0,0,0-16.41-31.8l4.67-8a.77.77,0,0,1,1.05-.27c.53.29,20.29,34.77,20.66,35.17a.76.76,0,0,1-.68,1.13H40.6q.09,1.91,0,3.81h4.78A4.59,4.59,0,0,0,50,39.43a4.49,4.49,0,0,0-.62-2.28Z"
-      />
+    <div class="flex-spacer"></div>
+    <svg height="40" width="40" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M21.85 2.995a3.698 3.698 0 0 1 1.353 1.354l16.303 28.278a3.703 3.703 0 0 1-1.354 5.053 3.694 3.694 0 0 1-1.848.496h-3.828a31.149 31.149 0 0 0 0-3.09h3.815a.61.61 0 0 0 .537-.917L20.523 5.893a.61.61 0 0 0-1.057 0l-3.739 6.494a28.948 28.948 0 0 1 9.63 10.453 28.988 28.988 0 0 1 3.499 13.78v1.542h-9.852v-1.544a19.106 19.106 0 0 0-2.182-8.85 19.08 19.08 0 0 0-6.032-6.829l-1.85 3.208a15.377 15.377 0 0 1 6.382 12.484v1.542H3.696A3.694 3.694 0 0 1 0 34.473c0-.648.17-1.286.494-1.849l2.33-4.074a8.562 8.562 0 0 1 2.689 1.536L3.158 34.17a.611.611 0 0 0 .538.917h8.448a12.481 12.481 0 0 0-6.037-9.09l-1.344-.772 4.908-8.545 1.344.77a22.16 22.16 0 0 1 7.705 7.444 22.193 22.193 0 0 1 3.316 10.193h3.699a25.892 25.892 0 0 0-3.811-12.033 25.856 25.856 0 0 0-9.046-8.796l-1.344-.772 5.269-9.136a3.698 3.698 0 0 1 3.2-1.849c.648 0 1.285.17 1.847.495Z" fill="currentcolor"/>
     </svg>
-    <p>
-      Get Started with this <strong>simple Example:</strong>
+    <h1>
+      sentry-example-page
+    </h1>
+
+    <p class="description">
+      Click the button below, and view the sample error on the Sentry <a target="_blank" href="${issuesPageLink}">Issues Page</a>. 
+      For more details about setting up Sentry, <a target="_blank" href="https://docs.sentry.io/platforms/javascript/guides/sveltekit/">read our docs</a>.
     </p>
 
-    <p>1. Send us a sample error:</p>
-    <button type="button" on:click={getSentryData}> Throw error! </button>
+    <button
+      type="button"
+      onclick={getSentryData}
+    >
+      <span>
+        Throw Sample Error
+      </span>
+    </button>
 
-    <p>
-      2. Look for the error on the
-      <a href="${issuesPageLink}">Issues Page</a>.
-    </p>
-    <p style="margin-top: 24px;">
-      For more information, take a look at the
-      <a href="https://docs.sentry.io/platforms/javascript/guides/sveltekit/">
-        Sentry SvelteKit Documentation
-      </a>
+    {#if hasSentError}
+      <p class="success">
+        Sample error was sent to Sentry.
+      </p>
+    {:else}
+      <div class="success_placeholder"></div>
+    {/if}
+
+    <div class="flex-spacer"></div> 
+    <p class="description">
+      Adblockers will prevent errors from being sent to Sentry.
     </p>
   </main>
 </div>
 
 <style>
+  :global(body) {
+    margin: 0;
+
+    @media (prefers-color-scheme: dark) {
+      color: #ededed;
+      background-color: #0a0a0a;
+    }
+  }
+
   main {
     display: flex;
+    min-height: 100vh;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    box-sizing: border-box;
+    gap: 16px;
+    margin: 0;
+    padding: 16px;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   }
 
-  svg {
-    font-size: 4rem;
-    margin: 14px 0;
-    height: 1em;
+  h1 {
+    padding: 0px 4px;
+    border-radius: 4px;
+    background-color: rgba(24, 20, 35, 0.03);
+    font-family: monospace;
+    font-size: 20px;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 0;
+    font-size: 20px;
+  }
+
+  a {
+    color: #6341F0;
+    text-decoration: underline;
+    cursor: pointer;
+
+    @media (prefers-color-scheme: dark) {
+      color: #B3A1FF;
+    }
   }
 
   button {
-    padding: 12px;
-    cursor: pointer;
-    background-color: rgb(54, 45, 89);
-    border-radius: 4px;
-    border: none;
+    border-radius: 8px;
     color: white;
-    font-size: 1em;
-    margin: 1em;
-    transition: all 0.25s ease-in-out;
+    cursor: pointer;
+    background-color: #553DB8;
+    border: none;
+    padding: 0;
+    margin-top: 4px;
+
+    & > span {
+      display: inline-block;
+      padding: 12px 16px;
+      border-radius: inherit;
+      font-size: 20px;
+      font-weight: bold;
+      line-height: 1;
+      background-color: #7553FF;
+      border: 1px solid #553DB8;
+      transform: translateY(-4px);
+    }
+
+    &:hover > span{
+      transform: translateY(-8px);
+    }
+
+    &:active > span{
+      transform: translateY(0);
+    }
   }
-  button:hover {
-    background-color: #8c5393;
-    box-shadow: 4px;
-    box-shadow: 0px 0px 15px 2px rgba(140, 83, 147, 0.5);
+
+  .description {
+    text-align: center;
+    color: #6E6C75;
+    max-width: 500px;
+    line-height: 1.5;
+    font-size: 20px;
+
+    @media (prefers-color-scheme: dark) {
+      color: #A49FB5;
+    }
   }
-  button:active {
-    background-color: #c73852;
+
+  .flex-spacer {
+    flex: 1;
+  }
+
+  .success {
+    padding: 12px 16px;
+    border-radius: 8px;
+    font-size: 20px;
+    line-height: 1;
+    background-color: #00F261;
+    border: 1px solid #00BF4D;
+    color: #181423;
+  }
+
+  .success_placeholder {
+    height: 46px;
   }
 </style>
 `;

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -91,6 +91,8 @@ Feel free to delete this file and the entire sentry route.
 <script>
   import * as Sentry from '@sentry/sveltekit';
   
+  // Svelte Runes (requires Svelte 5)
+  // let hasSentError = $state(false);
   let hasSentError = false;
 
   function getSentryData() {
@@ -219,11 +221,11 @@ Feel free to delete this file and the entire sentry route.
       transform: translateY(-4px);
     }
 
-    &:hover > span{
+    &:hover > span {
       transform: translateY(-8px);
     }
 
-    &:active > span{
+    &:active > span {
       transform: translateY(0);
     }
   }


### PR DESCRIPTION
Redesign the example page for Sveltekit

https://github.com/user-attachments/assets/344750e8-58cf-43dd-8392-e31666cf2daa

Note:
Once https://github.com/getsentry/sentry-javascript/issues/15780 is done, I will revisit this and show the adblocker warning only when needed.

- part of https://github.com/getsentry/sentry-wizard/issues/843