### PR TITLE
feat(cloudflare): Support wrapping workers main file

### DIFF
--- a/e2e-tests/tests/cloudflare-worker.test.ts
+++ b/e2e-tests/tests/cloudflare-worker.test.ts
@@ -76,4 +76,12 @@ describe('cloudflare-worker', () => {
       '"binding": "CF_VERSION_METADATA"',
     ]);
   });
+
+  it('modifies the worker file to include Sentry initialization', () => {
+    checkFileContents(`${projectDir}/src/index.ts`, [
+      'import * as Sentry from "@sentry/cloudflare";',
+      'export default Sentry.withSentry(env => ({',
+      'dsn: "https://public@dsn.ingest.sentry.io/1337",',
+    ]);
+  });
 });

--- a/src/cloudflare/sdk-setup.ts
+++ b/src/cloudflare/sdk-setup.ts
@@ -1,21 +1,76 @@
 // @ts-expect-error - clack is ESM and TS complains about that. It works though
 import clack from '@clack/prompts';
 import chalk from 'chalk';
-import { getCloudflareWorkerTemplate } from './templates';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  getCloudflareWorkerTemplate,
+  getCloudflareWorkerTemplateWithHandler,
+} from './templates';
+import {
+  defaultEntryPoint,
+  getEntryPointFromWranglerConfig,
+} from './wrangler/get-entry-point-from-wrangler-config';
+import { wrapWorkerWithSentry } from './wrap-worker';
 
 /**
- * Prints the Sentry worker template to the console.
- * Currently focused on Cloudflare Workers, but the structure can be
- * extended for other Cloudflare products in the future.
+ * Creates or updates the main worker file with Sentry initialization.
+ * Currently focused on Cloudflare Workers
  */
-export function createSentryInitFile(
+export async function createSentryInitFile(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
   },
-): void {
-  clack.log.step('Please wrap your handler with Sentry initialization:');
+): Promise<void> {
+  const entryPointFromConfig = getEntryPointFromWranglerConfig();
 
-  // eslint-disable-next-line no-console
-  console.log(chalk.cyan(getCloudflareWorkerTemplate(dsn, selectedFeatures)));
+  if (!entryPointFromConfig) {
+    clack.log.info(
+      'No entry point found in wrangler config, creating a new one.',
+    );
+
+    const cloudflareWorkerTemplate = getCloudflareWorkerTemplateWithHandler();
+
+    await fs.promises.mkdir(
+      path.join(process.cwd(), path.dirname(defaultEntryPoint)),
+      {
+        recursive: true,
+      },
+    );
+    await fs.promises.writeFile(
+      path.join(process.cwd(), defaultEntryPoint),
+      cloudflareWorkerTemplate,
+      { encoding: 'utf-8', flag: 'w' },
+    );
+
+    clack.log.success(`Created ${chalk.cyan(defaultEntryPoint)}.`);
+
+    return;
+  }
+
+  const entryPointPath = path.join(process.cwd(), entryPointFromConfig);
+
+  if (fs.existsSync(entryPointPath)) {
+    clack.log.info(
+      `Found existing entry point: ${chalk.cyan(entryPointFromConfig)}`,
+    );
+
+    try {
+      await wrapWorkerWithSentry(entryPointPath, dsn, selectedFeatures);
+      clack.log.success(
+        `Wrapped ${chalk.cyan(
+          entryPointFromConfig,
+        )} with Sentry initialization.`,
+      );
+    } catch (error) {
+      clack.log.warn('Failed to wrap worker automatically.');
+      clack.log.step('Please wrap your handler with Sentry initialization:');
+
+      clack.note(
+        chalk.cyan(getCloudflareWorkerTemplate(dsn, selectedFeatures)),
+      );
+    }
+    return;
+  }
 }

--- a/src/cloudflare/templates.ts
+++ b/src/cloudflare/templates.ts
@@ -26,3 +26,20 @@ export default Sentry.withSentry(
 );
 `;
 }
+
+export function getCloudflareWorkerTemplateWithHandler(): string {
+  return `export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		const url = new URL(request.url);
+		switch (url.pathname) {
+			case '/message':
+				return new Response('Hello, World!');
+			case '/random':
+				return new Response(crypto.randomUUID());
+			default:
+				return new Response('Not Found', { status: 404 });
+		}
+	},
+} satisfies ExportedHandler<Env>;
+`;
+}

--- a/src/cloudflare/wrangler/get-entry-point-from-wrangler-config.ts
+++ b/src/cloudflare/wrangler/get-entry-point-from-wrangler-config.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { findWranglerConfig } from './find-wrangler-config';
 import { parseJsonC, getObjectProperty } from '../../utils/ast-utils';
 
+export const defaultEntryPoint = 'src/index.ts';
+
 /**
  * Reads the main entry point from the wrangler config file
  * Returns undefined if no config exists or if main field is not specified

--- a/src/cloudflare/wrap-worker.ts
+++ b/src/cloudflare/wrap-worker.ts
@@ -1,0 +1,119 @@
+import * as recast from 'recast';
+import type { namedTypes as t } from 'ast-types';
+// @ts-expect-error - magicast is ESM and TS complains about that. It works though
+import { loadFile, writeFile } from 'magicast';
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import * as clack from '@clack/prompts';
+import { hasSentryContent } from '../utils/ast-utils';
+import chalk from 'chalk';
+import { ExpressionKind } from 'ast-types/lib/gen/kinds';
+
+const b = recast.types.builders;
+
+/**
+ * Wraps a Cloudflare Worker's default export with Sentry.withSentry()
+ *
+ * Before:
+ * ```
+ * export default {
+ *   async fetch(request, env, ctx) { ... }
+ * } satisfies ExportedHandler<Env>;
+ * ```
+ *
+ * After:
+ * ```
+ * import * as Sentry from '@sentry/cloudflare';
+ *
+ * export default Sentry.withSentry(
+ *   (env) => ({
+ *     dsn: 'your-dsn',
+ *     tracesSampleRate: 1,
+ *   }),
+ *   {
+ *     async fetch(request, env, ctx) { ... }
+ *   } satisfies ExportedHandler<Env>
+ * );
+ * ```
+ *
+ * @param workerFilePath - Path to the worker file to wrap
+ * @param dsn - Sentry DSN for initialization
+ * @param selectedFeatures - Feature flags for optional Sentry features
+ */
+export async function wrapWorkerWithSentry(
+  workerFilePath: string,
+  dsn: string,
+  selectedFeatures: {
+    performance: boolean;
+  },
+): Promise<void> {
+  const workerAst = await loadFile(workerFilePath);
+
+  if (hasSentryContent(workerAst.$ast as t.Program)) {
+    clack.log.warn(
+      `Sentry is already configured in ${chalk.cyan(
+        workerFilePath,
+      )}. Skipping wrapping with Sentry.`,
+    );
+    return;
+  }
+
+  workerAst.imports.$add({
+    from: '@sentry/cloudflare',
+    imported: '*',
+    local: 'Sentry',
+  });
+
+  recast.visit(workerAst.$ast, {
+    visitExportDefaultDeclaration(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const originalDeclaration = path.value.declaration as ExpressionKind;
+      const sentryConfig = createSentryConfigFunction(dsn, selectedFeatures);
+      const wrappedExport = b.callExpression(
+        b.memberExpression(b.identifier('Sentry'), b.identifier('withSentry')),
+        [sentryConfig, originalDeclaration],
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      path.value.declaration = wrappedExport;
+
+      return false;
+    },
+  });
+
+  await writeFile(workerAst.$ast, workerFilePath);
+}
+
+/**
+ * Creates the Sentry config function: (env) => ({ dsn: '...', ... })
+ */
+function createSentryConfigFunction(
+  dsn: string,
+  selectedFeatures: {
+    performance: boolean;
+  },
+): t.ArrowFunctionExpression {
+  const configProperties: t.ObjectProperty[] = [
+    b.objectProperty(b.identifier('dsn'), b.stringLiteral(dsn)),
+  ];
+
+  if (selectedFeatures.performance) {
+    const tracesSampleRateProperty = b.objectProperty(
+      b.identifier('tracesSampleRate'),
+      b.numericLiteral(1),
+    );
+
+    tracesSampleRateProperty.comments = [
+      b.commentLine(
+        ' Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.',
+        true,
+        false,
+      ),
+    ];
+
+    configProperties.push(tracesSampleRateProperty);
+  }
+
+  const configObject = b.objectExpression(configProperties);
+
+  return b.arrowFunctionExpression([b.identifier('env')], configObject);
+}

--- a/test/cloudflare/__snapshots__/wrap-worker.test.ts.snap
+++ b/test/cloudflare/__snapshots__/wrap-worker.test.ts.snap
@@ -1,0 +1,134 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`wrapWorkerWithSentry > DSN handling > uses the provided DSN 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+export default Sentry.withSentry(env => ({
+  dsn: "https://d7a9abbecd95ed7d0f5b6c965f5fb6ba@o447951.ingest.us.sentry.io/4510147615391744"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello');
+  }
+});"
+`;
+
+exports[`wrapWorkerWithSentry > basic wrapping > preserves complex handler logic 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    const url = new URL(request.url);
+    switch (url.pathname) {
+      case '/message':
+        return new Response('Hello, World!');
+      case '/random':
+        return new Response(crypto.randomUUID());
+      default:
+        return new Response('Not Found', { status: 404 });
+    }
+  },
+} satisfies ExportedHandler<Env>);"
+`;
+
+exports[`wrapWorkerWithSentry > basic wrapping > wraps a simple worker export with Sentry 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+export default Sentry.withSentry(env => ({
+  dsn: "my-test-dsn"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello World!');
+  },
+} satisfies ExportedHandler<Env>);"
+`;
+
+exports[`wrapWorkerWithSentry > edge cases > handles files with no default export gracefully 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+const helper = () => 'test';
+export { helper };"
+`;
+
+exports[`wrapWorkerWithSentry > edge cases > handles worker without satisfies clause 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello');
+  }
+});"
+`;
+
+exports[`wrapWorkerWithSentry > idempotency > does not wrap again if Sentry is already present 1`] = `
+"import * as Sentry from '@sentry/cloudflare';
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: 'existing-dsn',
+  }),
+  {
+    async fetch(request, env, ctx): Promise<Response> {
+      return new Response('Already wrapped');
+    },
+  },
+);
+"
+`;
+
+exports[`wrapWorkerWithSentry > import handling > adds Sentry import at the beginning of the file 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+// Worker comment
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Test');
+  }
+});"
+`;
+
+exports[`wrapWorkerWithSentry > import handling > preserves an external default export 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+import myWorker from './simple';
+
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn"
+}), myWorker);"
+`;
+
+exports[`wrapWorkerWithSentry > import handling > preserves existing imports 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+import { someHelper } from './helpers';
+
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response(someHelper());
+  }
+});"
+`;
+
+exports[`wrapWorkerWithSentry > performance monitoring > includes tracesSampleRate when performance is enabled 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn",
+
+  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+  tracesSampleRate: 1
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello');
+  }
+});"
+`;
+
+exports[`wrapWorkerWithSentry > performance monitoring > omits tracesSampleRate when performance is disabled 1`] = `
+"import * as Sentry from "@sentry/cloudflare";
+export default Sentry.withSentry(env => ({
+  dsn: "my-dsn"
+}), {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello');
+  }
+});"
+`;

--- a/test/cloudflare/fixtures/worker/already-wrapped.ts
+++ b/test/cloudflare/fixtures/worker/already-wrapped.ts
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/cloudflare';
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: 'existing-dsn',
+  }),
+  {
+    async fetch(request, env, ctx): Promise<Response> {
+      return new Response('Already wrapped');
+    },
+  },
+);

--- a/test/cloudflare/fixtures/worker/complex-handler.ts
+++ b/test/cloudflare/fixtures/worker/complex-handler.ts
@@ -1,0 +1,13 @@
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const url = new URL(request.url);
+    switch (url.pathname) {
+      case '/message':
+        return new Response('Hello, World!');
+      case '/random':
+        return new Response(crypto.randomUUID());
+      default:
+        return new Response('Not Found', { status: 404 });
+    }
+  },
+} satisfies ExportedHandler<Env>;

--- a/test/cloudflare/fixtures/worker/external-default-export.ts
+++ b/test/cloudflare/fixtures/worker/external-default-export.ts
@@ -1,0 +1,3 @@
+import myWorker from './simple';
+
+export default myWorker;

--- a/test/cloudflare/fixtures/worker/no-default-export.ts
+++ b/test/cloudflare/fixtures/worker/no-default-export.ts
@@ -1,0 +1,2 @@
+const helper = () => 'test';
+export { helper };

--- a/test/cloudflare/fixtures/worker/simple-with-satisfies.ts
+++ b/test/cloudflare/fixtures/worker/simple-with-satisfies.ts
@@ -1,0 +1,5 @@
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello World!');
+  },
+} satisfies ExportedHandler<Env>;

--- a/test/cloudflare/fixtures/worker/simple.ts
+++ b/test/cloudflare/fixtures/worker/simple.ts
@@ -1,0 +1,5 @@
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Hello');
+  },
+};

--- a/test/cloudflare/fixtures/worker/with-comment.ts
+++ b/test/cloudflare/fixtures/worker/with-comment.ts
@@ -1,0 +1,6 @@
+// Worker comment
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response('Test');
+  },
+};

--- a/test/cloudflare/fixtures/worker/with-import.ts
+++ b/test/cloudflare/fixtures/worker/with-import.ts
@@ -1,0 +1,7 @@
+import { someHelper } from './helpers';
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response(someHelper());
+  },
+};

--- a/test/cloudflare/fixtures/worker/with-sentry-import.ts
+++ b/test/cloudflare/fixtures/worker/with-sentry-import.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/cloudflare';
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    Sentry.captureMessage('test');
+    return new Response('Test');
+  },
+};

--- a/test/cloudflare/sdk-setup.test.ts
+++ b/test/cloudflare/sdk-setup.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { createSentryInitFile } from '../../src/cloudflare/sdk-setup';
+import { defaultEntryPoint } from '../../src/cloudflare/wrangler/get-entry-point-from-wrangler-config';
+import * as templates from '../../src/cloudflare/templates';
+import * as wrapWorker from '../../src/cloudflare/wrap-worker';
+
+const { clackMocks } = vi.hoisted(() => {
+  const info = vi.fn();
+  const warn = vi.fn();
+  const success = vi.fn();
+  const step = vi.fn();
+  const note = vi.fn();
+
+  return {
+    clackMocks: {
+      info,
+      warn,
+      success,
+      step,
+      note,
+    },
+  };
+});
+
+vi.mock('@clack/prompts', () => ({
+  __esModule: true,
+  default: {
+    log: {
+      info: clackMocks.info,
+      warn: clackMocks.warn,
+      success: clackMocks.success,
+      step: clackMocks.step,
+    },
+    note: clackMocks.note,
+  },
+}));
+
+const { getEntryPointFromWranglerConfigMock } = vi.hoisted(() => ({
+  getEntryPointFromWranglerConfigMock: vi.fn(),
+}));
+
+vi.mock(
+  '../../src/cloudflare/wrangler/get-entry-point-from-wrangler-config',
+  () => ({
+    getEntryPointFromWranglerConfig: getEntryPointFromWranglerConfigMock,
+    defaultEntryPoint: 'src/index.ts',
+  }),
+);
+
+describe('createSentryInitFile', () => {
+  let tmpDir: string;
+  const testDsn = 'https://example@sentry.io/123';
+  const testFeatures = {
+    performance: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sdk-setup-test-'));
+
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+
+    vi.restoreAllMocks();
+  });
+
+  it('creates a new default entry point file', async () => {
+    const template =
+      'export default { async fetch() { return new Response("ᕕ(⌐■_■)ᕗ ♪♬"); } }';
+    const getCloudflareWorkerTemplateWithHandlerSpy = vi
+      .spyOn(templates, 'getCloudflareWorkerTemplateWithHandler')
+      .mockReturnValue(template);
+
+    await createSentryInitFile(testDsn, testFeatures);
+
+    const expectedPath = path.join(tmpDir, 'src/index.ts');
+    const content = fs.readFileSync(expectedPath, 'utf-8');
+
+    expect(clackMocks.info).toHaveBeenCalledWith(
+      'No entry point found in wrangler config, creating a new one.',
+    );
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    expect(content).toBe(template);
+    expect(clackMocks.success).toHaveBeenCalledWith('Created src/index.ts.');
+    expect(getCloudflareWorkerTemplateWithHandlerSpy).toHaveBeenCalled();
+  });
+
+  describe('when entry point is found in wrangler config', () => {
+    describe('and the entry point file exists', () => {
+      beforeEach(async () => {
+        await createSentryInitFile(testDsn, testFeatures);
+        getEntryPointFromWranglerConfigMock.mockReturnValue(defaultEntryPoint);
+      });
+
+      it('wraps the worker with Sentry when wrapping succeeds', async () => {
+        const wrapWorkerWithSentrySpy = vi
+          .spyOn(wrapWorker, 'wrapWorkerWithSentry')
+          .mockResolvedValue(undefined);
+
+        await createSentryInitFile(testDsn, testFeatures);
+
+        expect(wrapWorkerWithSentrySpy).toHaveBeenCalledWith(
+          path.join(tmpDir, defaultEntryPoint),
+          testDsn,
+          testFeatures,
+        );
+      });
+
+      it('handles wrapping failure gracefully', async () => {
+        vi.spyOn(wrapWorker, 'wrapWorkerWithSentry').mockRejectedValue(
+          new Error('Wrapping failed'),
+        );
+
+        await createSentryInitFile(testDsn, testFeatures);
+
+        expect(clackMocks.warn).toHaveBeenCalledWith(
+          'Failed to wrap worker automatically.',
+        );
+        expect(clackMocks.step).toHaveBeenCalledWith(
+          'Please wrap your handler with Sentry initialization:',
+        );
+        expect(clackMocks.note).toHaveBeenCalledWith(
+          expect.stringContaining('import * as Sentry'),
+        );
+      });
+
+      it('shows template with correct DSN when wrapping fails', async () => {
+        vi.spyOn(wrapWorker, 'wrapWorkerWithSentry').mockRejectedValue(
+          new Error('Failed'),
+        );
+        const getCloudflareWorkerTemplateSpy = vi
+          .spyOn(templates, 'getCloudflareWorkerTemplate')
+          .mockReturnValue('template with dsn');
+
+        await createSentryInitFile(testDsn, testFeatures);
+
+        expect(getCloudflareWorkerTemplateSpy).toHaveBeenCalledWith(
+          testDsn,
+          testFeatures,
+        );
+        expect(clackMocks.note).toHaveBeenCalledWith('template with dsn');
+      });
+
+      it('passes performance feature flag correctly', async () => {
+        const wrapWorkerWithSentrySpy = vi
+          .spyOn(wrapWorker, 'wrapWorkerWithSentry')
+          .mockResolvedValue(undefined);
+
+        await createSentryInitFile(testDsn, { performance: false });
+
+        expect(wrapWorkerWithSentrySpy).toHaveBeenCalledWith(
+          path.join(tmpDir, defaultEntryPoint),
+          testDsn,
+          { performance: false },
+        );
+      });
+    });
+
+    describe('and the entry point file does not exist', () => {
+      it('does not throw an error', async () => {
+        vi.spyOn(wrapWorker, 'wrapWorkerWithSentry').mockResolvedValue(
+          undefined,
+        );
+
+        await expect(
+          createSentryInitFile(testDsn, testFeatures),
+        ).resolves.not.toThrow();
+      });
+
+      it('does not call wrapWorkerWithSentry', async () => {
+        const wrapWorkerWithSentrySpy = vi
+          .spyOn(wrapWorker, 'wrapWorkerWithSentry')
+          .mockResolvedValue(undefined);
+
+        await createSentryInitFile(testDsn, testFeatures);
+
+        expect(wrapWorkerWithSentrySpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/test/cloudflare/wrap-worker.test.ts
+++ b/test/cloudflare/wrap-worker.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { wrapWorkerWithSentry } from '../../src/cloudflare/wrap-worker';
+
+describe('wrapWorkerWithSentry', () => {
+  const fixturesDir = path.join(__dirname, 'fixtures', 'worker');
+  let tmpDir: string;
+
+  function copyFixture(fixtureName: string): string {
+    const content = fs.readFileSync(
+      path.join(fixturesDir, fixtureName),
+      'utf-8',
+    );
+    const targetPath = path.join(tmpDir, 'worker.ts');
+    fs.writeFileSync(targetPath, content);
+    return targetPath;
+  }
+
+  function readResult(): string {
+    return fs.readFileSync(path.join(tmpDir, 'worker.ts'), 'utf-8');
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wrap-worker-'));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+
+    vi.restoreAllMocks();
+  });
+
+  describe('basic wrapping', () => {
+    it('wraps a simple worker export with Sentry', async () => {
+      const filePath = copyFixture('simple-with-satisfies.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-test-dsn', {
+        performance: false,
+      });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('preserves complex handler logic', async () => {
+      const filePath = copyFixture('complex-handler.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('performance monitoring', () => {
+    it('includes tracesSampleRate when performance is enabled', async () => {
+      const filePath = copyFixture('simple.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: true });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('omits tracesSampleRate when performance is disabled', async () => {
+      const filePath = copyFixture('simple.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('import handling', () => {
+    it('adds Sentry import at the beginning of the file', async () => {
+      const filePath = copyFixture('with-comment.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('preserves existing imports', async () => {
+      const filePath = copyFixture('with-import.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('preserves an external default export', async () => {
+      const filePath = copyFixture('external-default-export.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('idempotency', () => {
+    it('does not wrap again if Sentry is already present', async () => {
+      const filePath = copyFixture('already-wrapped.ts');
+      const originalContent = fs.readFileSync(
+        path.join(fixturesDir, 'already-wrapped.ts'),
+        'utf-8',
+      );
+
+      await wrapWorkerWithSentry(filePath, 'new-dsn', { performance: true });
+
+      const result = readResult();
+
+      expect(result).toBe(originalContent);
+    });
+
+    it('does not modify if @sentry/cloudflare is imported', async () => {
+      const filePath = copyFixture('with-sentry-import.ts');
+      const originalContent = fs.readFileSync(
+        path.join(fixturesDir, 'with-sentry-import.ts'),
+        'utf-8',
+      );
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toBe(originalContent);
+    });
+  });
+
+  describe('DSN handling', () => {
+    it('uses the provided DSN', async () => {
+      const filePath = copyFixture('simple.ts');
+
+      const testDsn =
+        'https://d7a9abbecd95ed7d0f5b6c965f5fb6ba@o447951.ingest.us.sentry.io/4510147615391744';
+
+      await wrapWorkerWithSentry(filePath, testDsn, { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles worker without satisfies clause', async () => {
+      const filePath = copyFixture('simple.ts');
+
+      await wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false });
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('handles files with no default export gracefully', async () => {
+      const filePath = copyFixture('no-default-export.ts');
+
+      await expect(
+        wrapWorkerWithSentry(filePath, 'my-dsn', { performance: false }),
+      ).resolves.not.toThrow();
+
+      const result = readResult();
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
(closes #1155)
(closes [WIZARD-115](https://linear.app/getsentry/issue/WIZARD-115/cloudflare-update-workers-default-export))

This adds support for the Wizard to automatically wrap the default export of the Cloudflare Workers with `Sentry.withSentry`.

As of now no support for e.g. logging has been added (so the template stayed the same as the printed one from before). 

The traceStep "Update Wrangler config with Sentry requirements" has moved down, as it will create a default entry file automatically if there is none, and will then update the `wrangler.jsonc` with the correct main file in case that was not given just yet. This is actually an edge case but a possibility.