### PR TITLE
ref: Hide e2e test args in `--help` command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
           - NextJS-15
           - Remix
           - Sveltekit
+          - Help
     env:
       SENTRY_TEST_AUTH_TOKEN: ${{ secrets.E2E_TEST_SENTRY_AUTH_TOKEN }}
       SENTRY_TEST_ORG: 'sentry-javascript-sdks'

--- a/bin.ts
+++ b/bin.ts
@@ -25,30 +25,39 @@ export * from './lib/Setup';
 const PRESELECTED_PROJECT_OPTIONS: Record<string, yargs.Options> = {
   'preSelectedProject.authToken': {
     describe: 'Preselected project auth token',
+    hidden: true,
   },
   'preSelectedProject.selfHosted': {
     describe: 'Preselected project is self-hosted',
+    hidden: true,
   },
   'preSelectedProject.dsn': {
     describe: 'Preselected project DSN',
+    hidden: true,
   },
   'preSelectedProject.id': {
     describe: 'Preselected project id',
+    hidden: true,
   },
   'preSelectedProject.projectSlug': {
     describe: 'Preselected project slug',
+    hidden: true,
   },
   'preSelectedProject.projectName': {
     describe: 'Preselected project name',
+    hidden: true,
   },
   'preSelectedProject.orgId': {
     describe: 'Preselected organization id',
+    hidden: true,
   },
   'preSelectedProject.orgName': {
     describe: 'Preselected organization name',
+    hidden: true,
   },
   'preSelectedProject.orgSlug': {
     describe: 'Preselected organization slug',
+    hidden: true,
   },
 };
 const xcodeProjectDirOption: yargs.Options = {

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -1,0 +1,56 @@
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+describe('--help command', () => {
+  it('prints the up to date help command', () => {
+    const binName = process.env.SENTRY_WIZARD_E2E_TEST_BIN
+      ? ['dist-bin', `sentry-wizard-${process.platform}-${process.arch}`]
+      : ['dist', 'bin.js'];
+
+    const binPath = join(__dirname, '..', '..', ...binName);
+
+    const rv = execSync(`${binPath} --help`, {
+      stdio: 'pipe',
+    });
+
+    expect(rv.toString()).toMatchInlineSnapshot(`
+      "Options:
+            --help                Show help                                  [boolean]
+            --debug               Enable verbose logging
+                                  env: SENTRY_WIZARD_DEBUG  [boolean] [default: false]
+            --uninstall           Revert project setup process
+                                  env: SENTRY_WIZARD_UNINSTALL
+                                                            [boolean] [default: false]
+            --skip-connect        Skips the connection to the server
+                                  env: SENTRY_WIZARD_SKIP_CONNECT
+                                                            [boolean] [default: false]
+            --quiet               Do not fallback to prompting user asking questions
+                                  env: SENTRY_WIZARD_QUIET  [boolean] [default: false]
+        -i, --integration         Choose the integration to setup
+                                  env: SENTRY_WIZARD_INTEGRATION
+          [choices: "reactNative", "flutter", "ios", "android", "cordova", "electron",
+                                 "nextjs", "nuxt", "remix", "sveltekit", "sourcemaps"]
+        -p, --platform            Choose platform(s)
+                                  env: SENTRY_WIZARD_PLATFORM
+                                                   [array] [choices: "ios", "android"]
+        -u, --url                 The url to your Sentry installation
+                                  env: SENTRY_WIZARD_URL
+            --project             The Sentry project slug to use
+                                       [string] [default: Select project during setup]
+            --org                 The Sentry org slug to use
+                                           [string] [default: Select org during setup]
+            --saas                Skip the self-hosted or SaaS URL selection process
+                          [boolean] [default: Select self-hosted or SaaS during setup]
+        -s, --signup              Redirect to signup page if not logged in
+                                                            [boolean] [default: false]
+            --disable-telemetry   Don't send telemetry data to Sentry
+                                                            [boolean] [default: false]
+            --force-install       Force install the SDK NPM package
+                                                            [boolean] [default: false]
+            --ignore-git-changes  Ignore git changes in the project
+                                                            [boolean] [default: false]
+            --version             Show version number                        [boolean]
+      "
+    `);
+  });
+});

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -9,11 +9,11 @@ describe('--help command', () => {
 
     const binPath = join(__dirname, '..', '..', ...binName);
 
-    const rv = execSync(`${binPath} --help`, {
+    const output = execSync(`${binPath} --help`, {
       stdio: 'pipe',
     });
 
-    expect(rv.toString()).toMatchInlineSnapshot(`
+    expect(output.toString()).toMatchInlineSnapshot(`
       "Options:
             --help                Show help                                  [boolean]
             --debug               Enable verbose logging


### PR DESCRIPTION
We have a bunch of `preSelectedProject.*` CLI args which are only meant to bypass authentication and project selection in our e2e tests. These are not meant to be user-facing, so this PR removes them from the output of out `--help` command.

This also adds a snapshot test against the `--help` output, so that we're aware if something changes (and think twice if e.g. a newly added option should be user-facing.

#skip-changelog