### PR TITLE
fix(remix): Wrap app with `withSentry` independently from `hasSentryContent`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'assets/**',
     'scripts/**',
     'coverage/**',
+    '**/fixtures/**',
     'lib/Helper/test-fixtures/**',
     'e2e-tests/test-applications/**',
     'vitest.config.ts',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+- feat(cocoa): Add structured logs opt-in option ([#1051](https://github.com/getsentry/sentry-wizard/pull/1051))
 - feat(electron): Show `sendDefaultPii: true` inside `Sentry.init` example ([#1062](https://github.com/getsentry/sentry-wizard/pull/1062))
 - feat(flutter): Add structured logs opt-in #1050 ([#1050](https://github.com/getsentry/sentry-wizard/pull/1050))
 - fix(nextjs): Prevent double-wrapping of Next.js config ([#1058](https://github.com/getsentry/sentry-wizard/pull/1058))
 - fix(react-native): Add support for metro.config.cjs files ([#1064](https://github.com/getsentry/sentry-wizard/pull/1064))
-- feat(cocoa): Add structured logs opt-in option ([#1051](https://github.com/getsentry/sentry-wizard/pull/1051))
+- fix(remix): Wrap app with `withSentry` independently from `hasSentryContent` ([#1061](https://github.com/getsentry/sentry-wizard/pull/1061))
 
 <details>
 <summary><strong>Internal Changes</strong></summary>

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -8,7 +8,7 @@
     "test": "vitest -c ./vitest.config.ts --run --coverage"
   },
   "volta": {
-    "node": "20.18.3",
+    "node": "22.18.0",
     "yarn": "1.22.19"
   }
 }

--- a/e2e-tests/tests/remix.test.ts
+++ b/e2e-tests/tests/remix.test.ts
@@ -199,14 +199,15 @@ function checkRemixProject(
     ]);
   });
 
-  test('root file contains Sentry ErrorBoundary', () => {
+  test('root file contains Sentry ErrorBoundary and withSentry wrapper', () => {
     checkFileContents(`${projectDir}/app/root.tsx`, [
-      'import { captureRemixErrorBoundaryError } from "@sentry/remix";',
+      'import { captureRemixErrorBoundaryError, withSentry } from "@sentry/remix";',
       `export const ErrorBoundary = () => {
   const error = useRouteError();
   captureRemixErrorBoundaryError(error);
   return <div>Something went wrong</div>;
 };`,
+      `export default withSentry(App);`,
     ]);
   });
 

--- a/src/remix/codemods/root.ts
+++ b/src/remix/codemods/root.ts
@@ -5,10 +5,7 @@
 import * as recast from 'recast';
 import * as path from 'path';
 
-import type {
-  ExportNamedDeclaration,
-  Program,
-} from '@babel/types';
+import type { ExportNamedDeclaration, Program } from '@babel/types';
 
 import {
   builders,
@@ -78,7 +75,9 @@ export function wrapAppWithSentry(
   });
 }
 
-function isWithSentryAlreadyUsed(rootRouteAst: ProxifiedModule): boolean {
+export function isWithSentryAlreadyUsed(
+  rootRouteAst: ProxifiedModule,
+): boolean {
   // Check if withSentry is called anywhere in the code
   let isUsed = false;
   recast.visit(rootRouteAst.$ast, {

--- a/src/remix/codemods/root.ts
+++ b/src/remix/codemods/root.ts
@@ -5,7 +5,10 @@
 import * as recast from 'recast';
 import * as path from 'path';
 
-import type { ExportNamedDeclaration, Program } from '@babel/types';
+import type {
+  ExportNamedDeclaration,
+  Program,
+} from '@babel/types';
 
 import {
   builders,
@@ -75,6 +78,24 @@ export function wrapAppWithSentry(
   });
 }
 
+function isWithSentryAlreadyUsed(rootRouteAst: ProxifiedModule): boolean {
+  // Check if withSentry is called anywhere in the code
+  let isUsed = false;
+  recast.visit(rootRouteAst.$ast, {
+    visitCallExpression(path) {
+      if (
+        path.value.callee.type === 'Identifier' &&
+        path.value.callee.name === 'withSentry'
+      ) {
+        isUsed = true;
+        return false; // Stop traversal
+      }
+      this.traverse(path);
+    },
+  });
+  return isUsed;
+}
+
 export async function instrumentRoot(rootFileName: string): Promise<void> {
   const rootRouteAst = await loadFile(
     path.join(process.cwd(), 'app', rootFileName),
@@ -87,6 +108,7 @@ export async function instrumentRoot(rootFileName: string): Promise<void> {
   ) as ExportNamedDeclaration[];
 
   let foundErrorBoundary = false;
+  const withSentryAlreadyUsed = isWithSentryAlreadyUsed(rootRouteAst);
 
   namedExports.forEach((namedExport) => {
     const declaration = namedExport.declaration;
@@ -124,6 +146,11 @@ export async function instrumentRoot(rootFileName: string): Promise<void> {
       local: 'useRouteError',
     });
 
+    // Call wrapAppWithSentry if withSentry is not already used
+    if (!withSentryAlreadyUsed) {
+      wrapAppWithSentry(rootRouteAst, rootFileName);
+    }
+
     recast.visit(rootRouteAst.$ast, {
       visitExportDefaultDeclaration(path) {
         const implementation = recast.parse(ERROR_BOUNDARY_TEMPLATE).program
@@ -144,7 +171,10 @@ export async function instrumentRoot(rootFileName: string): Promise<void> {
       local: 'captureRemixErrorBoundaryError',
     });
 
-    wrapAppWithSentry(rootRouteAst, rootFileName);
+    // Call wrapAppWithSentry if withSentry is not already used
+    if (!withSentryAlreadyUsed) {
+      wrapAppWithSentry(rootRouteAst, rootFileName);
+    }
 
     recast.visit(rootRouteAst.$ast, {
       visitExportNamedDeclaration(path) {
@@ -202,6 +232,9 @@ export async function instrumentRoot(rootFileName: string): Promise<void> {
         this.traverse(path);
       },
     });
+  } else if (!withSentryAlreadyUsed) {
+    // Even if we have Sentry content but withSentry is not used, we should still wrap the app
+    wrapAppWithSentry(rootRouteAst, rootFileName);
   }
 
   await writeFile(

--- a/test/remix/fixtures/root-already-wrapped.tsx
+++ b/test/remix/fixtures/root-already-wrapped.tsx
@@ -1,0 +1,8 @@
+import { Outlet } from '@remix-run/react';
+import { withSentry } from '@sentry/remix';
+
+function App() {
+  return <Outlet />;
+}
+
+export default withSentry(App);

--- a/test/remix/fixtures/root-no-error-boundary.tsx
+++ b/test/remix/fixtures/root-no-error-boundary.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from '@remix-run/react';
+
+export default function App() {
+  return <Outlet />;
+}

--- a/test/remix/fixtures/root-variable-error-boundary.tsx
+++ b/test/remix/fixtures/root-variable-error-boundary.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from '@remix-run/react';
+
+const ErrorBoundary = () => {
+  return <div>Error occurred</div>;
+};
+
+export { ErrorBoundary };
+
+export default function App() {
+  return <Outlet />;
+}

--- a/test/remix/fixtures/root-with-error-boundary.tsx
+++ b/test/remix/fixtures/root-with-error-boundary.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from '@remix-run/react';
+
+export function ErrorBoundary() {
+  return <div>Error occurred</div>;
+}
+
+export default function App() {
+  return <Outlet />;
+}

--- a/test/remix/fixtures/root-with-sentry-error-boundary.tsx
+++ b/test/remix/fixtures/root-with-sentry-error-boundary.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from '@remix-run/react';
+import { captureRemixErrorBoundaryError } from '@sentry/remix';
+
+export function ErrorBoundary() {
+  captureRemixErrorBoundaryError();
+  return <div>Error occurred</div>;
+}
+
+export default function App() {
+  return <Outlet />;
+}

--- a/test/remix/root.test.ts
+++ b/test/remix/root.test.ts
@@ -1,10 +1,27 @@
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { parseModule } from 'magicast';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   wrapAppWithSentry,
   isWithSentryAlreadyUsed,
+  instrumentRoot,
 } from '../../src/remix/codemods/root';
+
+vi.mock('@clack/prompts', () => {
+  const mock = {
+    log: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+    },
+  };
+  return {
+    default: mock,
+    ...mock,
+  };
+});
 
 describe('wrapAppWithSentry', () => {
   it('should wrap the app with Sentry', () => {
@@ -125,5 +142,173 @@ describe('isWithSentryAlreadyUsed', () => {
     `);
 
     expect(isWithSentryAlreadyUsed(rootAst)).toBe(false);
+  });
+});
+
+describe('instrumentRoot', () => {
+  const fixturesDir = path.join(__dirname, 'fixtures');
+  const tmpDir = path.join(fixturesDir, 'tmp');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock process.cwd() to return the fixtures directory
+    vi.spyOn(process, 'cwd').mockReturnValue(fixturesDir);
+  });
+
+  afterEach(() => {
+    // Clean up any temporary files
+    if (fs.existsSync(tmpDir)) {
+      try {
+        // Remove files first, then directory
+        const appDir = path.join(tmpDir, 'app');
+        if (fs.existsSync(appDir)) {
+          const files = fs.readdirSync(appDir);
+          files.forEach((file) => {
+            fs.unlinkSync(path.join(appDir, file));
+          });
+          fs.rmdirSync(appDir);
+        }
+
+        const files = fs.readdirSync(tmpDir);
+        files.forEach((file) => {
+          const filePath = path.join(tmpDir, file);
+          const stat = fs.statSync(filePath);
+          if (stat.isDirectory()) {
+            fs.rmdirSync(filePath);
+          } else {
+            fs.unlinkSync(filePath);
+          }
+        });
+      } catch (error) {
+        // Ignore cleanup errors in tests
+      }
+    }
+  });
+
+  it('should add ErrorBoundary and wrap app with Sentry when no ErrorBoundary exists and withSentry is not used', async () => {
+    // Copy fixture to tmp directory for testing
+    const srcFile = path.join(fixturesDir, 'root-no-error-boundary.tsx');
+    const appDir = path.join(tmpDir, 'app');
+
+    // Create app directory and copy file
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.copyFileSync(srcFile, path.join(appDir, 'root.tsx'));
+
+    // Mock process.cwd() to return tmpDir
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    await instrumentRoot('root.tsx');
+
+    // Check that the file was modified correctly
+    const modifiedContent = fs.readFileSync(
+      path.join(appDir, 'root.tsx'),
+      'utf8',
+    );
+
+    expect(modifiedContent).toContain(
+      'import { captureRemixErrorBoundaryError, withSentry } from "@sentry/remix";',
+    );
+    expect(modifiedContent).toContain(
+      "import { Outlet, useRouteError } from '@remix-run/react';",
+    );
+    expect(modifiedContent).toContain('withSentry(App)');
+    expect(modifiedContent).toContain('const ErrorBoundary = () => {');
+  });
+
+  it('should wrap app with Sentry when ErrorBoundary exists but no Sentry content', async () => {
+    const srcFile = path.join(fixturesDir, 'root-with-error-boundary.tsx');
+    const appDir = path.join(tmpDir, 'app');
+
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.copyFileSync(srcFile, path.join(appDir, 'root.tsx'));
+
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    await instrumentRoot('root.tsx');
+
+    const modifiedContent = fs.readFileSync(
+      path.join(appDir, 'root.tsx'),
+      'utf8',
+    );
+
+    expect(modifiedContent).toContain(
+      'import { captureRemixErrorBoundaryError, withSentry } from "@sentry/remix";',
+    );
+    expect(modifiedContent).toContain('withSentry(App)');
+  });
+
+  it('should wrap app with Sentry when ErrorBoundary exists with Sentry content but withSentry is not used', async () => {
+    const srcFile = path.join(
+      fixturesDir,
+      'root-with-sentry-error-boundary.tsx',
+    );
+    const appDir = path.join(tmpDir, 'app');
+
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.copyFileSync(srcFile, path.join(appDir, 'root.tsx'));
+
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    await instrumentRoot('root.tsx');
+
+    const modifiedContent = fs.readFileSync(
+      path.join(appDir, 'root.tsx'),
+      'utf8',
+    );
+
+    expect(modifiedContent).toContain(
+      "import { captureRemixErrorBoundaryError, withSentry } from '@sentry/remix';",
+    );
+    expect(modifiedContent).toContain('withSentry(App)');
+  });
+
+  it('should not wrap app when withSentry is already used', async () => {
+    const srcFile = path.join(fixturesDir, 'root-already-wrapped.tsx');
+    const appDir = path.join(tmpDir, 'app');
+
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.copyFileSync(srcFile, path.join(appDir, 'root.tsx'));
+
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    await instrumentRoot('root.tsx');
+
+    const modifiedContent = fs.readFileSync(
+      path.join(appDir, 'root.tsx'),
+      'utf8',
+    );
+
+    // Should not add withSentry import or wrap again
+    expect(modifiedContent).toContain('withSentry(App)');
+
+    // Count occurrences of withSentry to ensure it's not duplicated
+    const withSentryOccurrences = (modifiedContent.match(/withSentry/g) || [])
+      .length;
+    expect(withSentryOccurrences).toBe(2); // One import, one usage
+
+    // The content should remain largely the same since withSentry is already used
+    expect(modifiedContent).toContain('export default withSentry(App)');
+  });
+
+  it('should handle ErrorBoundary as variable declaration', async () => {
+    const srcFile = path.join(fixturesDir, 'root-variable-error-boundary.tsx');
+    const appDir = path.join(tmpDir, 'app');
+
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.copyFileSync(srcFile, path.join(appDir, 'root.tsx'));
+
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    await instrumentRoot('root.tsx');
+
+    const modifiedContent = fs.readFileSync(
+      path.join(appDir, 'root.tsx'),
+      'utf8',
+    );
+
+    expect(modifiedContent).toContain(
+      'import { captureRemixErrorBoundaryError, withSentry } from "@sentry/remix";',
+    );
+    expect(modifiedContent).toContain('withSentry(App)');
   });
 });

--- a/test/remix/root.test.ts
+++ b/test/remix/root.test.ts
@@ -1,7 +1,10 @@
 // @ts-expect-error - magicast is ESM and TS complains about that. It works though
 import { parseModule } from 'magicast';
 import { describe, expect, it } from 'vitest';
-import { wrapAppWithSentry } from '../../src/remix/codemods/root';
+import {
+  wrapAppWithSentry,
+  isWithSentryAlreadyUsed,
+} from '../../src/remix/codemods/root';
 
 describe('wrapAppWithSentry', () => {
   it('should wrap the app with Sentry', () => {
@@ -28,5 +31,99 @@ describe('wrapAppWithSentry', () => {
 
       export default withSentry(App);"
     `);
+  });
+});
+
+describe('isWithSentryAlreadyUsed', () => {
+  it('should return false when withSentry is not used', () => {
+    const rootAst = parseModule(`
+      import { Outlet } from '@remix-run/react';
+
+      export default function App() {
+        return <Outlet />;
+      }
+    `);
+
+    expect(isWithSentryAlreadyUsed(rootAst)).toBe(false);
+  });
+
+  it('should return true when withSentry is used in default export', () => {
+    const rootAst = parseModule(`
+      import { withSentry } from '@sentry/remix';
+      import { Outlet } from '@remix-run/react';
+
+      function App() {
+        return <Outlet />;
+      }
+
+      export default withSentry(App);
+    `);
+
+    expect(isWithSentryAlreadyUsed(rootAst)).toBe(true);
+  });
+
+  it('should return true when withSentry is used in a variable assignment', () => {
+    const rootAst = parseModule(`
+      import { withSentry } from '@sentry/remix';
+      import { Outlet } from '@remix-run/react';
+
+      function App() {
+        return <Outlet />;
+      }
+
+      const WrappedApp = withSentry(App);
+      export default WrappedApp;
+    `);
+
+    expect(isWithSentryAlreadyUsed(rootAst)).toBe(true);
+  });
+
+  it('should return true when withSentry is used inside a function', () => {
+    const rootAst = parseModule(`
+      import { withSentry } from '@sentry/remix';
+      import { Outlet } from '@remix-run/react';
+
+      function App() {
+        return <Outlet />;
+      }
+
+      function createApp() {
+        return withSentry(App);
+      }
+
+      export default createApp();
+    `);
+
+    expect(isWithSentryAlreadyUsed(rootAst)).toBe(true);
+  });
+
+  it('should return false when withSentry is imported but not used', () => {
+    const rootAst = parseModule(`
+      import { withSentry } from '@sentry/remix';
+      import { Outlet } from '@remix-run/react';
+
+      export default function App() {
+        return <Outlet />;
+      }
+    `);
+
+    expect(isWithSentryAlreadyUsed(rootAst)).toBe(false);
+  });
+
+  it('should return false when a different function with similar name is used', () => {
+    const rootAst = parseModule(`
+      import { Outlet } from '@remix-run/react';
+
+      function withSentryLike() {
+        return null;
+      }
+
+      export default function App() {
+        withSentryLike();
+        return <Outlet />;
+      }
+    `);
+
+    expect(isWithSentryAlreadyUsed(rootAst)).toBe(false);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
   "exclude": [
     "e2e-tests/test-applications/**/*",
     "e2e-tests/vitest.config.ts",
+    "**/fixtures/**",
   ],
   "ts-node": {
     "files": true


### PR DESCRIPTION
Fixes the bug mentioned here: https://github.com/getsentry/sentry-docs/pull/13928#issuecomment-2983070968