### PR TITLE
fix: Add missing SDK packages to list of known SDKs

### DIFF
--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -27,6 +27,7 @@ const SENTRY_SDK_PACKAGE_NAMES = [
   '@sentry/remix',
   '@sentry/solidstart',
   '@sentry/sveltekit',
+  '@sentry/tanstackstart-react',
 
   // Framework SDKs
   '@sentry/angular',

--- a/src/sourcemaps/utils/sdk-version.ts
+++ b/src/sourcemaps/utils/sdk-version.ts
@@ -23,6 +23,7 @@ const SENTRY_SDK_PACKAGE_NAMES = [
   '@sentry/gatsby',
   '@sentry/nextjs',
   '@sentry/nuxt',
+  '@sentry/react-router',
   '@sentry/remix',
   '@sentry/solidstart',
   '@sentry/sveltekit',
@@ -43,6 +44,7 @@ const SENTRY_SDK_PACKAGE_NAMES = [
 
   // Base SDKs
   '@sentry/browser',
+  '@sentry/cloudflare',
   '@sentry/node',
   '@sentry/deno',
 ];


### PR DESCRIPTION
This PR adds a couple of packages to our list of known official Sentry SDK packages. Realized while working on #824 that the cloudflare SDK as well as some others were missing and hence the sourcemaps wizard incorrectly flagged that no sentry SDK was installed 

#skip-changelog