### PR TITLE
test(react-native): Add E2E Tests verifying the project builds correctly

### DIFF
--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -6,6 +6,7 @@ import {
   cleanupGit,
   checkFileContents,
   checkIfReactNativeBundles,
+  checkIfReactNativeReleaseBuilds,
   revertLocalChanges,
   startWizardInstance
 } from '../utils';
@@ -183,5 +184,10 @@ defaults.url=https://sentry.io/`,
   test('ios project is bundled correctly', async () => {
     const bundled = await checkIfReactNativeBundles(projectDir, 'ios');
     expect(bundled).toBe(true);
+  });
+
+  test('android project builds correctly', async () => {
+    const builds = await checkIfReactNativeReleaseBuilds(projectDir, 'android', true);
+    expect(builds).toBe(true);
   });
 });


### PR DESCRIPTION
**Based on: https://github.com/getsentry/sentry-wizard/pull/992**

Fixes https://github.com/getsentry/sentry-wizard/issues/948

## Description

Adds E2E tests verifying React Native and Expo projects build correctly 

### To test locally run:
- `yarn test:e2e React-Native`
- `yarn test:e2e Expo`

#skip-changelog