### PR TITLE
feat: Introduce run build command and prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Introduce run build command and prompts in soucemaps wizard ([#1024](https://github.com/getsentry/sentry-wizard/pull/1024))
+- Introduce run build command and prompts in sourcemaps wizard ([#1024](https://github.com/getsentry/sentry-wizard/pull/1024))
 - Add a default build path for create-react-app in soucemaps wizard ([#1025](https://github.com/getsentry/sentry-wizard/pull/1025))
 
 ## 5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Introduce run build command and prompts in sourcemaps wizard ([#1024](https://github.com/getsentry/sentry-wizard/pull/1024))
-- Add a default build path for create-react-app in soucemaps wizard ([#1025](https://github.com/getsentry/sentry-wizard/pull/1025))
+- feat: Introduce run build command and prompts in sourcemaps wizard ([#1024](https://github.com/getsentry/sentry-wizard/pull/1024))
+- feat: Add a default build path for create-react-app in soucemaps wizard ([#1025](https://github.com/getsentry/sentry-wizard/pull/1025))
 
 ## 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Introduce run build command and prompts in soucemaps wizard ([#1024](https://github.com/getsentry/sentry-wizard/pull/1024))
+
 ## 5.3.0
 
 - fix(react-native): Avoid importing `isPlainObject` from `@sentry/utils` ([#1023](https://github.com/getsentry/sentry-wizard/pull/1023))

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -125,7 +125,7 @@ async function runWizardOnAngularProject(
   );
 
   const optionalArtifactsNotFoundPromise = wizardInstance.waitForOutput(
-    "We couldn't find artifacts",
+    "We couldn't find build artifacts at",
     {
       optional: true,
       timeout: 5000,
@@ -139,6 +139,12 @@ async function runWizardOnAngularProject(
     await optionalArtifactsNotFoundPromise;
 
   if (optionalArtifactsNotFoundPrompted) {
+    // The wizard now presents options when artifacts aren't found:
+    // - "Let the wizard run the build command"
+    // - "Enter a different path manually"
+    // - "Proceed anyway — I believe the path is correct"
+    // We want to select "Proceed anyway" (third option)
+    wizardInstance.sendStdin(KEYS.DOWN);
     wizardInstance.sendStdin(KEYS.DOWN);
     wizardInstance.sendStdin(KEYS.ENTER);
   }

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -124,7 +124,7 @@ async function runWizardOnAngularProject(
   );
 
   const optionalArtifactsNotFoundPromise = wizardInstance.waitForOutput(
-    "We couldn't find artifacts",
+    "We couldn't find build artifacts at",
     {
       optional: true,
       timeout: 5000,
@@ -138,6 +138,12 @@ async function runWizardOnAngularProject(
     await optionalArtifactsNotFoundPromise;
 
   if (optionalArtifactsNotFoundPrompted) {
+    // The wizard now presents options when artifacts aren't found:
+    // - "Let the wizard run the build command"
+    // - "Enter a different path manually"
+    // - "Proceed anyway — I believe the path is correct"
+    // We want to select "Proceed anyway" (third option)
+    wizardInstance.sendStdin(KEYS.DOWN);
     wizardInstance.sendStdin(KEYS.DOWN);
     wizardInstance.sendStdin(KEYS.ENTER);
   }

--- a/src/sourcemaps/sourcemaps-wizard.ts
+++ b/src/sourcemaps/sourcemaps-wizard.ts
@@ -234,7 +234,10 @@ async function startToolSetupFlow(
       await configureSentryCLI(options, configureTscSourcemapGenerationFlow);
       break;
     case 'create-react-app':
-      await configureSentryCLI(options, configureCRASourcemapGenerationFlow);
+      await configureSentryCLI(
+        { ...options, defaultArtifactPath: `.${sep}build` },
+        configureCRASourcemapGenerationFlow,
+      );
       break;
     case 'wrangler':
       await configureWrangler(options);

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -11,7 +11,7 @@ import {
   getPackageManager,
   installPackage,
   artifactsExist,
-  promptWhatToDo,
+  askWhatToDoNext,
 } from '../../utils/clack';
 
 import { SourceMapUploadToolConfigurationOptions } from './types';
@@ -67,16 +67,16 @@ export async function configureSentryCLI(
       relativeArtifactPath = rawArtifactPath;
     }
 
-    if (await artifactsExist(relativeArtifactPath)) {
+    if (artifactsExist(relativeArtifactPath)) {
       validPath = true;
       continue;
     }
 
-    const whatToDo = await promptWhatToDo({ relativeArtifactPath });
+    const whatToDoNext = await askWhatToDoNext({ relativeArtifactPath });
 
-    validPath = whatToDo?.validPath ?? false;
+    validPath = whatToDoNext?.validPath ?? false;
     relativeArtifactPath =
-      whatToDo?.relativeArtifactPath ?? relativeArtifactPath;
+      whatToDoNext?.relativeArtifactPath ?? relativeArtifactPath;
   } while (!validPath);
 
   const relativePosixArtifactPath = relativeArtifactPath

--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -11,7 +11,7 @@ import {
   getPackageManager,
   installPackage,
   artifactsExist,
-  askWhatToDoNext,
+  askToRunBuildOrEnterPathOrProceed,
 } from '../../utils/clack';
 
 import { SourceMapUploadToolConfigurationOptions } from './types';
@@ -72,11 +72,15 @@ export async function configureSentryCLI(
       continue;
     }
 
-    const whatToDoNext = await askWhatToDoNext({ relativeArtifactPath });
+    const runBuildOrEnterPathOrProceed =
+      await askToRunBuildOrEnterPathOrProceed({
+        relativeArtifactPath,
+      });
 
-    validPath = whatToDoNext?.validPath ?? false;
+    validPath = runBuildOrEnterPathOrProceed?.validPath ?? false;
     relativeArtifactPath =
-      whatToDoNext?.relativeArtifactPath ?? relativeArtifactPath;
+      runBuildOrEnterPathOrProceed?.relativeArtifactPath ??
+      relativeArtifactPath;
   } while (!validPath);
 
   const relativePosixArtifactPath = relativeArtifactPath

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1680,7 +1680,7 @@ export async function promptWhatToDo({
 
   if (buildCommand) {
     options.push({
-      label: 'Run the build command for me',
+      label: 'Let the wizard run the build command',
       value: 'run-build',
     });
   }
@@ -1698,7 +1698,7 @@ export async function promptWhatToDo({
 
   const whatToDo = await abortIfCancelled(
     clack.select({
-      message: `We couldn't find build artifacts at "${relativeArtifactPath}". What would you like us to do?`,
+      message: `We couldn't find build artifacts at "${relativeArtifactPath}". What would you like to do?`,
       options,
       initialValue: buildCommand ? 'run-build' : 'manual',
     }),

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1660,7 +1660,7 @@ async function getBuildCommand(): Promise<string | null> {
   return typeof packageDotJson.scripts?.build === 'string' ? 'build' : null;
 }
 
-export function artifactsExist(relativePath: string) {
+export function artifactsExist(relativePath: string): boolean {
   return fs.existsSync(path.join(process.cwd(), relativePath));
 }
 

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1664,7 +1664,7 @@ export function artifactsExist(relativePath: string): boolean {
   return fs.existsSync(path.join(process.cwd(), relativePath));
 }
 
-export async function askWhatToDoNext({
+export async function askToRunBuildOrEnterPathOrProceed({
   relativeArtifactPath,
 }: {
   relativeArtifactPath: string;
@@ -1712,7 +1712,7 @@ export async function askWhatToDoNext({
     );
 
     if (ranBuildAndCheckArtifacts.validPath === false) {
-      return await askWhatToDoNext({ relativeArtifactPath });
+      return await askToRunBuildOrEnterPathOrProceed({ relativeArtifactPath });
     }
 
     return ranBuildAndCheckArtifacts;

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1669,53 +1669,6 @@ export async function artifactsExist(relativePath: string): Promise<boolean> {
   }
 }
 
-// export async function confirmArtifactPath(
-//   relativePath: string,
-// ): Promise<{ confirmed: boolean; newPath?: string }> {
-//   const possibleFolders = await getPossibleBuildFolders();
-
-//   const options: Array<{ label: string; value: string; hint?: string }> = [
-//     { label: 'Yes, I am sure the path is correct!', value: 'confirm' },
-//   ];
-
-//   if (possibleFolders.length > 0) {
-//     options.push({
-//       label: 'No, let me choose from detected folders',
-//       value: 'choose',
-//       hint: `Found: ${possibleFolders.join(', ')}`,
-//     });
-//   }
-
-//   options.push({
-//     label: 'No, let me enter a different path manually',
-//     value: 'manual',
-//   });
-
-//   const choice = await abortIfCancelled(
-//     clack.select({
-//       message: `We couldn't find artifacts at ${relativePath}. What would you like to do?`,
-//       options,
-//       initialValue: 'confirm',
-//     }),
-//   );
-
-//   if (choice === 'confirm') {
-//     return { confirmed: true };
-//   }
-
-//   if (choice === 'choose') {
-//     const fallbackPath = await promptForAlternativeArtifactPath();
-
-//     if (!fallbackPath) {
-//       return { confirmed: false };
-//     }
-
-//     return { confirmed: true, newPath: fallbackPath };
-//   }
-
-//   return { confirmed: false };
-// }
-
 export async function promptWhatToDo({
   relativeArtifactPath,
 }: {

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1806,7 +1806,7 @@ async function runBuildCommand(buildCommand: string): Promise<boolean> {
       `Build failed: ${error instanceof Error ? error.message : String(error)}`,
     );
     clack.log.error(
-      'Failed to run build command. Please run it manually and try again.',
+      'Failed to run your build command. Please run it manually and try again.',
     );
     return false;
   }


### PR DESCRIPTION
This PR improves the build artifact detection and selection flow in the setup wizard. Key changes:

**Create React App Support:**

- ./builder is now suggested as the default build folder when using Create React App.


**Improved Build Artifact Recovery for All Packages:**

- If the user-specified build folder is not found, the wizard now offers clearer fallback options:
  - Run the build command
  - Re-enter the path
  - Proceed without selecting a folder
  
- If the user chooses to run the build command:
  - The command is executed, and the wizard re-checks for the build folder.
  - If still not found, the wizard suggests other likely folders.

- If possible folders are found:
  - The user is prompted to pick one or none
  - If the user declines all suggestions, the wizard repeats the prompt with the original fallback options: run, re-enter, or proceed.

closes https://linear.app/getsentry/issue/TET-434/onboardingreact-wizard-does-not-know-where-build-artifacts-for-create