### PR TITLE
test(angular): Unflake Angular e2e test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,22 +111,22 @@ jobs:
     name: ${{ matrix.wizard }} E2E Tests (${{ matrix.os }})
     needs: job_build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 10
     strategy:
       matrix:
         wizard:
-          # - Expo
+          - Expo
           - Angular-17
           - Angular-19
-          # - Flutter
-          # - Nuxt-3
-          # - Nuxt-4
-          # - NextJS-14
-          # - NextJS-15
-          # - Remix
-          # - React-Native
-          # - Sveltekit
-          # - Help
+          - Flutter
+          - Nuxt-3
+          - Nuxt-4
+          - NextJS-14
+          - NextJS-15
+          - Remix
+          - React-Native
+          - Sveltekit
+          - Help
         os:
           - ubuntu-latest
           - macos-latest
@@ -158,24 +158,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.sha }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
-      - name: Run End-to-End Tests
-        run: yarn test:e2e:bin ${{ matrix.wizard }}
       - name: Run End-to-End Tests
         run: yarn test:e2e:bin ${{ matrix.wizard }}
       - name: Push code coverage to codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,16 @@ jobs:
         run: yarn test:e2e:bin ${{ matrix.wizard }}
       - name: Run End-to-End Tests
         run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
       - name: Push code coverage to codecov
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # pin@v5.3.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,18 +115,18 @@ jobs:
     strategy:
       matrix:
         wizard:
-          - Expo
+          # - Expo
           - Angular-17
           - Angular-19
-          - Flutter
-          - Nuxt-3
-          - Nuxt-4
-          - NextJS-14
-          - NextJS-15
-          - Remix
-          - React-Native
-          - Sveltekit
-          - Help
+          # - Flutter
+          # - Nuxt-3
+          # - Nuxt-4
+          # - NextJS-14
+          # - NextJS-15
+          # - Remix
+          # - React-Native
+          # - Sveltekit
+          # - Help
         os:
           - ubuntu-latest
           - macos-latest
@@ -158,6 +158,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.sha }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
+      - name: Run End-to-End Tests
+        run: yarn test:e2e:bin ${{ matrix.wizard }}
       - name: Run End-to-End Tests
         run: yarn test:e2e:bin ${{ matrix.wizard }}
       - name: Push code coverage to codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
     name: ${{ matrix.wizard }} E2E Tests (${{ matrix.os }})
     needs: job_build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 25
     strategy:
       matrix:
         wizard:

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -90,7 +90,7 @@ async function runWizardOnAngularProject(
   }
 
   await wizardInstance.sendStdinAndWaitForOutput(
-    // Selecting `yarn` as the package manager
+    // Selecting `yarn v1` as the package manager
     [KEYS.DOWN, KEYS.ENTER],
     // "Do you want to enable Tracing", sometimes doesn't work as `Tracing` can be printed in bold.
     'to track the performance of your application?',

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -17,6 +17,60 @@ import * as path from 'path';
 import { TEST_ARGS } from '../utils';
 import { test, expect, describe, beforeAll, afterAll } from 'vitest';
 
+// TODO: Remove repeats before merging!
+// eslint-disable-next-line vitest/valid-describe-callback
+describe.sequential('Angular-17', { repeats: 15 }, () => {
+  describe('with empty project', () => {
+    const integration = Integration.angular;
+    const projectDir = path.resolve(
+      __dirname,
+      '../test-applications/angular-17-test-app',
+    );
+
+    beforeAll(async () => {
+      revertLocalChanges(projectDir);
+      await runWizardOnAngularProject(projectDir, integration);
+    });
+
+    afterAll(() => {
+      revertLocalChanges(projectDir);
+      cleanupGit(projectDir);
+    });
+
+    checkAngularProject(projectDir, integration);
+  });
+
+  describe('with pre-defined ErrorHandler', () => {
+    const integration = Integration.angular;
+    const projectDir = path.resolve(
+      __dirname,
+      '../test-applications/angular-17-test-app',
+    );
+
+    beforeAll(async () => {
+      revertLocalChanges(projectDir);
+      await runWizardOnAngularProject(projectDir, integration, (projectDir) => {
+        modifyFile(`${projectDir}/src/app/app.config.ts`, {
+          'providers: [': `providers: [{
+            provide: ErrorHandler,
+            useValue: null
+            },
+            `,
+        });
+      });
+    });
+
+    afterAll(() => {
+      revertLocalChanges(projectDir);
+      cleanupGit(projectDir);
+    });
+
+    checkAngularProject(projectDir, integration, {
+      preExistingErrorHandler: true,
+    });
+  });
+});
+
 async function runWizardOnAngularProject(
   projectDir: string,
   integration: Integration,
@@ -224,55 +278,3 @@ function checkAngularProject(
     );
   });
 }
-
-describe('Angular-17', () => {
-  describe('with empty project', () => {
-    const integration = Integration.angular;
-    const projectDir = path.resolve(
-      __dirname,
-      '../test-applications/angular-17-test-app',
-    );
-
-    beforeAll(async () => {
-      revertLocalChanges(projectDir);
-      await runWizardOnAngularProject(projectDir, integration);
-    });
-
-    afterAll(() => {
-      revertLocalChanges(projectDir);
-      cleanupGit(projectDir);
-    });
-
-    checkAngularProject(projectDir, integration);
-  });
-
-  describe.skip('with pre-defined ErrorHandler', () => {
-    const integration = Integration.angular;
-    const projectDir = path.resolve(
-      __dirname,
-      '../test-applications/angular-17-test-app',
-    );
-
-    beforeAll(async () => {
-      revertLocalChanges(projectDir);
-      await runWizardOnAngularProject(projectDir, integration, (projectDir) => {
-        modifyFile(`${projectDir}/src/app/app.config.ts`, {
-          'providers: [': `providers: [{
-            provide: ErrorHandler,
-            useValue: null
-            },
-            `,
-        });
-      });
-    });
-
-    afterAll(() => {
-      revertLocalChanges(projectDir);
-      cleanupGit(projectDir);
-    });
-
-    checkAngularProject(projectDir, integration, {
-      preExistingErrorHandler: true,
-    });
-  });
-});

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -112,7 +112,7 @@ async function runWizardOnAngularProject(
     [KEYS.ENTER],
     'Where are your build artifacts located?',
     {
-      timeout: 5000,
+      timeout: 240_000, // installing Sentry CLI can take a while
     },
   );
 

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -76,7 +76,7 @@ async function runWizardOnAngularProject(
   integration: Integration,
   fileModificationFn?: (projectDir: string) => unknown,
 ) {
-  const wizardInstance = startWizardInstance(integration, projectDir);
+  const wizardInstance = startWizardInstance(integration, projectDir, true);
 
   if (fileModificationFn) {
     fileModificationFn(projectDir);

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -17,9 +17,7 @@ import * as path from 'path';
 import { TEST_ARGS } from '../utils';
 import { test, expect, describe, beforeAll, afterAll } from 'vitest';
 
-// TODO: Remove repeats before merging!
-// eslint-disable-next-line vitest/valid-describe-callback
-describe.sequential('Angular-17', { repeats: 15 }, () => {
+describe.sequential('Angular-17', () => {
   describe('with empty project', () => {
     const integration = Integration.angular;
     const projectDir = path.resolve(

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -75,7 +75,7 @@ async function runWizardOnAngularProject(
   integration: Integration,
   fileModificationFn?: (projectDir: string) => unknown,
 ) {
-  const wizardInstance = startWizardInstance(integration, projectDir);
+  const wizardInstance = startWizardInstance(integration, projectDir, true);
 
   if (fileModificationFn) {
     fileModificationFn(projectDir);

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -17,6 +17,59 @@ import * as path from 'path';
 import { TEST_ARGS } from '../utils';
 import { test, expect, describe, beforeAll, afterAll } from 'vitest';
 
+// TODO: Remove repeats before merging!
+// eslint-disable-next-line vitest/valid-describe-callback
+describe.sequential('Angular-19', { repeats: 15 }, () => {
+  describe('with empty project', () => {
+    const integration = Integration.angular;
+    const projectDir = path.resolve(
+      __dirname,
+      '../test-applications/angular-19-test-app',
+    );
+
+    beforeAll(async () => {
+      revertLocalChanges(projectDir);
+      await runWizardOnAngularProject(projectDir, integration);
+    });
+
+    afterAll(() => {
+      revertLocalChanges(projectDir);
+      cleanupGit(projectDir);
+    });
+
+    checkAngularProject(projectDir, integration);
+  });
+  describe('with pre-defined ErrorHandler', () => {
+    const integration = Integration.angular;
+    const projectDir = path.resolve(
+      __dirname,
+      '../test-applications/angular-19-test-app',
+    );
+
+    beforeAll(async () => {
+      revertLocalChanges(projectDir);
+      await runWizardOnAngularProject(projectDir, integration, (projectDir) => {
+        modifyFile(`${projectDir}/src/app/app.config.ts`, {
+          'providers: [': `providers: [{
+            provide: ErrorHandler,
+            useValue: null
+            },
+            `,
+        });
+      });
+    });
+
+    afterAll(() => {
+      revertLocalChanges(projectDir);
+      cleanupGit(projectDir);
+    });
+
+    checkAngularProject(projectDir, integration, {
+      preExistingErrorHandler: true,
+    });
+  });
+});
+
 async function runWizardOnAngularProject(
   projectDir: string,
   integration: Integration,
@@ -222,54 +275,3 @@ function checkAngularProject(
     );
   });
 }
-
-describe('Angular-19', () => {
-  describe('with empty project', () => {
-    const integration = Integration.angular;
-    const projectDir = path.resolve(
-      __dirname,
-      '../test-applications/angular-19-test-app',
-    );
-
-    beforeAll(async () => {
-      revertLocalChanges(projectDir);
-      await runWizardOnAngularProject(projectDir, integration);
-    });
-
-    afterAll(() => {
-      revertLocalChanges(projectDir);
-      cleanupGit(projectDir);
-    });
-
-    checkAngularProject(projectDir, integration);
-  });
-  describe('with pre-defined ErrorHandler', () => {
-    const integration = Integration.angular;
-    const projectDir = path.resolve(
-      __dirname,
-      '../test-applications/angular-19-test-app',
-    );
-
-    beforeAll(async () => {
-      revertLocalChanges(projectDir);
-      await runWizardOnAngularProject(projectDir, integration, (projectDir) => {
-        modifyFile(`${projectDir}/src/app/app.config.ts`, {
-          'providers: [': `providers: [{
-            provide: ErrorHandler,
-            useValue: null
-            },
-            `,
-        });
-      });
-    });
-
-    afterAll(() => {
-      revertLocalChanges(projectDir);
-      cleanupGit(projectDir);
-    });
-
-    checkAngularProject(projectDir, integration, {
-      preExistingErrorHandler: true,
-    });
-  });
-});

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -17,9 +17,7 @@ import * as path from 'path';
 import { TEST_ARGS } from '../utils';
 import { test, expect, describe, beforeAll, afterAll } from 'vitest';
 
-// TODO: Remove repeats before merging!
-// eslint-disable-next-line vitest/valid-describe-callback
-describe.sequential('Angular-19', { repeats: 15 }, () => {
+describe.sequential('Angular-19', () => {
   describe('with empty project', () => {
     const integration = Integration.angular;
     const projectDir = path.resolve(

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -79,6 +79,7 @@ export class WizardTestEnv {
   }
 
   sendStdin(input: string) {
+    console.log(`xx Sending input: ${input}`);
     this.taskHandle.stdin?.write(input);
   }
 

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -79,7 +79,6 @@ export class WizardTestEnv {
   }
 
   sendStdin(input: string) {
-    console.log(`xx Sending input: ${input}`);
     this.taskHandle.stdin?.write(input);
   }
 


### PR DESCRIPTION
Looks like we were running into a timeout during the Sentry CLI installation, so I bumped it to the same timeout as the SDK package installation. 

Also:
- Fixed memory leak (warning) by removing `waitForOutput` listeners once the returned promise resolved/rejected
- moved wizard execution logic beneath the actual tests for better readability  

#skip-changelog