### PR TITLE
feat(sveltekit): Add option to enable logs to be sent to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat(nextjs): Add option to enable logs to be sent to Sentry ([#1031](https://github.com/getsentry/sentry-wizard/pull/1031))
+- feat(sveltekit): Add option to enable logs to be sent to Sentry ([#1042](https://github.com/getsentry/sentry-wizard/pull/1042))
 
 ## 6.0.0
 

--- a/e2e-tests/tests/sveltekit.test.ts
+++ b/e2e-tests/tests/sveltekit.test.ts
@@ -88,7 +88,15 @@ async function runWizardOnSvelteKitProject(
       'to get a video-like reproduction of errors during a user session?',
     ));
 
-  replayOptionPrompted &&
+  const logsOptionPrompted =
+    replayOptionPrompted &&
+    (await wizardInstance.sendStdinAndWaitForOutput(
+      [KEYS.ENTER],
+      // "Do you want to enable Logs", sometimes doesn't work as `Logs` can be printed in bold.
+      'to send your application logs to Sentry?',
+    ));
+
+  logsOptionPrompted &&
     (await wizardInstance.sendStdinAndWaitForOutput(
       [KEYS.ENTER],
       'Do you want to create an example page',
@@ -191,6 +199,9 @@ describe('Sveltekit', () => {
 
   tracesSampleRate: 1.0,
 
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
+
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
   replaysSessionSampleRate: 0.1,
@@ -213,6 +224,9 @@ describe('Sveltekit', () => {
   dsn: '${TEST_ARGS.PROJECT_DSN}',
 
   tracesSampleRate: 1.0,
+
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: import.meta.env.DEV,
@@ -262,6 +276,7 @@ describe('Sveltekit', () => {
         `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
+    enableLogs: true,
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1,
     integrations: [Sentry.replayIntegration()]
@@ -275,7 +290,8 @@ describe('Sveltekit', () => {
         `import * as Sentry from '@sentry/sveltekit';`,
         `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
-    tracesSampleRate: 1
+    tracesSampleRate: 1,
+    enableLogs: true
 })`,
         'export const handleError = Sentry.handleErrorWithSentry();',
       ]);

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -3,6 +3,7 @@ export function getClientHooksTemplate(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
+    logs: boolean;
   },
 ) {
   return `import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
@@ -14,6 +15,14 @@ ${
   selectedFeatures.performance
     ? `
   tracesSampleRate: 1.0,
+`
+    : ''
+}
+${
+  selectedFeatures.logs
+    ? `
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
 `
     : ''
 }
@@ -43,6 +52,7 @@ export function getServerHooksTemplate(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
+    logs: boolean;
   },
 ) {
   return `import { sequence } from "@sveltejs/kit/hooks";
@@ -55,6 +65,14 @@ ${
   selectedFeatures.performance
     ? `
   tracesSampleRate: 1.0,
+`
+    : ''
+}
+${
+  selectedFeatures.logs
+    ? `
+  // Enable logs to be sent to Sentry
+  enableLogs: true,
 `
     : ''
 }

--- a/test/sveltekit/templates.test.ts
+++ b/test/sveltekit/templates.test.ts
@@ -9,6 +9,7 @@ describe('getClientHooksTemplate', () => {
     const result = getClientHooksTemplate('https://sentry.io/123', {
       performance: true,
       replay: true,
+      logs: true,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -19,6 +20,10 @@ describe('getClientHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
+
+
+        // Enable logs to be sent to Sentry
+        enableLogs: true,
 
         // This sets the sample rate to be 10%. You may want this to be 100% while
         // in development and sample at a lower rate in production
@@ -42,6 +47,7 @@ describe('getClientHooksTemplate', () => {
     const result = getClientHooksTemplate('https://sentry.io/123', {
       performance: false,
       replay: true,
+      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -50,6 +56,7 @@ describe('getClientHooksTemplate', () => {
 
       Sentry.init({
         dsn: 'https://sentry.io/123',
+
 
         // This sets the sample rate to be 10%. You may want this to be 100% while
         // in development and sample at a lower rate in production
@@ -73,6 +80,7 @@ describe('getClientHooksTemplate', () => {
     const result = getClientHooksTemplate('https://sentry.io/123', {
       performance: true,
       replay: false,
+      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -83,6 +91,34 @@ describe('getClientHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
+
+
+
+      });
+
+      // If you have a custom error handler, pass it to \`handleErrorWithSentry\`
+      export const handleError = handleErrorWithSentry();
+      "
+    `);
+  });
+
+  it('should generate client hooks template with only logs enabled', () => {
+    const result = getClientHooksTemplate('https://sentry.io/123', {
+      performance: false,
+      replay: false,
+      logs: true,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
+      import * as Sentry from '@sentry/sveltekit';
+
+      Sentry.init({
+        dsn: 'https://sentry.io/123',
+
+
+        // Enable logs to be sent to Sentry
+        enableLogs: true,
 
 
       });
@@ -99,6 +135,7 @@ describe('getServerHooksTemplate', () => {
     const result = getServerHooksTemplate('https://sentry.io/123', {
       performance: true,
       replay: true,
+      logs: true,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -110,6 +147,10 @@ describe('getServerHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
+
+
+        // Enable logs to be sent to Sentry
+        enableLogs: true,
 
         // uncomment the line below to enable Spotlight (https://spotlightjs.com)
         // spotlight: import.meta.env.DEV,
@@ -128,6 +169,7 @@ describe('getServerHooksTemplate', () => {
     const result = getServerHooksTemplate('https://sentry.io/123', {
       performance: false,
       replay: true,
+      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -137,6 +179,39 @@ describe('getServerHooksTemplate', () => {
 
       Sentry.init({
         dsn: 'https://sentry.io/123',
+
+
+        // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+        // spotlight: import.meta.env.DEV,
+      });
+
+      // If you have custom handlers, make sure to place them after \`sentryHandle()\` in the \`sequence\` function.
+      export const handle = sequence(sentryHandle());
+
+      // If you have a custom error handler, pass it to \`handleErrorWithSentry\`
+      export const handleError = handleErrorWithSentry();
+      "
+    `);
+  });
+
+  it('should generate server hooks template with only logs enabled', () => {
+    const result = getServerHooksTemplate('https://sentry.io/123', {
+      performance: false,
+      replay: false,
+      logs: true,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { sequence } from "@sveltejs/kit/hooks";
+      import { handleErrorWithSentry, sentryHandle } from "@sentry/sveltekit";
+      import * as Sentry from '@sentry/sveltekit';
+
+      Sentry.init({
+        dsn: 'https://sentry.io/123',
+
+
+        // Enable logs to be sent to Sentry
+        enableLogs: true,
 
         // uncomment the line below to enable Spotlight (https://spotlightjs.com)
         // spotlight: import.meta.env.DEV,


### PR DESCRIPTION
Add logs support to the SvelteKit wizard to enable sending application logs to Sentry.

resolves https://github.com/getsentry/sentry-wizard/issues/1035
