### PR TITLE
ref(eslint): Set `jest/expect-expect` from `warn` to `error`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,26 @@ module.exports = {
       env: {
         'jest/globals': true,
       },
+      rules: {
+        'jest/expect-expect': [
+          'error',
+          {
+            assertFunctionNames: [
+              'expect',
+              'checkPackageJson',
+              'checkFileContents',
+              'checkSentryProperties',
+              'checkIfFlutterBuilds',
+              'checkEnvBuildPlugin',
+              'checkFileExists',
+              'checkIfRunsOnDevMode',
+              'checkIfRunsOnProdMode',
+              'checkIfBuilds',
+            ],
+            additionalTestBlockFunctions: [],
+          },
+        ],
+      },
     },
   ],
   settings: {

--- a/e2e-tests/tests/flutter.test.ts
+++ b/e2e-tests/tests/flutter.test.ts
@@ -1,6 +1,5 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-/* eslint-disable jest/expect-expect */
 import { Integration } from '../../lib/Constants';
 import {
   KEYS,
@@ -32,7 +31,8 @@ describe('Flutter', () => {
         'to track the performance of your application?',
       );
 
-      const profilingOptionPrompted = tracingOptionPrompted &&
+      const profilingOptionPrompted =
+        tracingOptionPrompted &&
         (await wizardInstance.sendStdinAndWaitForOutput(
           [KEYS.ENTER],
           // "Do you want to enable Profiling", sometimes doesn't work as `Profiling` can be printed in bold.
@@ -68,13 +68,25 @@ describe('Flutter', () => {
     });
 
     test('lib/main.dart calls sentry init', () => {
-      checkFileContents(`${projectDir}/lib/main.dart`, `import 'package:sentry_flutter/sentry_flutter.dart';`);
-      checkFileContents(`${projectDir}/lib/main.dart`, `await SentryFlutter.init(`);
+      checkFileContents(
+        `${projectDir}/lib/main.dart`,
+        `import 'package:sentry_flutter/sentry_flutter.dart';`,
+      );
+      checkFileContents(
+        `${projectDir}/lib/main.dart`,
+        `await SentryFlutter.init(`,
+      );
     });
 
     test('lib/main.dart enables tracing and profiling', () => {
-      checkFileContents(`${projectDir}/lib/main.dart`, `options.tracesSampleRate = 1.0;`);
-      checkFileContents(`${projectDir}/lib/main.dart`, `options.profilesSampleRate = 1.0;`);
+      checkFileContents(
+        `${projectDir}/lib/main.dart`,
+        `options.tracesSampleRate = 1.0;`,
+      );
+      checkFileContents(
+        `${projectDir}/lib/main.dart`,
+        `options.profilesSampleRate = 1.0;`,
+      );
     });
 
     test('builds correctly', async () => {
@@ -84,7 +96,6 @@ describe('Flutter', () => {
 
   describe('without apple platforms', () => {
     beforeAll(async () => {
-
       const wizardInstance = startWizardInstance(integration, projectDir);
 
       if (fs.existsSync(`${projectDir}/ios`)) {
@@ -94,15 +105,15 @@ describe('Flutter', () => {
         fs.renameSync(`${projectDir}/macos`, `${projectDir}/_macos`);
       }
 
-      const continueOnUncommitedFilesPromted = await wizardInstance.waitForOutput(
-        'Do you want to continue anyway?'
-      )
+      const continueOnUncommitedFilesPromted =
+        await wizardInstance.waitForOutput('Do you want to continue anyway?');
 
-      const tracingOptionPrompted = continueOnUncommitedFilesPromted &&
+      const tracingOptionPrompted =
+        continueOnUncommitedFilesPromted &&
         (await wizardInstance.sendStdinAndWaitForOutput(
-        [KEYS.ENTER],
-        // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
-        'to track the performance of your application?',
+          [KEYS.ENTER],
+          // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
+          'to track the performance of your application?',
         ));
 
       tracingOptionPrompted &&
@@ -120,7 +131,10 @@ describe('Flutter', () => {
     });
 
     test('lib/main.dart does not add profiling with missing ios and macos folder', () => {
-      const fileContent = fs.readFileSync(`${projectDir}/lib/main.dart`, 'utf-8');
+      const fileContent = fs.readFileSync(
+        `${projectDir}/lib/main.dart`,
+        'utf-8',
+      );
       expect(fileContent).not.toContain(`options.profilesSampleRate = 1.0;`);
     });
   });

--- a/e2e-tests/tests/nextjs-14.test.ts
+++ b/e2e-tests/tests/nextjs-14.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import * as path from 'node:path';
 import { Integration } from '../../lib/Constants';
 import {

--- a/e2e-tests/tests/nextjs-15.test.ts
+++ b/e2e-tests/tests/nextjs-15.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import * as path from 'node:path';
 import { Integration } from '../../lib/Constants';
 import {

--- a/e2e-tests/tests/remix.test.ts
+++ b/e2e-tests/tests/remix.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import * as path from 'node:path';
 import { Integration } from '../../lib/Constants';
 import {

--- a/e2e-tests/tests/sveltekit.test.ts
+++ b/e2e-tests/tests/sveltekit.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import * as path from 'node:path';
 import { Integration } from '../../lib/Constants';
 import {


### PR DESCRIPTION
This PR also removes a couple of eslint-ignores in favour of explicitly declaring our custom `check*` functions in our e2e tests as assertion function names

closes #921 

#skip-changelog
