### PR TITLE
feat(nextjs): deactivate error button when adblocker is detected in example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 - fix(nextjs): Update jsx/tsx snippets ([#1015](https://github.com/getsentry/sentry-wizard/pull/1015))
 - feat(nextjs): deactivate error button when adblocker is detected ([#1010](https://github.com/getsentry/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - fix(nextjs): Update jsx/tsx snippets ([#1015](https://github.com/getsentry/sentry-wizard/pull/1015))
-- feat(nextjs): deactivate error button when adblocker is detected ([#1010](https://github.com/getsentry/
+- feat(nextjs): deactivate error button when adblocker is detected ([#1010](https://github.com/getsentry/))
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Unreleased
-
 - fix(nextjs): Update jsx/tsx snippets ([#1015](https://github.com/getsentry/sentry-wizard/pull/1015))
+- feat(nextjs): deactivate error button when adblocker is detected ([#1010](https://github.com/getsentry/
 
 ## 5.1.0
 

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -273,46 +273,47 @@ export default function Page() {
 
         <p className="description">
           Click the button below, and view the sample error on the Sentry <a target="_blank" href="${issuesPageLink}">Issues Page</a>.
-          For more details about setting up Sentry, <a target="_blank" href="https://docs.sentry.io/platforms/javascript/guides/nextjs/">read our docs</a>.
+          For more details about setting up Sentry, <a target="_blank"
+           href="https://docs.sentry.io/platforms/javascript/guides/nextjs/">read our docs</a>.
         </p>
 
-        <button
-          type="button"
-          onClick={async () => {
-            await Sentry.startSpan({
-              name: 'Example Frontend Span',
-              op: 'test'
-            }, async () => {
-              const res = await fetch("/api/sentry-example-api");
-              if (!res.ok) {
-                setHasSentError(true);
-                throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
-              }
-            });
-          }}
-        >
-          <span>
-            Throw Sample Error
-          </span>
-        </button>
+        <div className="button-container">
+          <button
+            type="button"
+            onClick={async () => {
+              await Sentry.startSpan({
+                name: 'Example Frontend/Backend Span',
+                op: 'test'
+              }, async () => {
+                const res = await fetch("/api/sentry-example-api");
+                if (!res.ok) {
+                  setHasSentError(true);
+                }
+              });
+              throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
+            }}
+            disabled={!isConnected}
+          >
+            <span>
+              Throw Sample Error
+            </span>
+          </button>
+        </div>
 
         {hasSentError ? (
           <p className="success">
-            Sample error was sent to Sentry.
+            Error sent to Sentry.
           </p>
         ) : !isConnected ? (
           <div className="connectivity-error">
-            <p>The Sentry SDK is not able to reach Sentry right now - this may be due to an adblocker. For more information, see <a target="_blank" href="https://docs.sentry.io/platforms/javascript/guides/nextjs/troubleshooting/#the-sdk-is-not-sending-any-data">the troubleshooting guide</a>.</p>
+            <p>It looks like network requests to Sentry are being blocked, which will prevent errors from being captured. Try disabling your ad-blocker to complete the test.</p>
           </div>
         ) : (
           <div className="success_placeholder" />
         )}
 
         <div className="flex-spacer" />
-        
-        <p className="description">
-          Adblockers will prevent errors from being sent to Sentry.
-        </p>
+      
       </main>
 
       <style>{\`
@@ -379,6 +380,21 @@ export default function Page() {
           &:active > span {
             transform: translateY(0);
           }
+
+          &:disabled {
+            cursor: not-allowed;
+            background-color: #888;
+
+            & > span {
+              background-color: #AAA;
+              border-color: #888;
+              transform: translateY(-2px);
+            }
+
+            &:hover > span {
+              transform: translateY(-2px);
+            }
+          }
         }
 
         .description {
@@ -407,6 +423,16 @@ export default function Page() {
           color: #181423;
         }
 
+        .error {
+          padding: 12px 16px;
+          border-radius: 8px;
+          font-size: 20px;
+          line-height: 1;
+          background-color: #FF4444;
+          border: 1px solid #CC0000;
+          color: #FFFFFF;
+        }
+
         .success_placeholder {
           height: 46px;
         }
@@ -425,6 +451,11 @@ export default function Page() {
         .connectivity-error a {
           color: #FFFFFF;
           text-decoration: underline;
+        }
+
+        .button-container {
+          display: flex;
+          gap: 16px;
         }
       \`}</style>
     </div>

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -277,28 +277,26 @@ export default function Page() {
            href="https://docs.sentry.io/platforms/javascript/guides/nextjs/">read our docs</a>.
         </p>
 
-        <div className="button-container">
-          <button
-            type="button"
-            onClick={async () => {
-              await Sentry.startSpan({
-                name: 'Example Frontend/Backend Span',
-                op: 'test'
-              }, async () => {
-                const res = await fetch("/api/sentry-example-api");
-                if (!res.ok) {
-                  setHasSentError(true);
-                }
-              });
-              throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
-            }}
-            disabled={!isConnected}
-          >
-            <span>
-              Throw Sample Error
-            </span>
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={async () => {
+            await Sentry.startSpan({
+              name: 'Example Frontend/Backend Span',
+              op: 'test'
+            }, async () => {
+              const res = await fetch("/api/sentry-example-api");
+              if (!res.ok) {
+                setHasSentError(true);
+              }
+            });
+            throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
+          }}
+          disabled={!isConnected}
+        >
+          <span>
+            Throw Sample Error
+          </span>
+        </button>
 
         {hasSentError ? (
           <p className="success">
@@ -382,19 +380,14 @@ export default function Page() {
           }
 
           &:disabled {
-            cursor: not-allowed;
-            background-color: #888;
-
-            & > span {
-              background-color: #AAA;
-              border-color: #888;
-              transform: translateY(-2px);
-            }
-
-            &:hover > span {
-              transform: translateY(-2px);
-            }
-          }
+	            cursor: not-allowed;
+	            opacity: 0.6;
+	
+	            & > span {
+	              transform: translateY(0);
+	              border: none
+	            }
+	          }
         }
 
         .description {
@@ -423,16 +416,6 @@ export default function Page() {
           color: #181423;
         }
 
-        .error {
-          padding: 12px 16px;
-          border-radius: 8px;
-          font-size: 20px;
-          line-height: 1;
-          background-color: #FF4444;
-          border: 1px solid #CC0000;
-          color: #FFFFFF;
-        }
-
         .success_placeholder {
           height: 46px;
         }
@@ -451,11 +434,6 @@ export default function Page() {
         .connectivity-error a {
           color: #FFFFFF;
           text-decoration: underline;
-        }
-
-        .button-container {
-          display: flex;
-          gap: 16px;
         }
       \`}</style>
     </div>


### PR DESCRIPTION
- Current design is a bit confusing when there is the warning about not being able to connect to sentry, but when you press the button, you get a success message.
- Grey out the button if there is a connection issue and display a clearer warning about ad blockers.


Before:
![Screenshot 2025-06-18 at 15 24 23](https://github.com/user-attachments/assets/97665364-bde5-4c0c-bf50-5b983b90b7f6)

After:
![Screenshot 2025-07-02 at 10 20 37](https://github.com/user-attachments/assets/f2c50894-1858-4e39-8d7b-df91f32f10d9)

Closes TET-775