### PR TITLE
feat: Add a section to contributing doc about the url  parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Features
-
-- Add a section to the contributing doc about the url parameter ([#1130](https://github.com/getsentry/sentry-wizard/pull/1130))
-
 ### Fixes
 
 - Change fastlane injection to `sentry_debug_files_upload` instead of `sentry_cli` ([#1125](https://github.com/getsentry/sentry-wizard/pull/1125))


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/TET-1385/dev-docs-for-debugging-wizard-wizard-ui

#skip-changelog