### PR TITLE
chore(vscode): Update formatter settings for TypeScript and JavaScript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,12 @@
 {
-
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
       },
-    
       "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
       },
-    
     "search.exclude": {
         "**/node_modules": true,
         "**/bower_components": true,


### PR DESCRIPTION
We didn't have a formatter in the settings so it takes the global one (for me that's biome ;) ). 

Adding this to the workspace vscode/cursor settings ensures that Prettier is always used when formatting files in the repo, regardless of each dev global config.

Also removed the `prettier.typescriptEnable` as it's deprecated. Same with `tslint`.