### PR TITLE
feat(sveltekit): add bad connection detection on example page

### DIFF
--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -90,10 +90,17 @@ Feel free to delete this file and the entire sentry route.
 
 <script>
   import * as Sentry from '@sentry/sveltekit';
+  import { onMount } from 'svelte';
   
   // Svelte Runes (requires Svelte 5)
   // let hasSentError = $state(false);
   let hasSentError = false;
+  let isConnected = true;
+
+  onMount(async () => {
+    const result = await Sentry.diagnoseSdkConnectivity();
+    isConnected = result !== 'sentry-unreachable';
+  });
 
   function getSentryData() {
     Sentry.startSpan(
@@ -142,6 +149,10 @@ Feel free to delete this file and the entire sentry route.
       <p class="success">
         Sample error was sent to Sentry.
       </p>
+    {:else if !isConnected}
+      <div class="connectivity-error">
+        <p>The Sentry SDK is not able to reach Sentry right now - this may be due to an adblocker. For more information, see <a target="_blank" href="https://docs.sentry.io/platforms/javascript/guides/sveltekit/troubleshooting/#the-sdk-is-not-sending-any-data">the troubleshooting guide</a>.</p>
+      </div>
     {:else}
       <div class="success_placeholder"></div>
     {/if}
@@ -258,6 +269,22 @@ Feel free to delete this file and the entire sentry route.
 
   .success_placeholder {
     height: 46px;
+  }
+
+  .connectivity-error {
+    padding: 12px 16px;
+    background-color: #E50045;
+    border-radius: 8px;
+    width: 500px;
+    color: #FFFFFF;
+    border: 1px solid #A80033;
+    text-align: center;
+    margin: 0;
+  }
+  
+  .connectivity-error a {
+    color: #FFFFFF;
+    text-decoration: underline;
   }
 </style>
 `;


### PR DESCRIPTION
- Use onMount to run connection check on mounting of component
- Contributes to TET-59

Initial State:
<img width="1004" alt="Screenshot 2025-04-22 at 14 24 03" src="https://github.com/user-attachments/assets/c6d899be-6bb9-49eb-bf6e-35621f1432ad" />

Success State:
<img width="1006" alt="Screenshot 2025-04-22 at 14 24 10" src="https://github.com/user-attachments/assets/e555db52-b2c8-4d20-a73b-40c14c35eb3c" />

Connection Error State (new):
<img width="1005" alt="Screenshot 2025-04-22 at 14 23 56" src="https://github.com/user-attachments/assets/c0ce5d24-9401-4288-93c5-0f824e8a0e5f" />