### PR TITLE
feat: track feature selection as span attributes

### DIFF
--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1598,7 +1598,7 @@ export async function askShouldCreateExampleComponent(): Promise<boolean> {
 export async function featureSelectionPrompt<F extends ReadonlyArray<Feature>>(
   features: F,
 ): Promise<{ [key in F[number]['id']]: boolean }> {
-  return traceStep('feature-selection', async () => {
+  return traceStep('feature-selection', async (span) => {
     const selectedFeatures: Record<string, boolean> = {};
 
     for (const feature of features) {
@@ -1623,6 +1623,16 @@ export async function featureSelectionPrompt<F extends ReadonlyArray<Feature>>(
 
       selectedFeatures[feature.id] = selected;
     }
+
+    span?.setAttributes(
+      Object.entries(selectedFeatures).reduce(
+        (acc, [key, value]) => {
+          acc[`wizard.feature.${key}`] = value;
+          return acc;
+        },
+        {} as Record<string, boolean>,
+      ),
+    );
 
     return selectedFeatures as { [key in F[number]['id']]: boolean };
   });


### PR DESCRIPTION
It would be good to get an idea of how many people select different features during installation, specifically for logs.

This PR adds that.