### PR TITLE
fix(apple): Use project-relative path to gitignore file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix(apple): add support for synchronized Xcode folders ([#904](https://github.com/getsentry/sentry-wizard/pull/904))
 - feat(react-native): Add Feedback Widget step ([#969](https://github.com/getsentry/sentry-wizard/pull/969))
 - feat(react-native): More granular error reporting for RN Wizard ([#861](https://github.com/getsentry/sentry-wizard/pull/861))
+- fix(apple): Use project-relative path to gitignore file ([#982](https://github.com/getsentry/sentry-wizard/pull/982))
 
 ## 4.8.0
 

--- a/lib/Helper/SentryCli.ts
+++ b/lib/Helper/SentryCli.ts
@@ -1,15 +1,8 @@
-import * as fs from 'node:fs';
 import type { Answers } from 'inquirer';
 import * as path from 'node:path';
 
 import type { Args } from '../Constants';
-import { addToGitignore } from './Git';
-import { green, l, nl, red } from './Logging';
 import { Config } from '../Types';
-
-const SENTRYCLIRC_FILENAME = '.sentryclirc';
-const GITIGNORE_FILENAME = '.gitignore';
-const PROPERTIES_FILENAME = 'sentry.properties';
 
 export interface SentryCliProps {
   'defaults/url': string;
@@ -93,71 +86,5 @@ export class SentryCli {
       dumpedSections.push(section);
     }
     return dumpedSections.join('\n');
-  }
-
-  /**
-   * Creates `.sentryclirc` and `sentry.properties` files with the CLI properties
-   * obtained from the user answers (or from logging into Sentry).
-   * The `.sentryclirc` only contains the auth token and will be added to the
-   * user's `.gitignore` file. The properties file contains the rest of the
-   * properties (org, project, etc.).
-   *
-   * @param sentryCli instance of the Sentry CLI
-   * @param cliProps the properties to write to the files
-   */
-  public async createSentryCliConfig(cliProps: SentryCliProps): Promise<void> {
-    const { 'auth/token': authToken, ...cliPropsToWrite } = cliProps;
-
-    /**
-     * To not commit the auth token to the VCS, instead of adding it to the
-     * properties file (like the rest of props), it's added to the Sentry CLI
-     * config, which is added to the gitignore. This way makes the properties
-     * file safe to commit without exposing any auth tokens.
-     */
-    if (authToken) {
-      try {
-        await fs.promises.appendFile(
-          SENTRYCLIRC_FILENAME,
-          this.dumpConfig({ auth: { 'auth/token': authToken } }),
-        );
-        green(`✓ Successfully added the auth token to ${SENTRYCLIRC_FILENAME}`);
-      } catch {
-        red(
-          `⚠ Could not add the auth token to ${SENTRYCLIRC_FILENAME}, ` +
-            `please add it to identify your user account:\n${authToken}`,
-        );
-        nl();
-      }
-    } else {
-      red(
-        `⚠ Did not find an auth token, please add your token to ${SENTRYCLIRC_FILENAME}`,
-      );
-      l(
-        'To generate an auth token, visit https://sentry.io/settings/account/api/auth-tokens/',
-      );
-      l(
-        'To learn how to configure Sentry CLI, visit ' +
-          'https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-sentry-cli',
-      );
-    }
-
-    await addToGitignore(
-      SENTRYCLIRC_FILENAME,
-      `⚠ Could not add ${SENTRYCLIRC_FILENAME} to ${GITIGNORE_FILENAME}, please add it to not commit your auth key.`,
-    );
-
-    try {
-      await fs.promises.writeFile(
-        `./${PROPERTIES_FILENAME}`,
-        this.dumpProperties(cliPropsToWrite),
-      );
-      green('✓ Successfully created sentry.properties');
-    } catch {
-      red(`⚠ Could not add org and project data to ${PROPERTIES_FILENAME}`);
-      l(
-        'See docs for a manual setup: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-sentry-cli',
-      );
-    }
-    nl();
   }
 }

--- a/src/utils/sentrycli-utils.ts
+++ b/src/utils/sentrycli-utils.ts
@@ -1,3 +1,6 @@
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -12,12 +15,21 @@ export function createSentryCLIRC(
   const rcPath = path.join(directory, '.sentryclirc');
   fs.writeFileSync(rcPath, '[auth]\ntoken=' + params.auth_token);
 
-  if (!fs.existsSync('.gitignore')) {
-    fs.writeFileSync('.gitignore', '.sentryclirc');
+  const gitignorePath = path.join(directory, '.gitignore');
+  if (!fs.existsSync(gitignorePath)) {
+    clack.log.info(
+      `Creating .gitignore file at path: ${chalk.cyan(gitignorePath)}`,
+    );
+    fs.writeFileSync(gitignorePath, '.sentryclirc');
   } else {
-    const gitIgnore = fs.readFileSync('.gitignore').toString();
+    const gitIgnore = fs.readFileSync(gitignorePath).toString();
     if (!gitIgnore.includes('.sentryclirc')) {
-      fs.appendFileSync('.gitignore', '\n.sentryclirc');
+      clack.log.info(
+        `Appending .sentryclirc to .gitignore file at path: ${chalk.cyan(
+          gitignorePath,
+        )}`,
+      );
+      fs.appendFileSync(gitignorePath, '\n.sentryclirc');
     }
   }
 }

--- a/src/utils/sentrycli-utils.ts
+++ b/src/utils/sentrycli-utils.ts
@@ -29,7 +29,7 @@ export function createSentryCLIRC(
           gitignorePath,
         )}`,
       );
-      fs.appendFileSync(gitignorePath, '\n.sentryclirc');
+      fs.appendFileSync(gitignorePath, '\n.sentryclirc\n');
     }
   }
 }

--- a/test/apple/configure-sentry-cli.test.ts
+++ b/test/apple/configure-sentry-cli.test.ts
@@ -1,0 +1,131 @@
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import * as clack from '@clack/prompts';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { configureSentryCLI } from '../../src/apple/configure-sentry-cli';
+
+vi.mock('@clack/prompts', async () => ({
+  __esModule: true,
+  ...(await vi.importActual<typeof clack>('@clack/prompts')),
+}));
+
+describe('configureSentryCLI', () => {
+  const authToken = 'test';
+  let projectDir: string;
+  let rcPath: string;
+  let gitignorePath: string;
+
+  beforeEach(() => {
+    beforeEach(() => {
+      vi.spyOn(clack.log, 'warn').mockImplementation(() => {
+        /* empty */
+      });
+      vi.spyOn(clack, 'select').mockResolvedValue(undefined);
+    });
+
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'project'));
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    rcPath = path.join(projectDir, '.sentryclirc');
+    gitignorePath = path.join(projectDir, '.gitignore');
+  });
+
+  describe('.sentryclirc file not exists', () => {
+    it('should create the .sentryclirc file', () => {
+      // -- Arrange --
+      // Pre-condition is that the .sentryclirc file does not exist
+      expect(fs.existsSync(rcPath)).toBe(false);
+
+      // -- Act --
+      configureSentryCLI({ projectDir, authToken });
+
+      // -- Assert --
+      expect(fs.existsSync(rcPath)).toBe(true);
+      expect(fs.readFileSync(rcPath, 'utf8')).toContain(`token=test`);
+    });
+  });
+
+  describe('.sentryclirc file exists', () => {
+    it('should update the .sentryclirc file', () => {
+      // -- Arrange --
+      // Pre-condition is that the .sentryclirc file exists
+      fs.writeFileSync(rcPath, `token=old`);
+
+      // -- Act --
+      configureSentryCLI({ projectDir, authToken });
+
+      // -- Assert --
+      expect(fs.readFileSync(rcPath, 'utf8')).toContain(`token=${authToken}`);
+    });
+  });
+
+  describe('.gitignore file not exists', () => {
+    it('should create the .gitignore file', () => {
+      // -- Arrange --
+      // Pre-condition is that the .gitignore file does not exist
+      expect(fs.existsSync(gitignorePath)).toBe(false);
+
+      // -- Act --
+      configureSentryCLI({ projectDir, authToken });
+
+      // -- Assert --
+      expect(fs.existsSync(gitignorePath)).toBe(true);
+      expect(fs.readFileSync(gitignorePath, 'utf8')).toContain('.sentryclirc');
+    });
+  });
+
+  describe('.gitignore file exists', () => {
+    describe("contains '.sentryclirc'", () => {
+      it('should not append the .sentryclirc file to the .gitignore file', () => {
+        // -- Arrange --
+        // Pre-condition is that the .gitignore file exists and contains '.sentryclirc'
+        fs.writeFileSync(
+          gitignorePath,
+          `
+# Xcode
+xcuserdata/
+
+# Sentry
+.sentryclirc
+`,
+        );
+
+        // -- Act --
+        configureSentryCLI({ projectDir, authToken });
+
+        // -- Assert --
+        expect(fs.readFileSync(gitignorePath, 'utf8')).toContain(
+          '.sentryclirc',
+        );
+      });
+    });
+
+    describe("does not contain '.sentryclirc'", () => {
+      it('should append the .sentryclirc file to the .gitignore file', () => {
+        // -- Arrange --
+        // Pre-condition is that the .gitignore file exists and does not contain '.sentryclirc'
+        fs.writeFileSync(
+          gitignorePath,
+          `
+# Xcode
+xcuserdata/
+`,
+        );
+
+        // -- Act --
+        configureSentryCLI({ projectDir, authToken });
+
+        // -- Assert --
+        expect(fs.readFileSync(gitignorePath, 'utf8')).toBe(
+          `
+# Xcode
+xcuserdata/
+.sentryclirc
+`,
+        );
+      });
+    });
+  });
+});

--- a/test/apple/configure-sentry-cli.test.ts
+++ b/test/apple/configure-sentry-cli.test.ts
@@ -8,7 +8,7 @@ import { configureSentryCLI } from '../../src/apple/configure-sentry-cli';
 
 vi.mock('@clack/prompts', async () => ({
   __esModule: true,
-  ...(await vi.importActual<typeof clack>('@clack/prompts')),
+  default: await vi.importActual<typeof clack>('@clack/prompts'),
 }));
 
 describe('configureSentryCLI', () => {
@@ -122,6 +122,7 @@ xcuserdata/
           `
 # Xcode
 xcuserdata/
+
 .sentryclirc
 `,
         );


### PR DESCRIPTION
- Removes unused code to create `.sentryclirc`
- Fixes the path to the `.gitignore` to ignore `sentryclirc`