### PR TITLE
feat(Mobile): adds `sendDefaultPii` to Mobile wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix(apple): add support for synchronized Xcode folders ([#904](https://github.com/getsentry/sentry-wizard/pull/904))
 - feat(react-native): Add Feedback Widget step ([#969](https://github.com/getsentry/sentry-wizard/pull/969))
 - feat(react-native): More granular error reporting for RN Wizard ([#861](https://github.com/getsentry/sentry-wizard/pull/861))
+- feat(Mobile): add `sendDefaultPii=true` to Mobile wizards ([#981](https://github.com/getsentry/sentry-wizard/pull/981))
 
 ## 4.8.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,20 +17,19 @@ Developer Documentation.
 1. Fork the repository
 2. Clone your fork
 3. Install dependencies with `yarn install`
-l: Some stuff that's probably worth mentioning here:
 
-Suggested change
-3. Install dependencies with `yarn install`
-## Running End-to-End Tests
-3. Install dependencies with `yarn install`
 ## Building and running locally
+
 Build the wizard with this command
+
 ```bash
 yarn build
 ```
+
 If you want to simply try out the wizard locally, you can use
+
 ```bash
-yarn try #also takes all CLI args you'd pass to the wizard 
+yarn try #also takes all CLI args you'd pass to the wizard
 ```
 
 ### Running local builds in external projects

--- a/e2e-tests/tests/expo.test.ts
+++ b/e2e-tests/tests/expo.test.ts
@@ -70,6 +70,10 @@ describe('Expo', () => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
+
   // Configure Session Replay
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1,

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -101,7 +101,7 @@ describe('ReactNative', () => {
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  
+
   // Adds more context data to events (IP address, cookies, user, etc.)
   // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
   sendDefaultPii: true,

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -101,6 +101,10 @@ describe('ReactNative', () => {
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
 
   // Configure Session Replay
   replaysSessionSampleRate: 0.1,

--- a/src/android/templates.ts
+++ b/src/android/templates.ts
@@ -23,6 +23,8 @@ export const pluginKts = (version = '3.12.0') => `
 export const manifest = (dsn: string) => `
     <!-- Required: set your sentry.io project identifier (DSN) -->
     <meta-data android:name="io.sentry.dsn" android:value="${dsn}" />
+    <!-- Add data like request headers, user ip address and device name, see https://docs.sentry.io/platforms/android/data-management/data-collected/ for more info -->
+    <meta-data android:name="io.sentry.send-default-pii" android:value="true" />
 
     <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
     <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />

--- a/src/apple/templates.ts
+++ b/src/apple/templates.ts
@@ -20,6 +20,11 @@ export function getSwiftSnippet(dsn: string): string {
   return `        SentrySDK.start { options in
             options.dsn = "${dsn}"
             options.debug = true // Enabled debug when first installing is always helpful
+
+            // Adds IP for users.
+            // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+            options.sendDefaultPii = true
+
             // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0
@@ -42,6 +47,11 @@ export function getObjcSnippet(dsn: string): string {
   return `    [SentrySDK startWithConfigureOptions:^(SentryOptions * options) {
         options.dsn = @"${dsn}";
         options.debug = YES; // Enabled debug when first installing is always helpful
+
+        // Adds IP for users.
+        // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+        options.sendDefaultPii = YES;
+
         // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
         // We recommend adjusting this value in production.
         options.tracesSampleRate = @1.0;

--- a/src/flutter/templates.ts
+++ b/src/flutter/templates.ts
@@ -25,7 +25,10 @@ export function initSnippet(
 ): string {
   let snippet = `await SentryFlutter.init(
     (options) {
-      options.dsn = '${dsn}';`;
+      options.dsn = '${dsn}';
+      // Adds request headers and IP for users, for more info visit:
+      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+      options.sendDefaultPii = true;`;
 
   if (selectedFeaturesMap.tracing) {
     snippet += `
@@ -77,6 +80,9 @@ Future<void>main() async {
   await SentryFlutter.init(
     (options) {
       options.dsn = '${dsn}';
+      // Adds request headers and IP for users, for more info visit:
+      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+      options.sendDefaultPii = true;
       // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
       // We recommend adjusting this value in production.
       options.tracesSampleRate = 1.0;

--- a/src/flutter/templates.ts
+++ b/src/flutter/templates.ts
@@ -27,7 +27,7 @@ export function initSnippet(
     (options) {
       options.dsn = '${dsn}';
       // Adds request headers and IP for users, for more info visit:
-      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
       options.sendDefaultPii = true;`;
 
   if (selectedFeaturesMap.tracing) {
@@ -81,7 +81,7 @@ Future<void>main() async {
     (options) {
       options.dsn = '${dsn}';
       // Adds request headers and IP for users, for more info visit:
-      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+      // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
       options.sendDefaultPii = true;
       // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
       // We recommend adjusting this value in production.

--- a/src/react-native/javascript.ts
+++ b/src/react-native/javascript.ts
@@ -141,7 +141,7 @@ export function getSentryInitPlainTextSnippet(
 
 Sentry.init({
   dsn: '${dsn}',
-  
+
   // Adds more context data to events (IP address, cookies, user, etc.)
   // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
   sendDefaultPii: true,

--- a/src/react-native/javascript.ts
+++ b/src/react-native/javascript.ts
@@ -141,6 +141,10 @@ export function getSentryInitPlainTextSnippet(
 
 Sentry.init({
   dsn: '${dsn}',
+  
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
 ${
   enableSessionReplay
     ? `

--- a/test/apple/code-tools.test.ts
+++ b/test/apple/code-tools.test.ts
@@ -35,6 +35,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SentrySDK.start { options in
             options.dsn = "https://example.com/sentry-dsn"
             options.debug = true // Enabled debug when first installing is always helpful
+
+            // Adds IP for users.
+            // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+            options.sendDefaultPii = true
+
             // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0
@@ -89,6 +94,11 @@ const validAppDelegateObjCWithSentry = `@import Sentry;
     [SentrySDK startWithConfigureOptions:^(SentryOptions * options) {
         options.dsn = @"https://example.com/sentry-dsn";
         options.debug = YES; // Enabled debug when first installing is always helpful
+
+        // Adds IP for users.
+        // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+        options.sendDefaultPii = YES;
+
         // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
         // We recommend adjusting this value in production.
         options.tracesSampleRate = @1.0;
@@ -139,6 +149,11 @@ struct TestApp: App {
         SentrySDK.start { options in
             options.dsn = "https://example.com/sentry-dsn"
             options.debug = true // Enabled debug when first installing is always helpful
+
+            // Adds IP for users.
+            // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+            options.sendDefaultPii = true
+
             // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0

--- a/test/apple/templates.test.ts
+++ b/test/apple/templates.test.ts
@@ -126,6 +126,11 @@ fi
         `        SentrySDK.start { options in
             options.dsn = "test-dsn"
             options.debug = true // Enabled debug when first installing is always helpful
+
+            // Adds IP for users.
+            // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+            options.sendDefaultPii = true
+
             // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
             // We recommend adjusting this value in production.
             options.tracesSampleRate = 1.0
@@ -157,6 +162,11 @@ fi
         `    [SentrySDK startWithConfigureOptions:^(SentryOptions * options) {
         options.dsn = @"test-dsn";
         options.debug = YES; // Enabled debug when first installing is always helpful
+
+        // Adds IP for users.
+        // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
+        options.sendDefaultPii = YES;
+
         // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
         // We recommend adjusting this value in production.
         options.tracesSampleRate = @1.0;

--- a/test/flutter/templates.test.ts
+++ b/test/flutter/templates.test.ts
@@ -40,7 +40,7 @@ describe('Flutter code templates', () => {
             (options) {
               options.dsn = 'my-dsn';
               // Adds request headers and IP for users, for more info visit:
-              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
               options.sendDefaultPii = true;
               // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
               // We recommend adjusting this value in production.
@@ -70,7 +70,7 @@ describe('Flutter code templates', () => {
             (options) {
               options.dsn = 'my-dsn';
               // Adds request headers and IP for users, for more info visit:
-              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
               options.sendDefaultPii = true;
               // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
               // We recommend adjusting this value in production.
@@ -97,7 +97,7 @@ describe('Flutter code templates', () => {
             (options) {
               options.dsn = 'my-dsn';
               // Adds request headers and IP for users, for more info visit:
-              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/
               options.sendDefaultPii = true;
             },
             appRunner: () => runApp(SentryWidget(child: const MyApp())),

--- a/test/flutter/templates.test.ts
+++ b/test/flutter/templates.test.ts
@@ -39,6 +39,9 @@ describe('Flutter code templates', () => {
         "await SentryFlutter.init(
             (options) {
               options.dsn = 'my-dsn';
+              // Adds request headers and IP for users, for more info visit:
+              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+              options.sendDefaultPii = true;
               // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
               // We recommend adjusting this value in production.
               options.tracesSampleRate = 1.0;
@@ -66,6 +69,9 @@ describe('Flutter code templates', () => {
         "await SentryFlutter.init(
             (options) {
               options.dsn = 'my-dsn';
+              // Adds request headers and IP for users, for more info visit:
+              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+              options.sendDefaultPii = true;
               // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.
               // We recommend adjusting this value in production.
               options.tracesSampleRate = 1.0;
@@ -90,6 +96,9 @@ describe('Flutter code templates', () => {
         "await SentryFlutter.init(
             (options) {
               options.dsn = 'my-dsn';
+              // Adds request headers and IP for users, for more info visit:
+              // https://docs.sentry.io/platforms/dart/guides/flutter/data-management/data-collected/ for more info
+              options.sendDefaultPii = true;
             },
             appRunner: () => runApp(SentryWidget(child: const MyApp())),
           );

--- a/test/react-native/javascript.test.ts
+++ b/test/react-native/javascript.test.ts
@@ -39,6 +39,10 @@ import * as Sentry from '@sentry/react-native';
 Sentry.init({
   dsn: 'dsn',
 
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
+
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: __DEV__,
 });
@@ -84,6 +88,10 @@ import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
   dsn: 'dsn',
+
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
 
   // Configure Session Replay
   replaysSessionSampleRate: 0.1,
@@ -138,6 +146,10 @@ import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
   dsn: 'dsn',
+
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
   integrations: [Sentry.feedbackIntegration()],
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
@@ -188,6 +200,10 @@ import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
   dsn: 'dsn',
+
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
 
   // Configure Session Replay
   replaysSessionSampleRate: 0.1,
@@ -498,6 +514,10 @@ import * as Sentry from '@sentry/react-native';
 Sentry.init({
   dsn: 'https://sentry.io/123',
 
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
+
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: __DEV__,
 });
@@ -546,6 +566,10 @@ import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
   dsn: 'https://sentry.io/123',
+
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: __DEV__,


### PR DESCRIPTION
- adds `sendDefaultPii=true` to Mobile wizards:
  - Android (no tests)
  - Apple (unit tests)
  - Flutter (unit + e2e tests)
  - RN (unit + e2e tests)

Note: as mentioned in https://github.com/getsentry/sentry-wizard/issues/955#issuecomment-2847282838 we set the default value of `true` and link to the relevant docs page

fixes https://github.com/getsentry/sentry-wizard/issues/790
fixes https://github.com/getsentry/sentry-wizard/issues/956
(Flutter + RN don't have GH issues for this)