### PR TITLE
ref(eslint): Set `no-explicit-any` to `error`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-argument': 'error',
     '@typescript-eslint/no-unsafe-return': 'error',
     '@typescript-eslint/no-var-requires': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },

--- a/bin.ts
+++ b/bin.ts
@@ -25,30 +25,39 @@ export * from './lib/Setup';
 const PRESELECTED_PROJECT_OPTIONS: Record<string, yargs.Options> = {
   'preSelectedProject.authToken': {
     describe: 'Preselected project auth token',
+    hidden: true,
   },
   'preSelectedProject.selfHosted': {
     describe: 'Preselected project is self-hosted',
+    hidden: true,
   },
   'preSelectedProject.dsn': {
     describe: 'Preselected project DSN',
+    hidden: true,
   },
   'preSelectedProject.id': {
     describe: 'Preselected project id',
+    hidden: true,
   },
   'preSelectedProject.projectSlug': {
     describe: 'Preselected project slug',
+    hidden: true,
   },
   'preSelectedProject.projectName': {
     describe: 'Preselected project name',
+    hidden: true,
   },
   'preSelectedProject.orgId': {
     describe: 'Preselected organization id',
+    hidden: true,
   },
   'preSelectedProject.orgName': {
     describe: 'Preselected organization name',
+    hidden: true,
   },
   'preSelectedProject.orgSlug': {
     describe: 'Preselected organization slug',
+    hidden: true,
   },
 };
 const xcodeProjectDirOption: yargs.Options = {

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -19,8 +19,12 @@ export enum Platform {
   android = 'android',
 }
 
-export function getPlatformChoices(): any[] {
-  return Object.keys(Platform).map((platform: string) => ({
+export function getPlatformChoices(): Array<{
+  checked: boolean;
+  name: string;
+  value: string;
+}> {
+  return Object.keys(Platform).map((platform) => ({
     checked: true,
     name: getPlatformDescription(platform),
     value: platform,

--- a/lib/Helper/Logging.ts
+++ b/lib/Helper/Logging.ts
@@ -42,6 +42,6 @@ export function cyan(msg: string): void {
 /**
  * @deprecated Use `debug` from `src/utils/debug.ts` instead.
  */
-export function debug(msg: any): void {
+export function debug(msg: unknown): void {
   return l(Chalk.italic.yellow(prepareMessage(msg)));
 }

--- a/lib/Steps/BaseStep.ts
+++ b/lib/Steps/BaseStep.ts
@@ -9,7 +9,7 @@ export abstract class BaseStep implements IStep {
     this._isDebug = _argv.debug;
   }
 
-  public debug(msg: any): void {
+  public debug(msg: unknown): void {
     if (this._isDebug) {
       nl();
       debug(msg);

--- a/lib/Steps/Integrations/Cordova.ts
+++ b/lib/Steps/Integrations/Cordova.ts
@@ -80,7 +80,7 @@ export class Cordova extends BaseIntegration {
   private _unpatchXcodeProj(filename: string): Promise<string> {
     const proj = xcode.project(filename);
     return new Promise((resolve, reject) => {
-      proj.parse((err: any) => {
+      proj.parse((err: unknown) => {
         if (err) {
           reject(err);
           return;
@@ -137,7 +137,7 @@ export class Cordova extends BaseIntegration {
   ): Promise<string | void> {
     const proj = xcode.project(filename);
     return new Promise((resolve, reject) => {
-      proj.parse((err: any) => {
+      proj.parse((err: unknown) => {
         if (err) {
           reject(err);
           return;


### PR DESCRIPTION
depends on #919 

explicitly sets `no-explicit-any` to `error`. Some `any`s are ignored but these are mainly in magicast code where this ProxifiedModule thing is impossible tp type correctly.

#skip-changelog

closes #920 