### PR TITLE
feat(sourcemaps): Add Cloudflare Wrangler Tool Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(nextjs): Add template for generateMetadata in App router for next@14 ([#1003](https://github.com/getsentry/sentry-wizard/pull/1003))
+- feat(sourcemaps): Add Cloudflare Wrangler Tool Flow ([#999](https://github.com/getsentry/sentry-wizard/pull/999))
 
 ## 5.0.0
 

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -131,7 +131,11 @@ You can turn this off by running the wizard with the '--disable-telemetry' flag.
     setupCI(selectedTool, authToken, options.comingFrom),
   );
 
-  await runPrettierIfInstalled({ cwd: process.cwd() });
+  if (!preSelectedTool) {
+    // running prettier is only necessary if the source maps wizard is the main flow
+    // skip it, if it's called from another wizard (e.g. angular)
+    await runPrettierIfInstalled({ cwd: process.cwd() });
+  }
 
   if (!preSelectedTool) {
     await traceStep('outro', () =>

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -120,21 +120,12 @@ export function getSentryCliCommand(
   options: SourceMapUploadToolConfigurationOptions & { outDir: string },
 ) {
   const sentryCliOptions = options.selfHosted ? ` --url ${options.url}` : '';
-  
+  const orgAndProjectArgs = `--org=${options.orgSlug} --project=${options.projectSlug}`;
+
   return [
     '_SENTRY_RELEASE=$(sentry-cli releases propose-version)',
-    `sentry-cli${
-      sentryCliOptions
-    } releases new $_SENTRY_RELEASE --org=${options.orgSlug} --project=${
-      options.projectSlug
-    }`,
-    `sentry-cli${
-      sentryCliOptions
-    } sourcemaps upload --org=${options.orgSlug} --project=${
-      options.projectSlug
-    } --release=$_SENTRY_RELEASE --strip-prefix '${options.outDir}/..' ${
-      options.outDir
-    }`,
+    `sentry-cli${sentryCliOptions} releases new $_SENTRY_RELEASE ${orgAndProjectArgs}`,
+    `sentry-cli${sentryCliOptions} sourcemaps upload ${orgAndProjectArgs} --release=$_SENTRY_RELEASE --strip-prefix '${options.outDir}/..' ${options.outDir}`,
   ].join(' && ');
 }
 

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -119,15 +119,17 @@ async function createAndAddSentrySourcemapsScript(
 export function getSentryCliCommand(
   options: SourceMapUploadToolConfigurationOptions & { outDir: string },
 ) {
+  const sentryCliOptions = options.selfHosted ? ` --url ${options.url}` : '';
+  
   return [
     '_SENTRY_RELEASE=$(sentry-cli releases propose-version)',
     `sentry-cli${
-      options.selfHosted ? ` --url ${options.url}` : ''
+      sentryCliOptions
     } releases new $_SENTRY_RELEASE --org=${options.orgSlug} --project=${
       options.projectSlug
     }`,
     `sentry-cli${
-      options.selfHosted ? ` --url ${options.url}` : ''
+      sentryCliOptions
     } sourcemaps upload --org=${options.orgSlug} --project=${
       options.projectSlug
     } --release=$_SENTRY_RELEASE --strip-prefix '${options.outDir}/..' ${

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -1,0 +1,359 @@
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import * as clack from '@clack/prompts';
+import chalk from 'chalk';
+import {
+  abortIfCancelled,
+  addSentryCliConfig,
+  getPackageDotJson,
+  getPackageManager,
+  installPackage,
+  showCopyPasteInstructions,
+} from '../../utils/clack';
+import { hasPackageInstalled } from '../../utils/package-json';
+import { NPM } from '../../utils/package-manager';
+import type { SourceMapUploadToolConfigurationOptions } from './types';
+import path from 'path';
+import fs from 'fs';
+const SENTRY_NPM_SCRIPT_NAME = 'sentry:sourcemaps';
+
+/**
+ * only exported for testing
+ */
+export const DIST_DIR = path.join('.', 'dist');
+
+export async function configureWrangler(
+  options: SourceMapUploadToolConfigurationOptions,
+) {
+  await installPackage({
+    packageName: '@sentry/cli',
+    alreadyInstalled: hasPackageInstalled(
+      '@sentry/cli',
+      await getPackageDotJson(),
+    ),
+    devDependency: true,
+  });
+
+  if (!(await askContinueIfHasSentrySourcemapsScript())) {
+    return;
+  }
+
+  const deployCommand = await getDeployCommand();
+  if (!deployCommand) {
+    return;
+  }
+
+  const outDir = await getWranglerOutDir(deployCommand);
+
+  await createAndAddSentrySourcemapsScript({ ...options, outDir });
+
+  await writePostDeployCommand(deployCommand);
+
+  await modifyDeployCommand(deployCommand, outDir);
+
+  await addSentryCliConfig({ authToken: options.authToken });
+}
+
+async function createAndAddSentrySourcemapsScript(
+  options: SourceMapUploadToolConfigurationOptions & { outDir: string },
+) {
+  const pkgJson = await getPackageDotJson();
+  pkgJson.scripts = pkgJson.scripts ?? {};
+  pkgJson.scripts[SENTRY_NPM_SCRIPT_NAME] = getSentryCliCommand(options);
+
+  await fs.promises.writeFile(
+    path.join(process.cwd(), 'package.json'),
+    JSON.stringify(pkgJson, null, 2),
+  );
+
+  clack.log.success(
+    `Added a ${chalk.cyan(SENTRY_NPM_SCRIPT_NAME)} script to your ${chalk.cyan(
+      'package.json',
+    )}.`,
+  );
+}
+
+/**
+ * only exported for testing
+ */
+export function getSentryCliCommand(
+  options: SourceMapUploadToolConfigurationOptions & { outDir: string },
+) {
+  return [
+    '_SENTRY_RELEASE=$(sentry-cli releases propose-version)',
+    `sentry-cli${
+      options.selfHosted ? ` --url ${options.url}` : ''
+    } releases new $_SENTRY_RELEASE --org=${options.orgSlug} --project=${
+      options.projectSlug
+    }`,
+    `sentry-cli${
+      options.selfHosted ? ` --url ${options.url}` : ''
+    } sourcemaps upload --org=${options.orgSlug} --project=${
+      options.projectSlug
+    } --release=$_SENTRY_RELEASE --strip-prefix '${options.outDir}/..' ${
+      options.outDir
+    }`,
+  ].join(' && ');
+}
+
+async function askContinueIfHasSentrySourcemapsScript(): Promise<boolean> {
+  const pkgJson = await getPackageDotJson();
+
+  pkgJson.scripts = pkgJson.scripts ?? {};
+
+  if (pkgJson.scripts[SENTRY_NPM_SCRIPT_NAME]) {
+    clack.log.warn(
+      `The ${chalk.cyan(
+        SENTRY_NPM_SCRIPT_NAME,
+      )} script already exists in your ${chalk.cyan('package.json')}.`,
+    );
+
+    const overwrite = await abortIfCancelled(
+      clack.select({
+        message: 'Do you want to overwrite it?',
+        options: [
+          { label: 'Yes', value: true, hint: 'Overwrite the existing script' },
+          { label: 'No', value: false, hint: 'This will exit the wizard' },
+        ],
+      }),
+    );
+
+    if (!overwrite) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function getDeployCommand(): Promise<string | undefined> {
+  const pkgJson = await getPackageDotJson();
+  const scripts = pkgJson.scripts ?? {};
+
+  let deployCommand = Object.keys(scripts).find((key) =>
+    /wrangler\s+deploy/.test(scripts[key] ?? ''),
+  );
+
+  const packageManager = await getPackageManager(NPM);
+  const isDeployCommand =
+    !!deployCommand &&
+    (await abortIfCancelled(
+      clack.confirm({
+        message: `Is ${chalk.cyan(
+          `${packageManager.runScriptCommand} ${deployCommand}`,
+        )} your build and deploy command?`,
+      }),
+    ));
+
+  if (Object.keys(scripts).length && (!deployCommand || !isDeployCommand)) {
+    deployCommand = await abortIfCancelled(
+      clack.select({
+        message: `Which ${packageManager.name} command in your ${chalk.cyan(
+          'package.json',
+        )} builds your worker and deploys it?`,
+        options: Object.keys(scripts)
+          .map((script) => ({
+            label: script,
+            value: script,
+          }))
+          .concat({ label: 'None of the above', value: 'none' }),
+      }),
+    );
+  }
+
+  if (!deployCommand || deployCommand === 'none') {
+    clack.log.warn(
+      `We can only add the ${chalk.cyan(
+        SENTRY_NPM_SCRIPT_NAME,
+      )} script to another \`script\` in your ${chalk.cyan('package.json')}.
+Please add it manually to your prod build command.`,
+    );
+    return undefined;
+  }
+
+  return deployCommand;
+}
+
+async function writePostDeployCommand(deployCommand: string): Promise<void> {
+  const pkgJson = await getPackageDotJson();
+  const packageManager = await getPackageManager(NPM);
+  pkgJson.scripts = pkgJson.scripts ?? {};
+  pkgJson.scripts[
+    `post${deployCommand}`
+  ] = `${packageManager.runScriptCommand} ${SENTRY_NPM_SCRIPT_NAME}`;
+
+  await fs.promises.writeFile(
+    path.join(process.cwd(), 'package.json'),
+    JSON.stringify(pkgJson, null, 2),
+  );
+
+  clack.log.success(
+    `Added a ${chalk.cyan(`post${deployCommand}`)} script to your ${chalk.cyan(
+      'package.json',
+    )}.`,
+  );
+}
+
+async function modifyDeployCommand(
+  deployCommand: string,
+  outDir: string,
+): Promise<void> {
+  const pkgJson = await getPackageDotJson();
+  pkgJson.scripts = pkgJson.scripts ?? {};
+  const oldDeployCommand = pkgJson.scripts[deployCommand];
+
+  if (!oldDeployCommand) {
+    clack.log.warn(
+      `The ${chalk.cyan(
+        deployCommand,
+      )} script doesn't seem to be part of your package.json scripts anymore. Cannot modify it. Please modify it manually:`,
+    );
+
+    await showCopyPasteInstructions({
+      codeSnippet: `wrangler deploy --outdir ${outDir} --var SENTRY_RELEASE:$(sentry-cli releases propose-version) --upload-source-maps`,
+      filename: 'package.json',
+    });
+
+    return;
+  }
+
+  const newDeployCommand = safeInsertArgsToWranglerDeployCommand(
+    oldDeployCommand,
+    outDir,
+  );
+
+  if (!newDeployCommand) {
+    clack.log.warn(
+      `The ${chalk.cyan(
+        deployCommand,
+      )} script doesn't seem to be a valid ${chalk.cyan(
+        'wrangler deploy',
+      )} command. Cannot modify it. Please modify it manually:`,
+    );
+
+    await showCopyPasteInstructions({
+      codeSnippet: oldDeployCommand,
+      filename: 'package.json',
+    });
+
+    return;
+  }
+
+  pkgJson.scripts[deployCommand] = newDeployCommand;
+
+  await fs.promises.writeFile(
+    path.join(process.cwd(), 'package.json'),
+    JSON.stringify(pkgJson, null, 2),
+  );
+
+  clack.log.success(
+    `Modified your ${chalk.cyan(
+      deployCommand,
+    )} script to enable uploading source maps.`,
+  );
+}
+
+/**
+ * Takes care of inserting the necessary arguments into the deploy command.
+ * Ensures that existing arguments and values are kept and that the
+ * wrangler deploy command is valid.
+ *
+ * only exported for testing
+ */
+export function safeInsertArgsToWranglerDeployCommand(
+  deployCommand: string,
+  outDir: string,
+): string | undefined {
+  const exisitingArgs = deployCommand
+    .split(' ')
+    .map((arg) => arg.trim())
+    .filter(Boolean);
+  const newArgs = [];
+
+  if (!exisitingArgs.find((arg) => arg.startsWith('--outdir'))) {
+    newArgs.push('--outdir', outDir);
+  }
+
+  // Adding --upload-source-maps saves us from having to
+  // modify the `wrangler.toml` or `wrangler.jsonc` files.
+  // Not ideal because this forces source maps to be uploaded
+  // but we'll live with it for now.
+  if (!exisitingArgs.find((arg) => arg.startsWith('--upload-source-maps'))) {
+    newArgs.push('--upload-source-maps');
+  }
+
+  // This is how we inject the SENTRY_RELEASE variable,
+  // which is picked up by the CloudFlare SDK.
+  // multiple --var arguments are allowed, so no need to check for existing --var arguments.
+  newArgs.push(
+    '--var',
+    'SENTRY_RELEASE:$(sentry-cli releases propose-version)',
+  );
+
+  // Find the index of 'deploy' command:
+  // - ensure that it's preceded by 'wrangler'
+  // - global args could be between 'wrangler' and 'deploy'
+  const deployIndex = exisitingArgs.findIndex((arg, i) => {
+    if (arg !== 'deploy') return false;
+    if (i === 0) return false;
+
+    // Look backwards from deploy to find wrangler, stopping at any delimiter
+    for (let j = i - 1; j >= 0; j--) {
+      const prevArg = exisitingArgs[j];
+      if (prevArg === '&&' || prevArg.endsWith(';') || prevArg.startsWith(';'))
+        return false;
+      if (prevArg === 'wrangler') return true;
+    }
+    return false;
+  });
+
+  if (deployIndex === -1) {
+    return undefined;
+  }
+
+  // insert the newArgs directly after the deploy command
+  exisitingArgs.splice(deployIndex + 1, 0, ...newArgs);
+
+  return exisitingArgs.join(' ');
+}
+
+/**
+ * Look up an already specified --outdir argument and return it if found.
+ * Otherwise, we defined `dist` as the default outdir.
+ */
+async function getWranglerOutDir(deployScript: string): Promise<string> {
+  const pkgJson = await getPackageDotJson();
+  const scripts = pkgJson.scripts ?? {};
+  const deployCommand = scripts[deployScript];
+
+  if (!deployCommand) {
+    return DIST_DIR;
+  }
+
+  return findOutDir(deployCommand);
+}
+
+/**
+ * only exported for testing
+ */
+export function findOutDir(deployCommand: string): string {
+  const args = deployCommand.split(' ').map((arg) => arg.trim());
+
+  const outDirArgIndex = args.findIndex((arg) => arg.startsWith('--outdir'));
+  if (outDirArgIndex === -1) {
+    return DIST_DIR;
+  }
+
+  const outDirArg = args[outDirArgIndex];
+
+  if (outDirArg.startsWith('--outdir=')) {
+    return outDirArg.split('=')[1].trim().replace(/['"]/g, '');
+  }
+
+  const maybeOutDir = args[outDirArgIndex + 1];
+
+  if (maybeOutDir && !maybeOutDir.startsWith('--')) {
+    return maybeOutDir.replace(/['"]/g, '');
+  }
+
+  return DIST_DIR;
+}

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -395,7 +395,7 @@ export function findOutDir(deployCommand: string): string {
  * Exported for testing
  */
 export function getWranglerDeployCommand(deployCommand: string) {
-  const individualCommands = deployCommand.split(/&&|\|\||>>|>|<|>>|\||;/);
+  const individualCommands = deployCommand.split(/&&|\|\||>>|>|<|\||;/);
 
   const originalWranglerDeployCommand = individualCommands.find((cmd) => {
     const argv = cmd

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -138,7 +138,9 @@ async function askContinueIfHasSentrySourcemapsScript(): Promise<boolean> {
     clack.log.warn(
       `The ${chalk.cyan(
         SENTRY_NPM_SCRIPT_NAME,
-      )} script already exists in your ${chalk.cyan('package.json')}.`,
+      )} script already exists in your ${chalk.cyan('package.json')}.
+This likely means that you already ran this wizard once.
+If things don't work yet, try overwriting the script and continue with the wizard.`,
     );
 
     const overwrite = await abortIfCancelled(

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -122,10 +122,12 @@ export function getSentryCliCommand(
   const sentryCliOptions = options.selfHosted ? ` --url ${options.url}` : '';
   const orgAndProjectArgs = `--org=${options.orgSlug} --project=${options.projectSlug}`;
 
+  const stripPrefixPath = path.join(options.outDir, '..');
+
   return [
     '_SENTRY_RELEASE=$(sentry-cli releases propose-version)',
     `sentry-cli${sentryCliOptions} releases new $_SENTRY_RELEASE ${orgAndProjectArgs}`,
-    `sentry-cli${sentryCliOptions} sourcemaps upload ${orgAndProjectArgs} --release=$_SENTRY_RELEASE --strip-prefix '${options.outDir}/..' ${options.outDir}`,
+    `sentry-cli${sentryCliOptions} sourcemaps upload ${orgAndProjectArgs} --release=$_SENTRY_RELEASE --strip-prefix '${stripPrefixPath}' ${options.outDir}`,
   ].join(' && ');
 }
 
@@ -306,12 +308,12 @@ export function safeInsertArgsToWranglerDeployCommand(
     return undefined;
   }
 
-  const exisitingArgs = originalWranglerDeployCommand
+  const existingArgs = originalWranglerDeployCommand
     .split(' ')
     .map((arg) => arg.trim())
     .filter(Boolean);
 
-  const parsedArgs = yargs(hideBin(exisitingArgs)).parse();
+  const parsedArgs = yargs(hideBin(existingArgs)).parse();
 
   const newArgs = [];
 

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -122,7 +122,7 @@ export function getSentryCliCommand(
   const sentryCliOptions = options.selfHosted ? ` --url ${options.url}` : '';
   const orgAndProjectArgs = `--org=${options.orgSlug} --project=${options.projectSlug}`;
 
-  const stripPrefixPath = path.join(options.outDir, '..');
+  const stripPrefixPath = `${options.outDir}${path.sep}..`;
 
   return [
     '_SENTRY_RELEASE=$(sentry-cli releases propose-version)',

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -2,6 +2,7 @@
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import {
+  abort,
   abortIfCancelled,
   addSentryCliConfig,
   getPackageDotJson,
@@ -24,6 +25,42 @@ export const DIST_DIR = path.join('.', 'dist');
 export async function configureWrangler(
   options: SourceMapUploadToolConfigurationOptions,
 ) {
+  clack.note(
+    chalk.whiteBright(
+      `Configuring source maps upload with Cloudflare Wrangler requires the wizard to:
+- Modify your deploy command to access source maps
+- Set the SENTRY_RELEASE env var to identify source maps
+
+Note: This setup may need additional configuration. 
+We recommend using Vite to build your worker instead, for an easier and more reliable setup.
+
+Learn more about CloudFlare's Vite setup here:
+${chalk.underline(
+  chalk.cyan(
+    'https://developers.cloudflare.com/workers/vite-plugin/get-started/',
+  ),
+)}
+
+You can switch to Vite and re-run this wizard later. 
+Otherwise, let's proceed with the Wrangler setup.`,
+    ),
+    'Before we get started',
+  );
+
+  const proceed = await abortIfCancelled(
+    clack.confirm({
+      message: 'Do you want to proceed with the Wrangler setup?',
+    }),
+  );
+
+  if (!proceed) {
+    await abort(
+      'Got it! You can switch to Vite and re-run this wizard later.',
+      0,
+    );
+    return;
+  }
+
   await installPackage({
     packageName: '@sentry/cli',
     alreadyInstalled: hasPackageInstalled(

--- a/src/sourcemaps/utils/detect-tool.ts
+++ b/src/sourcemaps/utils/detect-tool.ts
@@ -12,6 +12,7 @@ export type SupportedTools =
   | 'angular'
   | 'nextjs'
   | 'remix'
+  | 'wrangler'
   | 'no-tool';
 
 // A map of package names pointing to the tool slug.
@@ -21,6 +22,7 @@ export type SupportedTools =
 export const TOOL_PACKAGE_MAP: Record<string, SupportedTools> = {
   '@angular/core': 'angular',
   'create-react-app': 'create-react-app',
+  wrangler: 'wrangler',
   webpack: 'webpack',
   vite: 'vite',
   esbuild: 'esbuild',

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -327,6 +327,8 @@ type InstallPackageOptions = {
   packageManager?: PackageManager;
   /** Add force install flag to command to skip install precondition fails */
   forceInstall?: boolean;
+  /** Install as a dev dependency (@default: false) */
+  devDependency?: boolean;
 };
 
 /**
@@ -342,6 +344,7 @@ export async function installPackage({
   packageNameDisplayLabel,
   packageManager,
   forceInstall = false,
+  devDependency = false,
 }: InstallPackageOptions): Promise<{ packageManager?: PackageManager }> {
   return traceStep('install-package', async () => {
     if (alreadyInstalled && askBeforeUpdating) {
@@ -372,6 +375,7 @@ export async function installPackage({
       await new Promise<void>((resolve, reject) => {
         const installArgs = [
           pkgManager.installCommand,
+          ...(devDependency ? ['-D'] : []),
           pkgManager.registry
             ? `${pkgManager.registry}:${packageName}`
             : packageName,

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -108,6 +108,12 @@ export const propertiesCliSetupConfig: Required<CliSetupConfig> = {
   },
 };
 
+/**
+ * Aborts the wizard and sets the Sentry transaction status to `cancelled` or `aborted`.
+ *
+ * @param message The message to display to the user.
+ * @param status The status to set on the Sentry transaction. Defaults to `1`.
+ */
 export async function abort(message?: string, status?: number): Promise<never> {
   clack.outro(message ?? 'Wizard setup cancelled.');
   const sentryHub = Sentry.getCurrentHub();

--- a/test/sourcemaps/tools/wrangler.test.ts
+++ b/test/sourcemaps/tools/wrangler.test.ts
@@ -1,0 +1,175 @@
+import {
+  DIST_DIR,
+  findOutDir,
+  getSentryCliCommand,
+  safeInsertArgsToWranglerDeployCommand,
+} from '../../../src/sourcemaps/tools/wrangler';
+import { describe, expect, it } from 'vitest';
+
+describe('getSentryCliCommand', () => {
+  it('returns correct command for SaaS', () => {
+    const command = getSentryCliCommand({
+      selfHosted: false,
+      orgSlug: 'myOrg',
+      projectSlug: 'myProject',
+      url: 'https://sentry.io',
+      authToken: '_ignore',
+      outDir: 'dist',
+    });
+
+    expect(command).toBe(
+      "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=myOrg --project=myProject && sentry-cli sourcemaps upload --org=myOrg --project=myProject --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
+    );
+  });
+
+  it('returns correct command for self-hosted', () => {
+    const command = getSentryCliCommand({
+      selfHosted: true,
+      orgSlug: 'myOrg',
+      projectSlug: 'myProject',
+      url: 'https://santry.io',
+      authToken: '_ignore',
+      outDir: 'someplace',
+    });
+
+    expect(command).toBe(
+      "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli --url https://santry.io releases new $_SENTRY_RELEASE --org=myOrg --project=myProject && sentry-cli --url https://santry.io sourcemaps upload --org=myOrg --project=myProject --release=$_SENTRY_RELEASE --strip-prefix 'someplace/..' someplace",
+    );
+  });
+});
+
+describe('safeInsertArgsToWranglerDeployCommand', () => {
+  it('correctly inserts args into default command', () => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      'wrangler deploy',
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      'wrangler deploy --outdir dist --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version)',
+    );
+  });
+
+  it.each([
+    '--outdir someplace',
+    '--outdir=someplace',
+    '--outdir="./someplace"',
+  ])('retains existing %s arg', (arg) => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      `wrangler deploy ${arg}`,
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      `wrangler deploy --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version) ${arg}`,
+    );
+  });
+
+  it.each([
+    '--upload-source-maps',
+    '--upload-source-maps=true',
+    '--upload-source-maps true',
+    '--upload-source-maps=false',
+    '--upload-source-maps false',
+  ])('retains existing %s arg', (arg) => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      `wrangler deploy ${arg}`,
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      `wrangler deploy --outdir dist --var SENTRY_RELEASE:$(sentry-cli releases propose-version) ${arg}`,
+    );
+  });
+
+  it('inserts args directly after "wrangler deploy" command', () => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      'precheck && wrangler  deploy --outdir dist --upload-source-maps --var SOMEVAR:someValue && postcheck',
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      'precheck && wrangler deploy --var SENTRY_RELEASE:$(sentry-cli releases propose-version) --outdir dist --upload-source-maps --var SOMEVAR:someValue && postcheck',
+    );
+  });
+
+  it('handles multiple wrangler commands', () => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      'wrangler whoami && wrangler deploy --outdir dist --upload-source-maps --var SOMEVAR:someValue && wrangler someothercommand',
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      'wrangler whoami && wrangler deploy --var SENTRY_RELEASE:$(sentry-cli releases propose-version) --outdir dist --upload-source-maps --var SOMEVAR:someValue && wrangler someothercommand',
+    );
+  });
+
+  it('handles wrangler deploy command with global args', () => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      'wrangler --version --env production deploy --outdir someplace',
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      'wrangler --version --env production deploy --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version) --outdir someplace',
+    );
+  });
+
+  it('handles multiple commands and wrangler deploy command with global args', () => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(
+      'notwrangler --version deploy && wrangler --version --env whoami && wrangler --version --env production deploy --outdir someplace',
+      'dist',
+    );
+
+    expect(newCommand).toBe(
+      'notwrangler --version deploy && wrangler --version --env whoami && wrangler --version --env production deploy --upload-source-maps --var SENTRY_RELEASE:$(sentry-cli releases propose-version) --outdir someplace',
+    );
+  });
+
+  it.each([
+    'notwrangler deploy',
+    'wrangler dev',
+    'wrangler dev && notwrangler deploy',
+    'wrangler dev ; notwrangler deploy',
+    'wrangler dev; notwrangler deploy',
+    'wrangler dev ;notwrangler deploy',
+    'wrangler --env dev dev && notwrangler deploy',
+    'some completely different command',
+  ])('returns undefined if deploy command is not found', (command) => {
+    const newCommand = safeInsertArgsToWranglerDeployCommand(command, 'dist');
+
+    expect(newCommand).toBeUndefined();
+  });
+});
+
+describe('findOutDir', () => {
+  it('returns dist dir if no outdir arg is found', () => {
+    const outDir = findOutDir('wrangler deploy');
+
+    expect(outDir).toBe(DIST_DIR);
+  });
+
+  it('returns outdir arg if it is found', () => {
+    const outDir = findOutDir('wrangler deploy --outdir someplace');
+
+    expect(outDir).toBe('someplace');
+  });
+
+  it('handles --outdir "./someplace"', () => {
+    const outDir = findOutDir('wrangler deploy --outdir "./someplace"');
+
+    expect(outDir).toBe('./someplace');
+  });
+
+  it('handles --outdir=someplace', () => {
+    const outDir = findOutDir('wrangler deploy --outdir=someplace');
+
+    expect(outDir).toBe('someplace');
+  });
+
+  it("handles --outdir='./someplace'", () => {
+    const outDir = findOutDir('wrangler deploy --outdir="./someplace"');
+
+    expect(outDir).toBe('./someplace');
+  });
+});


### PR DESCRIPTION
This PR adds a Cloudflare Wrangler tool flow to the source maps wizard. Because wrangler doesn't allow us to inject debug ids after build and before deployment, we have to resort to our release-based legacy upload strategy. 

Therefore, this setup flow needs to do the following things:
- install Sentry CLI
- modify the `wrangler deploy` npm script to
  - determine the release value from `sentry-cli releases propose-version`
  - access source maps by setting the `--outdir` arg
  - inject the `SENTRY_RELEASE` environment variable
  - add the `--upload-source-maps` arg so that we can guarantee that source maps are emitted into the outdir
- add a `sentry:sourcemaps` npm script that  
  - determines the release value from `sentry-cli releases propose-version`
  - creates a new release
  - uploads source maps for the new release
- add a `postdeploy` script that invokes the `sentry:sourcemaps` script
- create a `.sentryclirc` file and `.gitignore` it

Additionally, because of the release based stuff, I decided to show a note at the beginning that this setup is a bit limited and more complicated and we'd generally recommend using the CF Vite plugin + the `vite` sourcemaps wizard flow.

Example:

https://github.com/user-attachments/assets/aab09e40-fc44-43ec-85a4-3e919fad150a

(note in this video, the wizard is only permanently installed because that's the easiest way to run it locally)

I'll add an e2e test but probably in a different PR because I wanna try something out to simplify the e2e tests

closes #824 
