### PR TITLE
fix(remix): linting issues in generated client init code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat: Add `deno` as a package manager ([#905](https://github.com/getsentry/sentry-wizard/pull/905))
 - feat(nextjs): Add `onRouterTransitionStart` to client instrumentation template ([#938](https://github.com/getsentry/sentry-wizard/pull/938))
 - feat(cocoa): Update snippets to use new UI Profiling configureation ([#933](https://github.com/getsentry/sentry-wizard/pull/933))
+- fix(remix): linting issues in generated client init code ([#949](https://github.com/getsentry/sentry-wizard/pull/949))
 
 ## 4.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- fix(remix): linting issues in generated client init code ([#949](https://github.com/getsentry/sentry-wizard/pull/949))
+
 ## 4.7.0
 
 - feat: Add `deno` as a package manager ([#905](https://github.com/getsentry/sentry-wizard/pull/905))
 - feat(nextjs): Add `onRouterTransitionStart` to client instrumentation template ([#938](https://github.com/getsentry/sentry-wizard/pull/938))
 - feat(cocoa): Update snippets to use new UI Profiling configureation ([#933](https://github.com/getsentry/sentry-wizard/pull/933))
-- fix(remix): linting issues in generated client init code ([#949](https://github.com/getsentry/sentry-wizard/pull/949))
 - fix(react-native): Handles xcode build phase patching failure ([#866](https://github.com/getsentry/sentry-wizard/pull/866))
 - feat(react-native): Add a Session Replay step ([#915](https://github.com/getsentry/sentry-wizard/pull/915))
 

--- a/e2e-tests/tests/remix.test.ts
+++ b/e2e-tests/tests/remix.test.ts
@@ -150,8 +150,8 @@ function checkRemixProject(
 
   test('entry.client file contains Sentry initialization', () => {
     checkFileContents(`${projectDir}/app/entry.client.tsx`, [
-      'import * as Sentry, { replayIntegration, browserTracingIntegration } from "@sentry/remix";',
-      `Sentry.init({
+      'import { init, replayIntegration, browserTracingIntegration } from "@sentry/remix";',
+      `init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
 

--- a/e2e-tests/tests/remix.test.ts
+++ b/e2e-tests/tests/remix.test.ts
@@ -150,16 +150,16 @@ function checkRemixProject(
 
   test('entry.client file contains Sentry initialization', () => {
     checkFileContents(`${projectDir}/app/entry.client.tsx`, [
-      'import * as Sentry from "@sentry/remix";',
+      'import * as Sentry, { replayIntegration, browserTracingIntegration } from "@sentry/remix";',
       `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
 
-    integrations: [Sentry.browserTracingIntegration({
+    integrations: [browserTracingIntegration({
       useEffect,
       useLocation,
       useMatches
-    }), Sentry.replayIntegration({
+    }), replayIntegration({
         maskAllText: true,
         blockAllMedia: true
     })],

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -111,7 +111,7 @@ function getInitCallArgs(
     if (selectedFeatures.performance) {
       initCallArgs.integrations.push(
         builders.functionCall(
-          'Sentry.browserTracingIntegration',
+          'browserTracingIntegration',
           builders.raw('{ useEffect, useLocation, useMatches }'),
         ),
       );
@@ -119,7 +119,7 @@ function getInitCallArgs(
 
     if (selectedFeatures.replay) {
       initCallArgs.integrations.push(
-        builders.functionCall('Sentry.replayIntegration', {
+        builders.functionCall('replayIntegration', {
           maskAllText: true,
           blockAllMedia: true,
         }),
@@ -390,6 +390,20 @@ export function updateEntryClientMod(
     imported: '*',
     local: 'Sentry',
   });
+
+  if (selectedFeatures.performance || selectedFeatures.replay) {
+    const imports = [];
+    if (selectedFeatures.replay) {
+      imports.push('replayIntegration');
+    }
+    if (selectedFeatures.performance) {
+      imports.push('browserTracingIntegration');
+    }
+    originalEntryClientMod.imports.$add({
+      from: '@sentry/remix',
+      imported: `${imports.join(', ')}`,
+    });
+  }
 
   if (selectedFeatures.performance) {
     originalEntryClientMod.imports.$add({

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -144,7 +144,7 @@ function insertClientInitCall(
   },
 ): void {
   const initCallArgs = getInitCallArgs(dsn, 'client', selectedFeatures);
-  const initCall = builders.functionCall('Sentry.init', initCallArgs);
+  const initCall = builders.functionCall('init', initCallArgs);
 
   const originalHooksModAST = originalHooksMod.$ast as Program;
   const initCallInsertionIndex =
@@ -385,25 +385,17 @@ export function updateEntryClientMod(
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): ProxifiedModule<any> {
+  const imports = ['init'];
+  if (selectedFeatures.replay) {
+    imports.push('replayIntegration');
+  }
+  if (selectedFeatures.performance) {
+    imports.push('browserTracingIntegration');
+  }
   originalEntryClientMod.imports.$add({
     from: '@sentry/remix',
-    imported: '*',
-    local: 'Sentry',
+    imported: `${imports.join(', ')}`,
   });
-
-  if (selectedFeatures.performance || selectedFeatures.replay) {
-    const imports = [];
-    if (selectedFeatures.replay) {
-      imports.push('replayIntegration');
-    }
-    if (selectedFeatures.performance) {
-      imports.push('browserTracingIntegration');
-    }
-    originalEntryClientMod.imports.$add({
-      from: '@sentry/remix',
-      imported: `${imports.join(', ')}`,
-    });
-  }
 
   if (selectedFeatures.performance) {
     originalEntryClientMod.imports.$add({

--- a/test/remix/client-entry.test.ts
+++ b/test/remix/client-entry.test.ts
@@ -28,17 +28,17 @@ describe('initializeSentryOnEntryClient', () => {
         useMatches,
       } from "@remix-run/react";
 
-      import * as Sentry from "@sentry/remix";
+      import * as Sentry, {  replayIntegration, browserTracingIntegration,} from "@sentry/remix";
 
       Sentry.init({
           dsn: "https://sentry.io/123",
           tracesSampleRate: 1,
 
-          integrations: [Sentry.browserTracingIntegration({
+          integrations: [browserTracingIntegration({
             useEffect,
             useLocation,
             useMatches
-          }), Sentry.replayIntegration({
+          }), replayIntegration({
               maskAllText: true,
               blockAllMedia: true
           })],
@@ -66,12 +66,12 @@ describe('initializeSentryOnEntryClient', () => {
     );
 
     expect(result.generate().code).toMatchInlineSnapshot(`
-      "import * as Sentry from "@sentry/remix";
+      "import * as Sentry, {  replayIntegration,} from "@sentry/remix";
 
       Sentry.init({
           dsn: "https://sentry.io/123",
 
-          integrations: [Sentry.replayIntegration({
+          integrations: [replayIntegration({
               maskAllText: true,
               blockAllMedia: true
           })],
@@ -106,13 +106,13 @@ describe('initializeSentryOnEntryClient', () => {
         useMatches,
       } from "@remix-run/react";
 
-      import * as Sentry from "@sentry/remix";
+      import * as Sentry, {  browserTracingIntegration,} from "@sentry/remix";
 
       Sentry.init({
           dsn: "https://sentry.io/123",
           tracesSampleRate: 1,
 
-          integrations: [Sentry.browserTracingIntegration({
+          integrations: [browserTracingIntegration({
             useEffect,
             useLocation,
             useMatches

--- a/test/remix/client-entry.test.ts
+++ b/test/remix/client-entry.test.ts
@@ -28,9 +28,9 @@ describe('initializeSentryOnEntryClient', () => {
         useMatches,
       } from "@remix-run/react";
 
-      import * as Sentry, {  replayIntegration, browserTracingIntegration,} from "@sentry/remix";
+      import {  init, replayIntegration, browserTracingIntegration,} from "@sentry/remix";
 
-      Sentry.init({
+      init({
           dsn: "https://sentry.io/123",
           tracesSampleRate: 1,
 
@@ -66,9 +66,9 @@ describe('initializeSentryOnEntryClient', () => {
     );
 
     expect(result.generate().code).toMatchInlineSnapshot(`
-      "import * as Sentry, {  replayIntegration,} from "@sentry/remix";
+      "import {  init, replayIntegration,} from "@sentry/remix";
 
-      Sentry.init({
+      init({
           dsn: "https://sentry.io/123",
 
           integrations: [replayIntegration({
@@ -106,9 +106,9 @@ describe('initializeSentryOnEntryClient', () => {
         useMatches,
       } from "@remix-run/react";
 
-      import * as Sentry, {  browserTracingIntegration,} from "@sentry/remix";
+      import {  init, browserTracingIntegration,} from "@sentry/remix";
 
-      Sentry.init({
+      init({
           dsn: "https://sentry.io/123",
           tracesSampleRate: 1,
 


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-74/[remix]-linting-errors-in-default-project-after-wizard