### PR TITLE
fix(sveltekit): Correct spacing in logs snippet

### DIFF
--- a/e2e-tests/tests/sveltekit.test.ts
+++ b/e2e-tests/tests/sveltekit.test.ts
@@ -276,10 +276,10 @@ describe('Sveltekit', () => {
         `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
-    enableLogs: true,
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1,
-    integrations: [Sentry.replayIntegration()]
+    integrations: [Sentry.replayIntegration()],
+    enableLogs: true
 })`,
         'export const handleError = Sentry.handleErrorWithSentry(',
       ]);

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -20,8 +20,7 @@ ${
 }
 ${
   selectedFeatures.logs
-    ? `
-  // Enable logs to be sent to Sentry
+    ? `  // Enable logs to be sent to Sentry
   enableLogs: true,
 `
     : ''
@@ -70,8 +69,7 @@ ${
 }
 ${
   selectedFeatures.logs
-    ? `
-  // Enable logs to be sent to Sentry
+    ? `  // Enable logs to be sent to Sentry
   enableLogs: true,
 `
     : ''

--- a/test/sveltekit/templates.test.ts
+++ b/test/sveltekit/templates.test.ts
@@ -21,7 +21,6 @@ describe('getClientHooksTemplate', () => {
 
         tracesSampleRate: 1.0,
 
-
         // Enable logs to be sent to Sentry
         enableLogs: true,
 
@@ -116,7 +115,6 @@ describe('getClientHooksTemplate', () => {
       Sentry.init({
         dsn: 'https://sentry.io/123',
 
-
         // Enable logs to be sent to Sentry
         enableLogs: true,
 
@@ -147,7 +145,6 @@ describe('getServerHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
-
 
         // Enable logs to be sent to Sentry
         enableLogs: true,
@@ -208,7 +205,6 @@ describe('getServerHooksTemplate', () => {
 
       Sentry.init({
         dsn: 'https://sentry.io/123',
-
 
         // Enable logs to be sent to Sentry
         enableLogs: true,


### PR DESCRIPTION
https://github.com/getsentry/sentry-wizard/pull/1042 was merged without CI passing, this PR helps fix that. Skipping changelog because https://github.com/getsentry/sentry-wizard/pull/1042 was where these changes needed to be.

#skip-changelog