### PR TITLE
fix(sveltekit): sentry example page should be at /sentry-example-page for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix(remix): linting issues in generated client init code ([#949](https://github.com/getsentry/sentry-wizard/pull/949))
 - feat(nuxt): Add connectivity check to example page ([#966](https://github.com/getsentry/sentry-wizard/pull/966))
 - feat(remix): Add connectivity check to example page([#967](https://github.com/getsentry/sentry-wizard/pull/967))
+- feat(sveltekit): move example page from sentry-example to sentry-example-page( [#973](https://github.com/getsentry/sentry-wizard/pull/973))
 
 ## 4.7.0
 

--- a/e2e-tests/tests/sveltekit.test.ts
+++ b/e2e-tests/tests/sveltekit.test.ts
@@ -123,10 +123,10 @@ function checkSvelteKitProject(
 
   test('example page exists', () => {
     checkFileExists(
-      path.resolve(projectDir, 'src/routes/sentry-example/+page.svelte'),
+      path.resolve(projectDir, 'src/routes/sentry-example-page/+page.svelte'),
     );
     checkFileExists(
-      path.resolve(projectDir, 'src/routes/sentry-example/+server.js'),
+      path.resolve(projectDir, 'src/routes/sentry-example-page/+server.js'),
     );
   });
 

--- a/src/sveltekit/sdk-example.ts
+++ b/src/sveltekit/sdk-example.ts
@@ -23,7 +23,7 @@ export async function createExamplePage(
 ): Promise<void> {
   const routesDirectory = svelteConfig.kit?.files?.routes || 'src/routes';
   const exampleRoutePath = path.resolve(
-    path.join(routesDirectory, 'sentry-example'),
+    path.join(routesDirectory, 'sentry-example-page'),
   );
 
   if (!fs.existsSync(routesDirectory)) {

--- a/src/sveltekit/sveltekit-wizard.ts
+++ b/src/sveltekit/sveltekit-wizard.ts
@@ -141,7 +141,7 @@ export async function runSvelteKitWizardWithTelemetry(
   }
 
   const shouldCreateExamplePage = await askShouldCreateExamplePage(
-    '/sentry-example',
+    '/sentry-example-page',
   );
 
   if (shouldCreateExamplePage) {
@@ -190,7 +190,7 @@ async function buildOutroMessage(
   if (shouldCreateExamplePage) {
     msg += `\n\nYou can validate your setup by starting your dev environment (${chalk.cyan(
       `\`${packageManager.runScriptCommand} dev\``,
-    )}) and visiting ${chalk.cyan('"/sentry-example"')}.`;
+    )}) and visiting ${chalk.cyan('"/sentry-example-page"')}.`;
   }
 
   msg += `\n\nCheck out the SDK documentation for further configuration:

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -102,7 +102,7 @@ Feel free to delete this file and the entire sentry route.
         op: 'test'
       },
       async () => {
-        const res = await fetch('/sentry-example');
+        const res = await fetch('/sentry-example-page');
         if (!res.ok) {
           hasSentError = true;
           throw new Error('Sentry Example Frontend Error');


### PR DESCRIPTION
- This aligns with the location of the page in other frameworks (consistency)
- Our onboarding tells you that the page is located at `sentry-example-page` as well:
<img width="930" alt="Screenshot 2025-04-22 at 14 35 53" src="https://github.com/user-attachments/assets/3b2fda39-3bde-492b-9a34-02318858222f" />
