### PR TITLE
feat(remix): add connection check to example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat(nextjs): Add connectivity check to example page([#951](https://github.com/getsentry/sentry-wizard/pull/951))
 - feat(nextjs): Improve error names in example page to better differentiate between frontend and API errors ([#944](https://github.com/getsentry/sentry-wizard/pull/944))
 - fix(remix): linting issues in generated client init code ([#949](https://github.com/getsentry/sentry-wizard/pull/949))
+- feat(remix): Add connectivity check to example page([#967](https://github.com/getsentry/sentry-wizard/pull/967))
 
 ## 4.7.0
 

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -70,7 +70,7 @@ export default function SentryExamplePage() {
       setIsConnected(result !== 'sentry-unreachable');
     }
     checkConnectivity();
-  }, []);
+  }, [setIsConnected]);
 
   return (
     <div>

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -243,8 +243,6 @@ const styles = \`
     color: #FFFFFF;
     text-decoration: underline;
   }
-`;
-
 \`;
 `;
 }

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -84,7 +84,7 @@ export default function SentryExamplePage() {
         </h1>
 
         <p className="description">
-          Click the button below, and view the sample error on the Sentry <a target="_blank" rel="noreferrer" href="https://simon-test-us.sentry.io/issues/?project=4509168399613952">Issues Page</a>. 
+          Click the button below, and view the sample error on the Sentry <a target="_blank" rel="noreferrer" href="${issuesPageLink}">Issues Page</a>. 
           For more details about setting up Sentry, <a target="_blank" rel="noreferrer" href="https://docs.sentry.io/platforms/javascript/guides/remix/">read our docs</a>.
         </p>
 

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -52,7 +52,7 @@ export function getSentryExamplePageContents(options: {
     : `https://${options.orgSlug}.sentry.io/issues/?project=${options.projectId}`;
 
   return `import * as Sentry from "@sentry/remix";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export const meta = () => {
   return [
@@ -62,6 +62,15 @@ export const meta = () => {
 
 export default function SentryExamplePage() {
   const [hasSentError, setHasSentError] = useState(false);
+  const [isConnected, setIsConnected] = useState(true);
+  
+  useEffect(() => {
+    async function checkConnectivity() {
+      const result = await Sentry.diagnoseSdkConnectivity();
+      setIsConnected(result !== 'sentry-unreachable');
+    }
+    checkConnectivity();
+  }, []);
 
   return (
     <div>
@@ -75,7 +84,7 @@ export default function SentryExamplePage() {
         </h1>
 
         <p className="description">
-          Click the button below, and view the sample error on the Sentry <a target="_blank" rel="noreferrer" href="${issuesPageLink}">Issues Page</a>. 
+          Click the button below, and view the sample error on the Sentry <a target="_blank" rel="noreferrer" href="https://simon-test-us.sentry.io/issues/?project=4509168399613952">Issues Page</a>. 
           For more details about setting up Sentry, <a target="_blank" rel="noreferrer" href="https://docs.sentry.io/platforms/javascript/guides/remix/">read our docs</a>.
         </p>
 
@@ -103,6 +112,10 @@ export default function SentryExamplePage() {
           <p className="success">
             Sample error was sent to Sentry.
           </p>
+        ) : !isConnected ? (
+          <div className="connectivity-error">
+            <p>The Sentry SDK is not able to reach Sentry right now - this may be due to an adblocker. For more information, see <a target="_blank" rel="noreferrer" href="https://docs.sentry.io/platforms/javascript/guides/remix/troubleshooting/#the-sdk-is-not-sending-any-data">the troubleshooting guide</a>.</p>
+          </div>
         ) : (
           <div className="success_placeholder" />
         )}
@@ -214,6 +227,24 @@ const styles = \`
   .success_placeholder {
     height: 46px;
   }
+  
+  .connectivity-error {
+    padding: 12px 16px;
+    background-color: #E50045;
+    border-radius: 8px;
+    width: 500px;
+    color: #FFFFFF;
+    border: 1px solid #A80033;
+    text-align: center;
+    margin: 0;
+  }
+  
+  .connectivity-error a {
+    color: #FFFFFF;
+    text-decoration: underline;
+  }
+`;
+
 \`;
 `;
 }


### PR DESCRIPTION
- Uses the new diagnoseSdkConnectivity() function to check whether something is preventing data from reaching sentry https://github.com/getsentry/sentry-javascript/pull/15821
- If the connection is disturbed, call this out to the user using a banner and link to the docs explaining how to solve the issue
- Contributes to [TET-59](https://linear.app/getsentry/issue/TET-59/add-error-state-to-example-pages)

Before:
![Screenshot 2025-04-17 at 13 35 07](https://github.com/user-attachments/assets/3d6aafea-4ea8-4b4a-b09a-81ce765c01d7)

After: 
![Screenshot 2025-04-17 at 13 35 14](https://github.com/user-attachments/assets/34045c2d-a012-4fc1-b5b2-3862b65bbf64)
