### PR TITLE
chore(ci): Add concurrency config to prevent duplicate (outdated) runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,12 @@ on:
       - release/**
   pull_request:
 
+# Cancel in-progress runs when a new run is triggered (e.g. by a new commit)
+# Only apply to PRs to ensure all commits are tested on main branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   job_build:
     name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,12 @@
 #
 name: "CodeQL"
 
+# Cancel in-progress runs when a new run is triggered (e.g. by a new commit)
+# Only apply to PRs to ensure all commits are tested on main branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,5 +1,11 @@
 name: Danger
 
+# Cancel in-progress runs when a new run is triggered (e.g. by a new commit)
+# Only apply to PRs to ensure all commits are tested on main branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]


### PR DESCRIPTION
Inspired by https://github.com/getsentry/sentry-cocoa/pull/5838, this PR adds a concurrency config to our CI workflows (most importantly build, but decided to apply to the others as well for completeness)

- group by workflow and ref: new commits on an existing branch will cancel CI on old commits on the same exiting branch
- limit to pull request runs to ensure we still test every commit on `master`

#skip-changelog