### PR TITLE
Implement sentry-wizard issue 1092 in PR

### DIFF
--- a/src/apple/templates.ts
+++ b/src/apple/templates.ts
@@ -34,7 +34,6 @@ export const scriptInputPath =
 export function getSwiftSnippet(dsn: string, enableLogs: boolean): string {
   let snippet = `        SentrySDK.start { options in
             options.dsn = "${dsn}"
-            options.debug = true // Enabled debug when first installing is always helpful
 
             // Adds IP for users.
             // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/
@@ -72,7 +71,6 @@ export function getSwiftSnippet(dsn: string, enableLogs: boolean): string {
 export function getObjcSnippet(dsn: string, enableLogs: boolean): string {
   let snippet = `    [SentrySDK startWithConfigureOptions:^(SentryOptions * options) {
         options.dsn = @"${dsn}";
-        options.debug = YES; // Enabled debug when first installing is always helpful
 
         // Adds IP for users.
         // For more information, visit: https://docs.sentry.io/platforms/apple/data-management/data-collected/

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -172,9 +172,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "${dsn}",${performanceOptions}${logsOptions}
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
@@ -231,9 +228,6 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: "${dsn}",${integrationsOptions}${performanceOptions}${logsOptions}${replayOptions}
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii

--- a/src/nuxt/templates.ts
+++ b/src/nuxt/templates.ts
@@ -114,8 +114,6 @@ Sentry.init({
   // dsn: useRuntimeConfig().public.sentry.dsn,
   ${getConfigBody(dsn, 'client', selectedFeatures)}
   
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
 });
 `;
 }
@@ -129,8 +127,6 @@ function getSentryServerConfigContents(
 Sentry.init({
   ${getConfigBody(dsn, 'server', selectedFeatures)}
   
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
 });
 `;
 }


### PR DESCRIPTION
Remove `debug` configuration from Apple, Next.js, and Nuxt templates.

This change prevents debug logging from being enabled by default when setting up Sentry through the wizard, aligning with the request in #1092.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9a101e5-0f75-4269-a039-d06a8d529576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9a101e5-0f75-4269-a039-d06a8d529576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

