### PR TITLE
test(e2e): Disable telemetry collection in e2e tests

### DIFF
--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -294,6 +294,7 @@ export function startWizardInstance(
       TEST_ARGS.ORG_SLUG,
       '--preSelectedProject.projectSlug',
       TEST_ARGS.PROJECT_SLUG,
+      '--disable-telemetry',
     ],
     { cwd: projectDir, debug },
   );


### PR DESCRIPTION
The e2e test runs actually skew our collected telemetry data quite a lot (~10% of runs last week were from e2e tests). Let's disable telemetry collection for e2e tests.

#skip-changelog