### PR TITLE
fix(angular): Fix source map generation bugs

### DIFF
--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -22,56 +22,48 @@ async function runWizardOnAngularProject(
   integration: Integration,
   fileModificationFn?: (projectDir: string) => unknown,
 ) {
-  const wizardInstance = startWizardInstance(integration, projectDir);
-  let packageManagerPrompted = false;
+  const wizardInstance = startWizardInstance(integration, projectDir, true);
 
   if (fileModificationFn) {
     fileModificationFn(projectDir);
 
     await wizardInstance.waitForOutput('Do you want to continue anyway?');
 
-    packageManagerPrompted = await wizardInstance.sendStdinAndWaitForOutput(
+    await wizardInstance.sendStdinAndWaitForOutput(
       [KEYS.ENTER],
       'Please select your package manager.',
     );
   } else {
-    packageManagerPrompted = await wizardInstance.waitForOutput(
-      'Please select your package manager.',
-    );
+    await wizardInstance.waitForOutput('Please select your package manager.');
   }
 
-  const tracingOptionPrompted =
-    packageManagerPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      // Selecting `yarn` as the package manager
-      [KEYS.DOWN, KEYS.ENTER],
-      // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
-      'to track the performance of your application?',
-      {
-        timeout: 240_000,
-        optional: true,
-      },
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    // Selecting `yarn` as the package manager
+    [KEYS.DOWN, KEYS.ENTER],
+    // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
+    'to track the performance of your application?',
+    {
+      timeout: 60_000, // installing the sdk can take a while
+      optional: true,
+    },
+  );
 
-  const replayOptionPrompted =
-    tracingOptionPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      // "Do you want to enable Sentry Session Replay", sometimes doesn't work as `Sentry Session Replay` can be printed in bold.
-      'to get a video-like reproduction of errors during a user session?',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    // select "Yes" for tracing
+    [KEYS.ENTER],
+    // "Do you want to enable Sentry Session Replay", sometimes doesn't work as `Sentry Session Replay` can be printed in bold.
+    'to get a video-like reproduction of errors during a user session?',
+  );
 
-  const sourcemapsPrompted =
-    replayOptionPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      // The first choice here is Angular
-      [KEYS.ENTER],
-      'Where are your build artifacts located?',
-      {
-        optional: true,
-        timeout: 5000,
-      },
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    // select "Yes" for replay
+    [KEYS.ENTER],
+    'Where are your build artifacts located?',
+    {
+      optional: true,
+      timeout: 5000,
+    },
+  );
 
   const sourcemapsConfiguredPromise = wizardInstance.waitForOutput(
     'Added a sentry:sourcemaps script to your package.json',
@@ -89,50 +81,42 @@ async function runWizardOnAngularProject(
     },
   );
 
-  if (sourcemapsPrompted) {
-    wizardInstance.sendStdin('./dist');
-    wizardInstance.sendStdin(KEYS.ENTER);
-  }
+  // ./dist is the default value, no need to change it
+  wizardInstance.sendStdin(KEYS.ENTER);
 
   const optionalArtifactsNotFoundPrompted =
-    sourcemapsPrompted && (await optionalArtifactsNotFoundPromise);
+    await optionalArtifactsNotFoundPromise;
 
   if (optionalArtifactsNotFoundPrompted) {
     wizardInstance.sendStdin(KEYS.DOWN);
     wizardInstance.sendStdin(KEYS.ENTER);
   }
 
-  const sourcemapsConfigured =
-    sourcemapsPrompted && (await sourcemapsConfiguredPromise);
-  const buildScriptPrompted =
-    sourcemapsConfigured && (await buildScriptPromptedPromise);
+  await sourcemapsConfiguredPromise;
 
-  const defaultBuildCommandPrompted =
-    buildScriptPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      'Is yarn build your production build command?',
-    ));
+  await buildScriptPromptedPromise;
 
-  const ciCdPrompted =
-    defaultBuildCommandPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      'Are you using a CI/CD tool to build and deploy your application?',
-    ));
+  wizardInstance.sendStdin(KEYS.ENTER);
 
-  const prettierPrompted =
-    ciCdPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.DOWN, KEYS.ENTER],
-      'Looks like you have Prettier in your project. Do you want to run it on your files?',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    'Is yarn build your production build command?',
+  );
 
-  prettierPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      'Sentry has been successfully configured for your Angular project',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    'Are you using a CI/CD tool to build and deploy your application?',
+  );
+
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.DOWN, KEYS.ENTER],
+    'Looks like you have Prettier in your project. Do you want to run it on your files?',
+  );
+
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    'Sentry has been successfully configured for your Angular project',
+  );
 
   wizardInstance.kill();
 }
@@ -243,6 +227,7 @@ describe('Angular-17', () => {
     );
 
     beforeAll(async () => {
+      revertLocalChanges(projectDir);
       await runWizardOnAngularProject(projectDir, integration);
     });
 
@@ -262,6 +247,7 @@ describe('Angular-17', () => {
     );
 
     beforeAll(async () => {
+      revertLocalChanges(projectDir);
       await runWizardOnAngularProject(projectDir, integration, (projectDir) => {
         modifyFile(`${projectDir}/src/app/app.config.ts`, {
           'providers: [': `providers: [{

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -22,7 +22,7 @@ async function runWizardOnAngularProject(
   integration: Integration,
   fileModificationFn?: (projectDir: string) => unknown,
 ) {
-  const wizardInstance = startWizardInstance(integration, projectDir, true);
+  const wizardInstance = startWizardInstance(integration, projectDir);
 
   if (fileModificationFn) {
     fileModificationFn(projectDir);
@@ -43,7 +43,7 @@ async function runWizardOnAngularProject(
     // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
     'to track the performance of your application?',
     {
-      timeout: 60_000, // installing the sdk can take a while
+      timeout: 240_000, // installing the sdk can take a while
       optional: true,
     },
   );

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -90,7 +90,6 @@ async function runWizardOnAngularProject(
   );
 
   if (sourcemapsPrompted) {
-    wizardInstance.sendStdin('./dist');
     wizardInstance.sendStdin(KEYS.ENTER);
   }
 
@@ -242,6 +241,7 @@ describe('Angular-19', () => {
     );
 
     beforeAll(async () => {
+      revertLocalChanges(projectDir);
       await runWizardOnAngularProject(projectDir, integration);
     });
 
@@ -260,6 +260,7 @@ describe('Angular-19', () => {
     );
 
     beforeAll(async () => {
+      revertLocalChanges(projectDir);
       await runWizardOnAngularProject(projectDir, integration, (projectDir) => {
         modifyFile(`${projectDir}/src/app/app.config.ts`, {
           'providers: [': `providers: [{

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -23,55 +23,46 @@ async function runWizardOnAngularProject(
   fileModificationFn?: (projectDir: string) => unknown,
 ) {
   const wizardInstance = startWizardInstance(integration, projectDir);
-  let packageManagerPrompted = false;
 
   if (fileModificationFn) {
     fileModificationFn(projectDir);
 
     await wizardInstance.waitForOutput('Do you want to continue anyway?');
 
-    packageManagerPrompted = await wizardInstance.sendStdinAndWaitForOutput(
+    await wizardInstance.sendStdinAndWaitForOutput(
       [KEYS.ENTER],
       'Please select your package manager.',
     );
   } else {
-    packageManagerPrompted = await wizardInstance.waitForOutput(
-      'Please select your package manager.',
-    );
+    await wizardInstance.waitForOutput('Please select your package manager.');
   }
 
-  const tracingOptionPrompted =
-    packageManagerPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      // Selecting `yarn` as the package manager
-      [KEYS.DOWN, KEYS.ENTER],
-      // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
-      'to track the performance of your application?',
-      {
-        timeout: 240_000,
-        optional: true,
-      },
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    // Selecting `yarn` as the package manager
+    [KEYS.DOWN, KEYS.ENTER],
+    // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
+    'to track the performance of your application?',
+    {
+      timeout: 240_000,
+      optional: true,
+    },
+  );
 
-  const replayOptionPrompted =
-    tracingOptionPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      // "Do you want to enable Sentry Session Replay", sometimes doesn't work as `Sentry Session Replay` can be printed in bold.
-      'to get a video-like reproduction of errors during a user session?',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    // "Do you want to enable Sentry Session Replay", sometimes doesn't work as `Sentry Session Replay` can be printed in bold.
+    'to get a video-like reproduction of errors during a user session?',
+  );
 
-  const sourcemapsPrompted =
-    replayOptionPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      // The first choice here is Angular
-      [KEYS.ENTER],
-      'Where are your build artifacts located?',
-      {
-        optional: true,
-        timeout: 5000,
-      },
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    // The first choice here is Angular
+    [KEYS.ENTER],
+    'Where are your build artifacts located?',
+    {
+      optional: true,
+      timeout: 5000,
+    },
+  );
 
   const sourcemapsConfiguredPromise = wizardInstance.waitForOutput(
     'Added a sentry:sourcemaps script to your package.json',
@@ -89,49 +80,39 @@ async function runWizardOnAngularProject(
     },
   );
 
-  if (sourcemapsPrompted) {
-    wizardInstance.sendStdin(KEYS.ENTER);
-  }
+  // ./dist is the default value, no need to change it
+  wizardInstance.sendStdin(KEYS.ENTER);
 
   const optionalArtifactsNotFoundPrompted =
-    sourcemapsPrompted && (await optionalArtifactsNotFoundPromise);
+    await optionalArtifactsNotFoundPromise;
 
   if (optionalArtifactsNotFoundPrompted) {
     wizardInstance.sendStdin(KEYS.DOWN);
     wizardInstance.sendStdin(KEYS.ENTER);
   }
 
-  const sourcemapsConfigured =
-    sourcemapsPrompted && (await sourcemapsConfiguredPromise);
-  const buildScriptPrompted =
-    sourcemapsConfigured && (await buildScriptPromptedPromise);
+  await sourcemapsConfiguredPromise;
+  await buildScriptPromptedPromise;
 
-  const defaultBuildCommandPrompted =
-    buildScriptPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      'Is yarn build your production build command?',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    'Is yarn build your production build command?',
+  );
 
-  const ciCdPrompted =
-    defaultBuildCommandPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      'Are you using a CI/CD tool to build and deploy your application?',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    'Are you using a CI/CD tool to build and deploy your application?',
+  );
 
-  const prettierPrompted =
-    ciCdPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.DOWN, KEYS.ENTER],
-      'Looks like you have Prettier in your project. Do you want to run it on your files?',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.DOWN, KEYS.ENTER],
+    'Looks like you have Prettier in your project. Do you want to run it on your files?',
+  );
 
-  prettierPrompted &&
-    (await wizardInstance.sendStdinAndWaitForOutput(
-      [KEYS.ENTER],
-      'Sentry has been successfully configured for your Angular project',
-    ));
+  await wizardInstance.sendStdinAndWaitForOutput(
+    [KEYS.ENTER],
+    'Sentry has been successfully configured for your Angular project',
+  );
 
   wizardInstance.kill();
 }

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -254,6 +254,9 @@ export function revertLocalChanges(projectDir: string): void {
     execSync('git restore .', { cwd: projectDir });
     // Revert untracked files
     execSync('git clean -fd .', { cwd: projectDir });
+    // Remove node_modules and dist (.gitignore'd and therefore not removed via git clean)
+    execSync('rm -rf node_modules', { cwd: projectDir });
+    execSync('rm -rf dist', { cwd: projectDir });
   } catch (e) {
     log.error('Error reverting local changes');
     log.error(e);
@@ -338,7 +341,10 @@ export function modifyFile(
  * @param {string} filePath
  * @param {(string | string[])} content
  */
-export function checkFileDoesNotContain(filePath: string, content: string | string[]) {
+export function checkFileDoesNotContain(
+  filePath: string,
+  content: string | string[],
+) {
   const fileContent = fs.readFileSync(filePath, 'utf-8');
   const contentArray = Array.isArray(content) ? content : [content];
 

--- a/src/angular/codemods/sourcemaps.ts
+++ b/src/angular/codemods/sourcemaps.ts
@@ -2,10 +2,8 @@
 import * as clack from '@clack/prompts';
 import * as path from 'path';
 import * as fs from 'fs';
-import {
-  angularJsonTemplate,
-  configureAngularSourcemapGenerationFlow,
-} from '../../sourcemaps/tools/angular';
+import { configureAngularSourcemapGenerationFlow } from '../../sourcemaps/tools/angular';
+import { captureException } from '@sentry/node';
 
 interface PartialAngularJson {
   projects?: {
@@ -15,7 +13,7 @@ interface PartialAngularJson {
           configurations?: {
             production?: {
               sourceMap?: boolean;
-            };
+            } & Record<string, unknown>;
           };
         };
       };
@@ -25,22 +23,49 @@ interface PartialAngularJson {
 
 export async function addSourcemapEntryToAngularJSON(): Promise<void> {
   const angularJsonPath = path.join(process.cwd(), 'angular.json');
-  const angularJSONFile = fs.readFileSync(angularJsonPath, 'utf-8');
-  const angularJson = JSON.parse(angularJSONFile) as PartialAngularJson;
+  const angularJson = getParsedAngularJson(angularJsonPath);
 
   if (!angularJson || typeof angularJson !== 'object') {
     await configureAngularSourcemapGenerationFlow();
+    return;
   }
 
-  const projects = Object.keys(angularJson.projects as Record<string, unknown>);
+  const updatedAngularJson = addSourceMapsSetting(angularJson);
 
-  if (!projects.length) {
+  if (!updatedAngularJson) {
     await configureAngularSourcemapGenerationFlow();
+    return;
+  }
+
+  try {
+    fs.writeFileSync(
+      angularJsonPath,
+      JSON.stringify(updatedAngularJson, null, 2),
+    );
+  } catch (error) {
+    clack.log.error(`Failed to write sourcemap configuration to angular.json`);
+    captureException('Failed to write sourcemap configuration to angular.json');
+    await configureAngularSourcemapGenerationFlow();
+  }
+}
+
+/**
+ * Extracted from `addSourcemapEntryToAngularJSON` and exported to allow for easier testing.
+ */
+export function addSourceMapsSetting(
+  angularJson: PartialAngularJson,
+): PartialAngularJson | undefined {
+  const newAngularJson = { ...angularJson };
+
+  const projectKeys = Object.keys(newAngularJson.projects || {});
+
+  if (!projectKeys.length || !newAngularJson.projects) {
+    return undefined;
   }
 
   // Emit sourcemaps from all projects in angular.json
-  for (const project of projects) {
-    const projectConfig = angularJson.projects?.[project] || {};
+  for (const projectKey of projectKeys) {
+    const projectConfig = newAngularJson.projects[projectKey];
 
     if (!projectConfig.architect) {
       projectConfig.architect = {};
@@ -55,16 +80,20 @@ export async function addSourcemapEntryToAngularJSON(): Promise<void> {
     }
 
     projectConfig.architect.build.configurations.production = {
+      ...projectConfig.architect.build.configurations.production,
       sourceMap: true,
     };
   }
 
+  return newAngularJson;
+}
+
+function getParsedAngularJson(path: string): PartialAngularJson | undefined {
   try {
-    fs.writeFileSync(angularJsonPath, JSON.stringify(angularJson, null, 2));
-  } catch (error) {
-    clack.log.error(`Failed to write sourcemap configuration to angular.json`);
-    clack.log
-      .warn(`Please add the following configuration to your angular.json file:
-        ${angularJsonTemplate}`);
+    const angularJSONFile = fs.readFileSync(path, 'utf-8');
+    return JSON.parse(angularJSONFile) as PartialAngularJson | undefined;
+  } catch {
+    captureException('Could not parse `angular.json`');
+    return undefined;
   }
 }

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -31,6 +31,7 @@ import type { SupportedTools } from './utils/detect-tool';
 import { detectUsedTool } from './utils/detect-tool';
 import { checkIfMoreSuitableWizardExistsAndAskForRedirect } from './utils/other-wizards';
 import { ensureMinimumSdkVersionIsInstalled } from './utils/sdk-version';
+import { sep } from 'path';
 
 export async function runSourcemapsWizard(
   options: WizardOptions,
@@ -222,7 +223,7 @@ async function startToolSetupFlow(
       break;
     case 'angular':
       await configureSentryCLI(
-        options,
+        { ...options, defaultArtifactPath: `.${sep}dist` },
         configureAngularSourcemapGenerationFlow,
         preSelectedTool === 'angular',
       );

--- a/src/sourcemaps/tools/angular.ts
+++ b/src/sourcemaps/tools/angular.ts
@@ -1,21 +1,23 @@
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
-import { abortIfCancelled } from '../../utils/clack';
+import { abortIfCancelled, makeCodeSnippet } from '../../utils/clack';
 
-export const angularJsonTemplate = chalk.gray(`{
+export const angularJsonTemplate = makeCodeSnippet(true, (unchanged, plus) =>
+  unchanged(`{
   "projects": {
     ${chalk.green('your-project')}: {
       "architect": {
         "build": {
           "options": {
-            ${chalk.greenBright(`"sourceMap": true`)}
+            ${plus(`"sourceMap": true`)}
           },
         },
       }
     }
   }
-}`);
+}`),
+);
 
 export async function configureAngularSourcemapGenerationFlow(): Promise<void> {
   clack.log.info(

--- a/src/sourcemaps/tools/angular.ts
+++ b/src/sourcemaps/tools/angular.ts
@@ -6,7 +6,7 @@ import { abortIfCancelled, makeCodeSnippet } from '../../utils/clack';
 export const angularJsonTemplate = makeCodeSnippet(true, (unchanged, plus) =>
   unchanged(`{
   "projects": {
-    ${chalk.green('your-project')}: {
+    'your-project: {
       "architect": {
         "build": {
           "options": {

--- a/src/sourcemaps/tools/angular.ts
+++ b/src/sourcemaps/tools/angular.ts
@@ -6,7 +6,7 @@ import { abortIfCancelled, makeCodeSnippet } from '../../utils/clack';
 export const angularJsonTemplate = makeCodeSnippet(true, (unchanged, plus) =>
   unchanged(`{
   "projects": {
-    'your-project: {
+    'your-project': {
       "architect": {
         "build": {
           "options": {

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -21,8 +21,12 @@ const SENTRY_NPM_SCRIPT_NAME = 'sentry:sourcemaps';
 
 let addedToBuildCommand = false;
 
+type configureSentryCLIOptions = SourceMapUploadToolConfigurationOptions & {
+  defaultArtifactPath?: string;
+};
+
 export async function configureSentryCLI(
-  options: SourceMapUploadToolConfigurationOptions,
+  options: configureSentryCLIOptions,
   configureSourcemapGenerationFlow: () => Promise<void> = defaultConfigureSourcemapGenerationFlow,
   skipValidation = false,
 ): Promise<void> {
@@ -39,7 +43,8 @@ export async function configureSentryCLI(
     const rawArtifactPath = await abortIfCancelled(
       clack.text({
         message: 'Where are your build artifacts located?',
-        placeholder: `.${path.sep}out`,
+        placeholder: options.defaultArtifactPath ?? `.${path.sep}out`,
+        initialValue: options.defaultArtifactPath ?? `.${path.sep}out`,
         validate(value) {
           if (!value) {
             return 'Please enter a path.';


### PR DESCRIPTION
While working on #953, I noticed that our source map generation flow has some bugs that we should fix:

- avoid crash when reading `angular.json` fails
- fixed bug where we'd remove production config in `angular.json`
- added reporting of read/write file errors to Sentry
- added a bunch of tests for `angular.json` manipulation
- fixed a bunch of lint and TS errors by introducing a defensively typed `PartialAngularJson` type

#skip-changelog