### PR TITLE
feat(remix): deactivate error button when adblocker is detected in example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(nextjs): Update jsx/tsx snippets ([#1015](https://github.com/getsentry/sentry-wizard/pull/1015))
 - feat(nextjs): deactivate error button when adblocker is detected ([#1010](https://github.com/getsentry/))
+- feat(remix): deactivate error button when adblocker is detected ([#1017](https://github.com/getsentry/))
 
 ## 5.1.0
 

--- a/src/remix/sdk-example.ts
+++ b/src/remix/sdk-example.ts
@@ -54,6 +54,13 @@ export function getSentryExamplePageContents(options: {
   return `import * as Sentry from "@sentry/remix";
 import { useState, useEffect } from "react";
 
+class SentryExampleFrontendError extends Error {
+  constructor(message${options.isTS ? ': string | undefined' : ''}) {
+    super(message);
+    this.name = "SentryExampleFrontendError";
+  }
+}
+
 export const meta = () => {
   return [
     { title: "sentry-example-page" },
@@ -98,10 +105,11 @@ export default function SentryExamplePage() {
               const res = await fetch("/api/sentry-example-api");
               if (!res.ok) {
                 setHasSentError(true);
-                throw new Error("Sentry Example Frontend Error");
               }
             });
+            throw new SentryExampleFrontendError("This error is raised on the frontend of the example page.");
           }}
+          disabled={!isConnected}
         >
           <span>
             Throw Sample Error
@@ -114,16 +122,13 @@ export default function SentryExamplePage() {
           </p>
         ) : !isConnected ? (
           <div className="connectivity-error">
-            <p>The Sentry SDK is not able to reach Sentry right now - this may be due to an adblocker. For more information, see <a target="_blank" rel="noreferrer" href="https://docs.sentry.io/platforms/javascript/guides/remix/troubleshooting/#the-sdk-is-not-sending-any-data">the troubleshooting guide</a>.</p>
+            <p>It looks like network requests to Sentry are being blocked, which will prevent errors from being captured. Try disabling your ad-blocker to complete the test.</p>
           </div>
         ) : (
           <div className="success_placeholder" />
         )}
 
         <div className="flex-spacer" />
-        <p className="description">
-          Adblockers will prevent errors from being sent to Sentry.
-        </p>
       </main>
 
       {/* Not for production use! We're just saving you from having to delete an extra CSS file ;) */}
@@ -195,6 +200,16 @@ const styles = \`
 
     &:active > span {
       transform: translateY(0);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+
+      & > span {
+        transform: translateY(0);
+        border: none;
+      }
     }
   }
 


### PR DESCRIPTION
Successful connection:
![Screenshot 2025-07-02 at 13 01 51](https://github.com/user-attachments/assets/0767bf9c-2acb-4e3c-be04-c13017a75ea1)


Blocked Connection:
![Screenshot 2025-07-02 at 13 01 42](https://github.com/user-attachments/assets/b03a276d-def7-4109-9f24-284278bd7735)

Closes TET-777