### PR TITLE
ci(security): exclude test directories from semgrep code scanning

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,6 @@
+:include .gitignore
+
+# test directories
+e2e-tests/
+test/
+**/__tests__/


### PR DESCRIPTION
#skip-changelog

This excludes the test directories from Semgrep's scanning.