### PR TITLE
feat(nextjs): Add `onRouterTransitionStart` to client instrumentation template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: Add `deno` as a package manager ([#905](https://github.com/getsentry/sentry-wizard/pull/905))
+- feat(nextjs): Add `onRouterTransitionStart` to client instrumentation template ([#938](https://github.com/getsentry/sentry-wizard/pull/938))
 
 ## 4.6.0
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -213,7 +213,9 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
-});`;
+});
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;`;
 }
 
 export function getSentryExamplePageContents(options: {

--- a/test/nextjs/templates.test.ts
+++ b/test/nextjs/templates.test.ts
@@ -42,7 +42,9 @@ describe('Next.js code templates', () => {
 
           // Setting this option to true will print useful information to the console while you're setting up Sentry.
           debug: false,
-        });"
+        });
+
+        export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;"
       `);
     });
 
@@ -77,7 +79,9 @@ describe('Next.js code templates', () => {
 
           // Setting this option to true will print useful information to the console while you're setting up Sentry.
           debug: false,
-        });"
+        });
+
+        export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;"
       `);
     });
 
@@ -102,7 +106,9 @@ describe('Next.js code templates', () => {
 
           // Setting this option to true will print useful information to the console while you're setting up Sentry.
           debug: false,
-        });"
+        });
+
+        export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;"
       `);
     });
   });


### PR DESCRIPTION
This is necessary for routing instrumentation to work.