### PR TITLE
fix(tests): Fix Expo and React Native E2E test flakes

### DIFF
--- a/e2e-tests/tests/expo.test.ts
+++ b/e2e-tests/tests/expo.test.ts
@@ -30,7 +30,10 @@ describe('Expo', () => {
         // Selecting `yarn` as the package manager
         [KEYS.DOWN, KEYS.DOWN, KEYS.ENTER],
         'Do you want to enable Session Replay to help debug issues? (See https://docs.sentry.io/platforms/react-native/session-replay/)',
-      ));
+      ),
+      {
+        timeout: 240_000,
+      });
     const feedbackWidgetPrompted =
       sessionReplayPrompted &&
       (await wizardInstance.sendStdinAndWaitForOutput(
@@ -38,7 +41,8 @@ describe('Expo', () => {
         [KEYS.ENTER],
         'Do you want to enable the Feedback Widget to collect feedback from your users? (See https://docs.sentry.io/platforms/react-native/user-feedback/)',
       ));
-    const logsPrompted =
+
+      const logsPrompted =
       feedbackWidgetPrompted &&
       (await wizardInstance.sendStdinAndWaitForOutput(
         // Enable feedback widget

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -31,7 +31,9 @@ describe('ReactNative', () => {
         // Selecting `yarn` as the package manager
         [KEYS.DOWN, KEYS.DOWN, KEYS.ENTER],
         'Do you want to enable Session Replay to help debug issues? (See https://docs.sentry.io/platforms/react-native/session-replay/)',
-      ));
+      ), {
+        timeout: 240_000,
+      });
 
     const feedbackWidgetPrompted =
       sessionReplayPrompted &&


### PR DESCRIPTION
Fixes recent E2E test flakes, added timeouts to allow potentially slow package manager downloads, similar to other E2E tests.

#skip-changelog