### PR TITLE
chore(ci): add test jobs for macOS runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,12 +78,13 @@ jobs:
         run: yarn lint
 
   job_unit_test:
-    name: Node (${{ matrix.node }}) Unit Tests
-    runs-on: ubuntu-latest
+    name: Node (${{ matrix.node }}) Unit Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         node: [18, 20, 22]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
@@ -107,9 +108,9 @@ jobs:
           flags: unit-tests
 
   job_e2e_test:
-    name: ${{ matrix.wizard }} E2E Tests
+    name: ${{ matrix.wizard }} E2E Tests (${{ matrix.os }})
     needs: job_build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       matrix:
@@ -124,6 +125,9 @@ jobs:
           - React-Native
           - Sveltekit
           - Help
+        os:
+          - ubuntu-latest
+          - macos-latest
     env:
       SENTRY_TEST_AUTH_TOKEN: ${{ secrets.E2E_TEST_SENTRY_AUTH_TOKEN }}
       SENTRY_TEST_ORG: 'sentry-javascript-sdks'


### PR DESCRIPTION
Adds the `macOS-latest` to the `runs-on` to run unit and E2E tests also on macOS.
This way we can also run tests that are expecting macOS specific environments, i.e. CLI utilities only available for macOS.

Full context in [this PR review comment thread](https://github.com/getsentry/sentry-wizard/pull/904#discussion_r2041962378).

#skip-changelog