### PR TITLE
Updates Sentry bundle script injection to work with REACT_NATIVE_PATH env variable (which was used in older versions of RN)

### DIFF
--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -7,7 +7,7 @@ import {
   checkFileContents,
   checkIfReactNativeBundles,
   revertLocalChanges,
-  startWizardInstance
+  startWizardInstance,
 } from '../utils';
 import { afterAll, beforeAll, describe, test, expect } from 'vitest';
 
@@ -31,7 +31,8 @@ describe('ReactNative', () => {
         // Selecting `yarn` as the package manager
         [KEYS.DOWN, KEYS.DOWN, KEYS.ENTER],
         'Do you want to enable Session Replay to help debug issues? (See https://docs.sentry.io/platforms/react-native/session-replay/)',
-      ), {
+      ),
+      {
         timeout: 240_000,
       });
 
@@ -192,7 +193,7 @@ defaults.url=https://sentry.io/`,
     }
     checkFileContents(
       `${projectDir}/ios/reactnative078.xcodeproj/project.pbxproj`,
-      `../node_modules/@sentry/react-native/scripts/sentry-xcode.sh`,
+      `@sentry/react-native/scripts/sentry-xcode.sh`,
     );
     checkFileContents(
       `${projectDir}/ios/reactnative078.xcodeproj/project.pbxproj`,

--- a/src/react-native/xcode.ts
+++ b/src/react-native/xcode.ts
@@ -93,6 +93,11 @@ export function addSentryWithBundledScriptsToBundleShellScript(
       .replace(
         'react-native/scripts/react-native-xcode.sh',
         '@sentry/react-native/scripts/sentry-xcode.sh',
+      )
+      // that might be needed for older versions of React Native (< 0.81)
+      .replace(
+        '$REACT_NATIVE_PATH/scripts/react-native-xcode.sh',
+        '$REACT_NATIVE_PATH/../@sentry/react-native/scripts/sentry-xcode.sh',
       );
   }
 

--- a/test/react-native/xcode.test.ts
+++ b/test/react-native/xcode.test.ts
@@ -51,6 +51,28 @@ SENTRY_XCODE="../node_modules/@sentry/react-native/scripts/sentry-xcode.sh"
       );
     });
 
+    it('adds sentry cli to rn bundle build phase for versions of RN that use REACT_NATIVE_PATH env variable', () => {
+      const input = `set -e
+
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+REACT_NATIVE_XCODE="$REACT_NATIVE_PATH/scripts/react-native-xcode.sh"
+
+/bin/sh -c "$WITH_ENVIRONMENT $REACT_NATIVE_XCODE"`;
+      // actual shell script looks like this:
+      // /bin/sh -c "$WITH_ENVIRONMENT \"$REACT_NATIVE_XCODE\""
+      // but during parsing xcode library removes the quotes
+      const expectedOutput = `set -e
+
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+SENTRY_XCODE="$REACT_NATIVE_PATH/../@sentry/react-native/scripts/sentry-xcode.sh"
+
+/bin/sh -c "$WITH_ENVIRONMENT $SENTRY_XCODE"`;
+
+      expect(addSentryWithBundledScriptsToBundleShellScript(input)).toBe(
+        expectedOutput,
+      );
+    });
+
     it('does not add sentry cli to rn bundle build phase if $REACT_NATIVE_XCODE is not present and shows code snippet', () => {
       const input = `set -e
   


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-wizard/pull/1098#issuecomment-3401188136