### PR TITLE
chore: Update changelog for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,22 @@
 
 ### Features
 
-- feat(nextjs): Add --spotlight support
-  ([#1119](https://github.com/getsentry/sentry-wizard/pull/1119))
+- feat: Add wizard for `react-router` framework mode ([#1076](https://github.com/getsentry/sentry-wizard/pull/1076))
+
+  This release adds a new wizard setup flow for React Router (framework): 
+  ```sh
+  npx @sentry/wizard@latest -i reactRouter
+  ```
+- feat(nextjs): Add --spotlight support ([#1119](https://github.com/getsentry/sentry-wizard/pull/1119))
+
+  This release adds a new mode for setting up the Sentry SDK in NextJS for Spotlight.
+  When running
+  
+  ```sh
+  npx @sentry/wizard@latest -i nextjs --spotlight
+  ```
+  the NextJS SDK will be configured to only send its telemetry to Spotlight. 
+  No Sentry account is required to complete this flow.
 
 
 ## 6.6.1


### PR DESCRIPTION
Usually, we update the changelog directly in respective PRs. This time, an entry was lost and I decided to add a bit more description to each change. 

#skip-changelog