### PR TITLE
fix(nextjs): Prevent double-wrapping of Next.js config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(nextjs): Prevent double-wrapping of Next.js config ([#1058](https://github.com/getsentry/sentry-wizard/pull/1058))
+
 ## 6.1.2
 
 - ref(angular,nextjs,nuxt,remix,sveltekit): Install SDK package version `@^10` ([#1048](https://github.com/getsentry/sentry-wizard/pull/1048))

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -4,7 +4,7 @@ import clack from '@clack/prompts';
 import chalk from 'chalk';
 import * as fs from 'fs';
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
-import { builders, generateCode, parseModule } from 'magicast';
+import { parseModule } from 'magicast';
 import * as path from 'path';
 
 import * as Sentry from '@sentry/node';
@@ -58,7 +58,8 @@ import {
   getMaybeAppDirLocation,
   getNextJsVersionBucket,
   hasRootLayoutFile,
-  unwrapSentryConfigExpression,
+  unwrapSentryConfigAst,
+  wrapWithSentryConfig,
 } from './utils';
 
 export function runNextjsWizard(options: WizardOptions) {
@@ -849,19 +850,24 @@ async function createOrMergeNextJsFiles(
             imported: 'withSentryConfig',
             local: 'withSentryConfig',
           });
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-          let expressionToWrap = generateCode(mod.exports.default.$ast).code;
 
           if (probablyIncludesSdk) {
             // Prevent double wrapping like: withSentryConfig(withSentryConfig(nextConfig), { ... })
-            expressionToWrap = unwrapSentryConfigExpression(expressionToWrap);
+            // Use AST manipulation instead of string parsing for better reliability
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+            mod.exports.default.$ast = unwrapSentryConfigAst(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+              mod.exports.default.$ast,
+            );
           }
 
+          // Use the shared utility function for wrapping
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          mod.exports.default = builders.raw(`withSentryConfig(
-      ${expressionToWrap},
-      ${withSentryConfigOptionsTemplate}
-)`);
+          mod.exports.default = wrapWithSentryConfig(
+            mod.exports.default,
+            withSentryConfigOptionsTemplate,
+          );
+
           const newCode = mod.generate().code;
 
           await fs.promises.writeFile(

--- a/src/nextjs/utils.ts
+++ b/src/nextjs/utils.ts
@@ -40,3 +40,71 @@ export function hasRootLayoutFile(appFolderPath: string) {
     fs.existsSync(path.join(appFolderPath, `layout.${ext}`)),
   );
 }
+
+/**
+ * Unwraps a simple expression containing withSentryConfig.
+ * Prevent double wrapping like: `withSentryConfig(withSentryConfig(nextConfig), { ... })`
+ * Used for MJS/TS export statements.
+ */
+export function unwrapSentryConfigExpression(expression: string): string {
+  // Find the start of withSentryConfig(
+  const startMatch = expression.match(/withSentryConfig\s*\(/);
+  if (!startMatch || startMatch.index === undefined) {
+    return expression;
+  }
+
+  const startIndex = startMatch.index + startMatch[0].length;
+  const innerContent = extractInnerContent(expression, startIndex);
+
+  if (innerContent === null) {
+    // Malformed expression, return as-is
+    return expression;
+  }
+
+  return getFirstArgument(innerContent);
+}
+
+/**
+ * Extracts content between matching parentheses starting from a given index
+ */
+function extractInnerContent(
+  expression: string,
+  startIndex: number,
+): string | null {
+  let parenCount = 1;
+  let currentIndex = startIndex;
+
+  while (currentIndex < expression.length && parenCount > 0) {
+    const char = expression[currentIndex];
+    if (char === '(') {
+      parenCount++;
+    } else if (char === ')') {
+      parenCount--;
+    }
+    currentIndex++;
+  }
+
+  return parenCount === 0
+    ? expression.substring(startIndex, currentIndex - 1)
+    : null;
+}
+
+/**
+ * Gets the first argument (nextConfig) from a comma-separated list, respecting nested parentheses
+ */
+function getFirstArgument(content: string): string {
+  let parenCount = 0;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+    if (char === '(') {
+      parenCount++;
+    } else if (char === ')') {
+      parenCount--;
+    } else if (char === ',' && parenCount === 0) {
+      return content.substring(0, i).trim();
+    }
+  }
+
+  return content.trim();
+}

--- a/test/nextjs/wizard-double-wrap-prevention.test.ts
+++ b/test/nextjs/wizard-double-wrap-prevention.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
+import { builders, generateCode, parseModule } from 'magicast';
+import { getWithSentryConfigOptionsTemplate } from '../../src/nextjs/templates';
+import { unwrapSentryConfigExpression } from '../../src/nextjs/utils';
+
+describe('Next.js wizard double wrap prevention', () => {
+  const mockWithSentryConfigOptionsTemplate =
+    getWithSentryConfigOptionsTemplate({
+      orgSlug: 'test-org',
+      projectSlug: 'test-project',
+      selfHosted: false,
+      sentryUrl: 'https://sentry.io',
+      tunnelRoute: false,
+    });
+
+  describe('unwrapSentryConfigExpression utility function', () => {
+    describe('MJS/TS expression unwrapping', () => {
+      it('keeps code without withSentryConfig', () => {
+        const input = `const nextConfig = { /* config options here */ }; export default nextConfig`;
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe(input);
+      });
+
+      it('should unwrap withSentryConfig with options', () => {
+        const input = 'withSentryConfig(nextConfig, { org: "test" })';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('nextConfig');
+      });
+
+      it('should unwrap withSentryConfig without options', () => {
+        const input = 'withSentryConfig(nextConfig)';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('nextConfig');
+      });
+
+      it('should unwrap multiple-wrapped withSentryConfig without options', () => {
+        const input = 'withSentryConfig(withSentryConfig(nextConfig))';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('withSentryConfig(nextConfig)');
+      });
+
+      it('should handle nested withSentryConfig calls', () => {
+        const input =
+          'withSentryConfig(withSentryConfig(nextConfig, { dsn: "inner-dsn", sampleRate: 1.0 }), { org: "outer" })';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe(
+          'withSentryConfig(nextConfig, { dsn: "inner-dsn", sampleRate: 1.0 })',
+        );
+      });
+
+      it('should handle nested withSentryConfig calls with object option', () => {
+        const input =
+          'withSentryConfig(withSentryConfig(nextConfig, { dsn: "inner-dsn", obj: { test: "hey" } }), { org: "outer" })';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe(
+          'withSentryConfig(nextConfig, { dsn: "inner-dsn", obj: { test: "hey" } })',
+        );
+      });
+
+      it('should handle complex expressions', () => {
+        const input = 'withSentryConfig(someComplexExpression.withMethods())';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('someComplexExpression.withMethods()');
+      });
+
+      it('should handle expressions with whitespace', () => {
+        const input = 'withSentryConfig( nextConfig , { org: "test" })';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('nextConfig');
+      });
+
+      it('should return unchanged if no withSentryConfig present', () => {
+        const input = 'nextConfig';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('nextConfig');
+      });
+
+      it('should handle the exact reported case', () => {
+        const input = 'withSentryConfig(nextConfig)';
+        const result = unwrapSentryConfigExpression(input);
+        expect(result).toBe('nextConfig');
+      });
+    });
+  });
+
+  describe('MJS/TS files', () => {
+    it('should unwrap existing withSentryConfig and re-wrap with new config', () => {
+      const existingMjsContent = `import { withSentryConfig } from "@sentry/nextjs";
+
+const nextConfig = {};
+
+export default withSentryConfig(nextConfig, {
+  org: "old-org",
+  project: "old-project",
+});`;
+
+      const mod = parseModule(existingMjsContent);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+      let expressionToWrap = generateCode(mod.exports.default.$ast).code;
+
+      expressionToWrap = unwrapSentryConfigExpression(expressionToWrap);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mod.exports.default = builders.raw(`withSentryConfig(
+      ${expressionToWrap},
+      ${mockWithSentryConfigOptionsTemplate}
+)`);
+
+      const newCode = mod.generate().code;
+
+      const withSentryConfigMatches = newCode.match(/withSentryConfig\s*\(/g);
+      expect(withSentryConfigMatches).toHaveLength(1);
+
+      expect(newCode).toContain('test-org');
+      expect(newCode).toContain('test-project');
+      expect(newCode).not.toContain('"old-org"');
+      expect(newCode).not.toContain('"old-project"');
+    });
+
+    it('should handle complex nested configurations', () => {
+      const existingMjsContent = `import { withSentryConfig } from "@sentry/nextjs";
+
+const nextConfig = { experimental: { appDir: true } };
+
+export default withSentryConfig(
+  withSentryConfig(nextConfig, { org: "nested-org" }),
+  { org: "outer-org" }
+);`;
+
+      const mod = parseModule(existingMjsContent);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+      let expressionToWrap = generateCode(mod.exports.default.$ast).code;
+
+      // Use the utility function to unwrap once - extracts the outermost-wrapped expression first
+      expressionToWrap = unwrapSentryConfigExpression(expressionToWrap);
+      expect(expressionToWrap).toContain('withSentryConfig(nextConfig');
+
+      // If we extract again (simulating multiple runs) - should eventually get to the base config
+      expressionToWrap = unwrapSentryConfigExpression(expressionToWrap);
+      expect(expressionToWrap).toBe('nextConfig');
+    });
+
+    it('should handle simple export without existing withSentryConfig', () => {
+      const simpleMjsContent = `const nextConfig = {};
+
+export default nextConfig;`;
+
+      const mod = parseModule(simpleMjsContent);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+      const expressionToWrap = generateCode(mod.exports.default.$ast).code;
+
+      // Should not try to unwrap when there's no existing wrap
+      expect(expressionToWrap).toBe('nextConfig');
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mod.exports.default = builders.raw(`withSentryConfig(
+      ${expressionToWrap},
+      ${mockWithSentryConfigOptionsTemplate}
+)`);
+
+      const newCode = mod.generate().code;
+
+      // Should have exactly one withSentryConfig call
+      const withSentryConfigMatches = newCode.match(/withSentryConfig\s*\(/g);
+      expect(withSentryConfigMatches).toHaveLength(1);
+    });
+
+    it('should handle withSentryConfig(nextConfig) without options', () => {
+      const existingMjsContent = `import { withSentryConfig } from "@sentry/nextjs";
+
+const nextConfig = {};
+
+export default withSentryConfig(nextConfig);`;
+
+      const mod = parseModule(existingMjsContent);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+      let expressionToWrap = generateCode(mod.exports.default.$ast).code;
+
+      expect(expressionToWrap).toBe('withSentryConfig(nextConfig)');
+
+      expressionToWrap = unwrapSentryConfigExpression(expressionToWrap);
+
+      expect(expressionToWrap).toBe('nextConfig');
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mod.exports.default = builders.raw(`withSentryConfig(
+      ${expressionToWrap},
+      ${mockWithSentryConfigOptionsTemplate}
+)`);
+
+      const newCode = mod.generate().code;
+
+      // Should have exactly one withSentryConfig call
+      const withSentryConfigMatches = newCode.match(/withSentryConfig\s*\(/g);
+      expect(withSentryConfigMatches).toHaveLength(1);
+
+      expect(newCode).not.toContain('withSentryConfig(withSentryConfig(');
+      expect(newCode).toMatch(/withSentryConfig\s*\(\s*nextConfig\s*,/);
+    });
+  });
+});


### PR DESCRIPTION
Prevents double-wrapping in MJS/TS files. The CJS content is not replaced, but appended, so there is not double-wrapping in the first place.

I also tested this in a local Next.js project.

Closes https://github.com/getsentry/sentry-wizard/issues/1007