### PR TITLE
telemetry: Add basic telemetry for electron and cordova wizards

### DIFF
--- a/lib/Setup.ts
+++ b/lib/Setup.ts
@@ -5,6 +5,9 @@ import { Args } from './Constants';
 import { readEnvironment } from './Helper/Env';
 import { startWizard } from './Helper/Wizard';
 import * as Step from './Steps';
+import { withTelemetry } from '../src/telemetry';
+import { WizardOptions } from '../src/utils/types';
+import { flush } from '@sentry/node';
 
 /**
  * @deprecated this function is the entry point to the old, step-based wizards located in `lib`.
@@ -12,7 +15,10 @@ import * as Step from './Steps';
  * Therefor, do not call this function anymore.
  * Use `run` from {@link ../src/run.ts} instead.
  */
-export async function run(argv: Args): Promise<Answers> {
+export async function run(
+  argv: Args,
+  wizardOptions: WizardOptions,
+): Promise<Answers> {
   const args = { ...argv, ...readEnvironment() };
 
   if (argv.debug) {
@@ -38,5 +44,16 @@ export async function run(argv: Args): Promise<Answers> {
   }
   steps.push(Step.ConfigureProject, Step.Result);
 
-  return startWizard(args, ...steps);
+  return withTelemetry(
+    {
+      enabled: wizardOptions.telemetryEnabled,
+      integration: args.integration,
+      wizardOptions,
+    },
+    async () => {
+      const res = await startWizard(args, ...steps);
+      await flush(3000);
+      return res;
+    },
+  );
 }

--- a/lib/Steps/Welcome.ts
+++ b/lib/Steps/Welcome.ts
@@ -1,6 +1,6 @@
 import type { Answers } from 'inquirer';
 
-import { dim, green, l } from '../Helper/Logging';
+import { dim, green } from '../Helper/Logging';
 import { BaseStep } from './BaseStep';
 import chalk from 'chalk';
 

--- a/lib/Steps/Welcome.ts
+++ b/lib/Steps/Welcome.ts
@@ -1,7 +1,8 @@
 import type { Answers } from 'inquirer';
 
-import { dim, green } from '../Helper/Logging';
+import { dim, green, l } from '../Helper/Logging';
 import { BaseStep } from './BaseStep';
+import chalk from 'chalk';
 
 export class Welcome extends BaseStep {
   private static _didShow = false;
@@ -13,6 +14,11 @@ export class Welcome extends BaseStep {
     }
     if (this._argv.uninstall === false) {
       green('Sentry Wizard will help you to configure your project');
+      dim(
+        `This wizard sends telemetry data and crash reports to Sentry. This helps us improve the Wizard. You can turn telemetry off at any time by running sentry-wizard ${chalk.cyan(
+          '--disable-telemetry',
+        )}.`,
+      );
       dim('Thank you for using Sentry :)');
     }
     Welcome._didShow = true;

--- a/src/run.ts
+++ b/src/run.ts
@@ -192,22 +192,28 @@ export async function run(argv: Args) {
 
     case 'cordova':
       argv.integration = 'cordova';
-      void legacyRun({
-        ...argv,
-        url: argv.url ?? '',
-        integration: Integration.cordova,
-        platform: argv.platform ?? [],
-      });
+      void legacyRun(
+        {
+          ...argv,
+          url: argv.url ?? '',
+          integration: Integration.cordova,
+          platform: argv.platform ?? [],
+        },
+        wizardOptions,
+      );
       break;
 
     case 'electron':
       argv.integration = 'electron';
-      void legacyRun({
-        ...argv,
-        url: argv.url ?? '',
-        integration: Integration.electron,
-        platform: argv.platform ?? [],
-      });
+      void legacyRun(
+        {
+          ...argv,
+          url: argv.url ?? '',
+          integration: Integration.electron,
+          platform: argv.platform ?? [],
+        },
+        wizardOptions,
+      );
       break;
 
     default:


### PR DESCRIPTION
This PR adds very basic telemetry collection to Electron and Cordova wizards. This doesn't add most of the tags we collect in other wizards but it should be good enough to at least get an idea of usage of these two wizards. Which is the main thing we're interested in.

#skip-changelog