### PR TITLE
feat(nextjs): make errors on example page more useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - feat(nextjs): Add connectivity check to example page([#951](https://github.com/getsentry/sentry-wizard/pull/951))
 
 
+## Unreleased
+
+- feat(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
+
 ## 4.7.0
 
 - feat: Add `deno` as a package manager ([#905](https://github.com/getsentry/sentry-wizard/pull/905))
@@ -15,7 +19,6 @@
 - feat(cocoa): Update snippets to use new UI Profiling configureation ([#933](https://github.com/getsentry/sentry-wizard/pull/933))
 - fix(react-native): Handles xcode build phase patching failure ([#866](https://github.com/getsentry/sentry-wizard/pull/866))
 - feat(react-native): Add a Session Replay step ([#915](https://github.com/getsentry/sentry-wizard/pull/915))
-- feat(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
 
 ## 4.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - feat(cocoa): Update snippets to use new UI Profiling configureation ([#933](https://github.com/getsentry/sentry-wizard/pull/933))
 - fix(react-native): Handles xcode build phase patching failure ([#866](https://github.com/getsentry/sentry-wizard/pull/866))
 - feat(react-native): Add a Session Replay step ([#915](https://github.com/getsentry/sentry-wizard/pull/915))
+- fix(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
 
 ## 4.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - feat(cocoa): Update snippets to use new UI Profiling configureation ([#933](https://github.com/getsentry/sentry-wizard/pull/933))
 - fix(react-native): Handles xcode build phase patching failure ([#866](https://github.com/getsentry/sentry-wizard/pull/866))
 - feat(react-native): Add a Session Replay step ([#915](https://github.com/getsentry/sentry-wizard/pull/915))
-- fix(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
+- feat(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
 
 ## 4.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 ## Unreleased
 - test(react-native): Add E2E Tests for React Native and Expo projects ([#884](https://github.com/getsentry/sentry-wizard/pull/884))
 - feat(nextjs): Add connectivity check to example page([#951](https://github.com/getsentry/sentry-wizard/pull/951))
-
-
-## Unreleased
-
 - feat(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
 
 ## 4.7.0

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -434,16 +434,16 @@ export default function Page() {
 
 export function getSentryExamplePagesDirApiRoute() {
   return `// Custom error class for Sentry testing
-  class SentryExampleAPIError extends Error {
-    constructor(message: string | undefined) {
-      super(message);
-      this.name = "SentryExampleAPIError";
-    }
+class SentryExampleAPIError extends Error {
+  constructor(message: string | undefined) {
+    super(message);
+    this.name = "SentryExampleAPIError";
   }
-  // A faulty API route to test Sentry's error monitoring
-  export default function handler(_req, res) {
-  throw new SentryExampleAPIError("This error is raised on the backend called by the example page.");
-  res.status(200).json({ name: "John Doe" });
+}
+// A faulty API route to test Sentry's error monitoring
+export default function handler(_req, res) {
+throw new SentryExampleAPIError("This error is raised on the backend called by the example page.");
+res.status(200).json({ name: "John Doe" });
 }
 `;
 }

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -452,16 +452,14 @@ export function getSentryExampleAppDirApiRoute() {
   return `import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
-
+class SentryExampleAPIError extends Error {
+  constructor(message: string | undefined) {
+    super(message);
+    this.name = "SentryExampleAPIError";
+  }
+}
 // A faulty API route to test Sentry's error monitoring
 export function GET() {
-  class SentryExampleAPIError extends Error {
-    constructor(message: string | undefined) {
-      super(message);
-      this.name = "SentryExampleAPIError";
-    }
-  }
-
   throw new SentryExampleAPIError("This error is raised on the backend called by the example page.");
   return NextResponse.json({ data: "Testing Sentry Error..." });
 }

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -235,6 +235,13 @@ export function getSentryExamplePageContents(options: {
 import * as Sentry from "@sentry/nextjs";
 import { useState, useEffect } from "react";
 
+class SentryExampleFrontendError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SentryExampleFrontendError";
+  }
+}
+
 export default function Page() {
   const [hasSentError, setHasSentError] = useState(false);
   const [isConnected, setIsConnected] = useState(true);
@@ -278,7 +285,7 @@ export default function Page() {
               const res = await fetch("/api/sentry-example-api");
               if (!res.ok) {
                 setHasSentError(true);
-                throw new Error("Sentry Example Frontend Error");
+                throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
               }
             });
           }}
@@ -428,7 +435,15 @@ export default function Page() {
 export function getSentryExamplePagesDirApiRoute() {
   return `// A faulty API route to test Sentry's error monitoring
 export default function handler(_req, res) {
-  throw new Error("Sentry Example API Route Error");
+  // Custom error class for Sentry testing
+  class SentryExampleAPIError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = "SentryExampleAPIError";
+    }
+  }
+
+  throw new SentryExampleAPIError("This error is raised on the backend called by the example page.");
   res.status(200).json({ name: "John Doe" });
 }
 `;
@@ -441,7 +456,14 @@ export const dynamic = "force-dynamic";
 
 // A faulty API route to test Sentry's error monitoring
 export function GET() {
-  throw new Error("Sentry Example API Route Error");
+  class SentryExampleAPIError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = "SentryExampleAPIError";
+    }
+  }
+
+  throw new SentryExampleAPIError("This error is raised on the backend called by the example page.");
   return NextResponse.json({ data: "Testing Sentry Error..." });
 }
 `;

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -433,16 +433,15 @@ export default function Page() {
 }
 
 export function getSentryExamplePagesDirApiRoute() {
-  return `// A faulty API route to test Sentry's error monitoring
-export default function handler(_req, res) {
-  // Custom error class for Sentry testing
+  return `// Custom error class for Sentry testing
   class SentryExampleAPIError extends Error {
     constructor(message: string | undefined) {
       super(message);
       this.name = "SentryExampleAPIError";
     }
   }
-
+  // A faulty API route to test Sentry's error monitoring
+  export default function handler(_req, res) {
   throw new SentryExampleAPIError("This error is raised on the backend called by the example page.");
   res.status(200).json({ name: "John Doe" });
 }
@@ -457,7 +456,7 @@ export const dynamic = "force-dynamic";
 // A faulty API route to test Sentry's error monitoring
 export function GET() {
   class SentryExampleAPIError extends Error {
-    constructor(message) {
+    constructor(message: string | undefined) {
       super(message);
       this.name = "SentryExampleAPIError";
     }

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -236,7 +236,7 @@ import * as Sentry from "@sentry/nextjs";
 import { useState, useEffect } from "react";
 
 class SentryExampleFrontendError extends Error {
-  constructor(message) {
+  constructor(message: string | undefined) {
     super(message);
     this.name = "SentryExampleFrontendError";
   }
@@ -437,7 +437,7 @@ export function getSentryExamplePagesDirApiRoute() {
 export default function handler(_req, res) {
   // Custom error class for Sentry testing
   class SentryExampleAPIError extends Error {
-    constructor(message) {
+    constructor(message: string | undefined) {
       super(message);
       this.name = "SentryExampleAPIError";
     }


### PR DESCRIPTION
- Add error classes for the example errors
- Add some context that one is raised on the frontend, and one on the backend to educate about full stack support

Before:
![Screenshot 2025-04-14 at 14 17 09](https://github.com/user-attachments/assets/06f04164-2b8a-4351-ae11-39d74450cc72)

After:
![Screenshot 2025-04-14 at 14 15 22](https://github.com/user-attachments/assets/ca3e4c14-240a-44b0-8baa-ab2072401040)
