### PR TITLE
fix(react-native): Add support for metro.config.cjs files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix(nextjs): Prevent double-wrapping of Next.js config ([#1058](https://github.com/getsentry/sentry-wizard/pull/1058))
+- fix(react-native): Add support for metro.config.cjs files ([#1064](https://github.com/getsentry/sentry-wizard/pull/1064))
 
 ## 6.1.2
 

--- a/src/react-native/expo-metro.ts
+++ b/src/react-native/expo-metro.ts
@@ -22,13 +22,11 @@ import t = x.namedTypes;
 const b = recast.types.builders;
 
 export async function addSentryToExpoMetroConfig() {
-  const metroConfigPath = findMetroConfigPath();
+  let metroConfigPath = findMetroConfigPath();
 
   if (!metroConfigPath) {
-    clack.log.error(
-      'No Metro config file found. Expected: metro.config.js or metro.config.cjs',
-    );
-    return await showInstructions('metro.config.js'); // fallback for instructions
+    // No existing metro config found, create metro.config.js (Expo default)
+    metroConfigPath = 'metro.config.js';
   }
 
   if (!fs.existsSync(metroConfigPath)) {

--- a/src/react-native/expo-metro.ts
+++ b/src/react-native/expo-metro.ts
@@ -9,7 +9,11 @@ import * as Sentry from '@sentry/node';
 import { getLastRequireIndex, hasSentryContent } from '../utils/ast-utils';
 import { makeCodeSnippet, showCopyPasteInstructions } from '../utils/clack';
 
-import { metroConfigPath, parseMetroConfig, writeMetroConfig } from './metro';
+import {
+  findMetroConfigPath,
+  parseMetroConfig,
+  writeMetroConfig,
+} from './metro';
 
 import * as recast from 'recast';
 import x = recast.types;
@@ -18,11 +22,20 @@ import t = x.namedTypes;
 const b = recast.types.builders;
 
 export async function addSentryToExpoMetroConfig() {
+  const metroConfigPath = findMetroConfigPath();
+
+  if (!metroConfigPath) {
+    clack.log.error(
+      'No Metro config file found. Expected: metro.config.js or metro.config.cjs',
+    );
+    return await showInstructions('metro.config.js'); // fallback for instructions
+  }
+
   if (!fs.existsSync(metroConfigPath)) {
-    const success = await createSentryExpoMetroConfig();
+    const success = await createSentryExpoMetroConfig(metroConfigPath);
     if (!success) {
       Sentry.setTag('expo-metro-config', 'create-new-error');
-      return await showInstructions();
+      return await showInstructions(metroConfigPath);
     }
     Sentry.setTag('expo-metro-config', 'created-new');
     return undefined;
@@ -31,14 +44,14 @@ export async function addSentryToExpoMetroConfig() {
   Sentry.setTag('expo-metro-config', 'exists');
   clack.log.info(`Updating existing ${metroConfigPath}.`);
 
-  const mod = await parseMetroConfig();
+  const mod = await parseMetroConfig(metroConfigPath);
   if (!mod) {
-    return await showInstructions();
+    return await showInstructions(metroConfigPath);
   }
 
   let didPatch = false;
   try {
-    didPatch = patchMetroInMemory(mod);
+    didPatch = patchMetroInMemory(mod, metroConfigPath);
   } catch (e) {
     Sentry.captureException('Unable to patch expo metro config');
   }
@@ -49,10 +62,10 @@ export async function addSentryToExpoMetroConfig() {
         metroConfigPath,
       )} with Sentry configuration.`,
     );
-    return await showInstructions();
+    return await showInstructions(metroConfigPath);
   }
 
-  const saved = await writeMetroConfig(mod);
+  const saved = await writeMetroConfig(mod, metroConfigPath);
   if (saved) {
     Sentry.setTag('expo-metro-config', 'patch-saved');
     clack.log.success(
@@ -65,11 +78,14 @@ export async function addSentryToExpoMetroConfig() {
         metroConfigPath,
       )}, please follow the manual steps.`,
     );
-    return await showInstructions();
+    return await showInstructions(metroConfigPath);
   }
 }
 
-export function patchMetroInMemory(mod: ProxifiedModule): boolean {
+export function patchMetroInMemory(
+  mod: ProxifiedModule,
+  metroConfigPath: string,
+): boolean {
   const ast = mod.$ast as t.Program;
 
   if (hasSentryContent(ast)) {
@@ -137,12 +153,15 @@ export function patchMetroInMemory(mod: ProxifiedModule): boolean {
     return false;
   }
 
-  addSentryExpoConfigRequire(ast);
+  addSentryExpoConfigRequire(ast, metroConfigPath);
 
   return true;
 }
 
-export function addSentryExpoConfigRequire(program: t.Program) {
+export function addSentryExpoConfigRequire(
+  program: t.Program,
+  metroConfigPath: string,
+) {
   try {
     const lastRequireIndex = getLastRequireIndex(program);
     const sentryExpoConfigRequire = createSentryExpoConfigRequire();
@@ -181,7 +200,9 @@ function createSentryExpoConfigRequire() {
   ]);
 }
 
-async function createSentryExpoMetroConfig(): Promise<boolean> {
+async function createSentryExpoMetroConfig(
+  metroConfigPath: string,
+): Promise<boolean> {
   const snippet = `const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
 const config = getSentryExpoConfig(__dirname);
@@ -207,7 +228,7 @@ module.exports = config;
   return true;
 }
 
-function showInstructions() {
+function showInstructions(metroConfigPath: string) {
   return showCopyPasteInstructions({
     filename: metroConfigPath,
     codeSnippet: getMetroWithSentryExpoConfigSnippet(true),

--- a/test/react-native/expo-metro.test.ts
+++ b/test/react-native/expo-metro.test.ts
@@ -19,7 +19,7 @@ config.resolver.assetExts.push(
 module.exports = config;
       `);
 
-    const result = patchMetroInMemory(mod);
+    const result = patchMetroInMemory(mod, 'metro.config.js');
     expect(result).toBe(true);
     expect(generateCode(mod.$ast).code).toBe(
       `
@@ -49,7 +49,7 @@ const config = getDefaultConfig(__dirname);
 module.exports = config;
       `);
 
-    const result = patchMetroInMemory(mod);
+    const result = patchMetroInMemory(mod, 'metro.config.js');
     expect(result).toBe(true);
     expect(generateCode(mod.$ast).code).toBe(
       `
@@ -71,7 +71,7 @@ module.exports = config;
 const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 `);
 
-    const result = patchMetroInMemory(mod);
+    const result = patchMetroInMemory(mod, 'metro.config.js');
     expect(result).toBe(false);
     expect(generateCode(mod.$ast).code).toBe(
       `

--- a/test/react-native/metro.test.ts
+++ b/test/react-native/metro.test.ts
@@ -8,10 +8,20 @@ import t = x.namedTypes;
 import {
   addSentrySerializerRequireToMetroConfig,
   addSentrySerializerToMetroConfig,
+  findMetroConfigPath,
   getMetroConfigObject,
   patchMetroWithSentryConfigInMemory,
 } from '../../src/react-native/metro';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  };
+});
 
 describe('patch metro config - sentry serializer', () => {
   describe('patchMetroWithSentryConfigInMemory', () => {
@@ -29,9 +39,11 @@ const config = {};
 
 module.exports = mergeConfig(getDefaultConfig(__dirname), config);`);
 
-      const result = await patchMetroWithSentryConfigInMemory(mod, async () => {
-        /* noop */
-      });
+      const result = await patchMetroWithSentryConfigInMemory(
+        mod,
+        'metro.config.js',
+        true,
+      );
       expect(result).toBe(true);
       expect(generateCode(mod.$ast).code)
         .toBe(`const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
@@ -70,9 +82,11 @@ module.exports = {
   },
 };`);
 
-      const result = await patchMetroWithSentryConfigInMemory(mod, async () => {
-        /* noop */
-      });
+      const result = await patchMetroWithSentryConfigInMemory(
+        mod,
+        'metro.config.js',
+        true,
+      );
       expect(result).toBe(true);
       expect(generateCode(mod.$ast).code).toBe(`const {
   withSentryConfig
@@ -102,9 +116,11 @@ module.exports = withSentryConfig({
 
 module.exports = testConfig;`);
 
-      const result = await patchMetroWithSentryConfigInMemory(mod, async () => {
-        /* noop */
-      });
+      const result = await patchMetroWithSentryConfigInMemory(
+        mod,
+        'metro.config.js',
+        true,
+      );
       expect(result).toBe(true);
       expect(generateCode(mod.$ast).code).toBe(`const {
   withSentryConfig
@@ -169,9 +185,11 @@ const config = {
 
 module.exports = mergeConfig(getDefaultConfig(__dirname), config);`);
 
-      const result = await patchMetroWithSentryConfigInMemory(mod, async () => {
-        /* noop */
-      });
+      const result = await patchMetroWithSentryConfigInMemory(
+        mod,
+        'metro.config.js',
+        true,
+      );
       expect(result).toBe(true);
       expect(generateCode(mod.$ast).code)
         .toBe(`const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
@@ -231,12 +249,34 @@ const config = {
 module.exports = withSentryConfig(mergeConfig(getDefaultConfig(__dirname), config));`);
     });
 
+    it('patches CJS style metro config', async () => {
+      const mod =
+        parseModule(`const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+
+const config = {};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), config);`);
+
+      const result = await patchMetroWithSentryConfigInMemory(
+        mod,
+        'metro.config.cjs',
+        true,
+      );
+      expect(result).toBe(true);
+
+      const code = generateCode(mod.$ast).code;
+      expect(code).toContain('require("@sentry/react-native/metro")');
+      expect(code).toContain('withSentryConfig');
+    });
+
     it('does not patch react native metro config exported as factory function', async () => {
       const mod = parseModule(`module.exports = () => ({});`);
 
-      const result = await patchMetroWithSentryConfigInMemory(mod, async () => {
-        /* noop */
-      });
+      const result = await patchMetroWithSentryConfigInMemory(
+        mod,
+        'metro.config.js',
+        true,
+      );
       expect(result).toBe(false);
       expect(generateCode(mod.$ast).code).toBe(`module.exports = () => ({});`);
     });
@@ -384,6 +424,44 @@ module.exports = {
         ).value,
       ).toBe('config');
     });
+  });
+});
+
+describe('Dynamic Metro Config path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('finds metro.config.js when it exists', () => {
+    vi.mocked(fs.existsSync).mockImplementation(
+      (path: string) => path === 'metro.config.js',
+    );
+
+    const result = findMetroConfigPath();
+    expect(result).toBe('metro.config.js');
+  });
+
+  it('finds metro.config.cjs when it exists', () => {
+    vi.mocked(fs.existsSync).mockImplementation(
+      (path: string) => path === 'metro.config.cjs',
+    );
+
+    const result = findMetroConfigPath();
+    expect(result).toBe('metro.config.cjs');
+  });
+
+  it('prefers metro.config.js over metro.config.cjs when both exist', () => {
+    vi.mocked(fs.existsSync).mockImplementation(() => true);
+
+    const result = findMetroConfigPath();
+    expect(result).toBe('metro.config.js');
+  });
+
+  it('returns undefined when no metro config exists', () => {
+    vi.mocked(fs.existsSync).mockImplementation(() => false);
+
+    const result = findMetroConfigPath();
+    expect(result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-wizard/issues/1046

## Description
Adds support for `metro.config.cjs` configuration files.
Note that the injected code is already by compatible with CommonJS.

<img width="1005" height="581" alt="Screenshot 2025-08-11 at 5 29 33 PM" src="https://github.com/user-attachments/assets/460cf59d-4c2c-441f-8426-1d2f4ef7301e" />
