### PR TITLE
refactor(mcp): Enhance MCP configuration functions to return results

### DIFF
--- a/test/utils/clack/mcp-config.test.ts
+++ b/test/utils/clack/mcp-config.test.ts
@@ -134,10 +134,10 @@ describe('mcp-config', () => {
       );
 
       expect(clack.log.success).toHaveBeenCalledWith(
-        expect.stringContaining('.cursor/mcp.json'),
+        expect.stringContaining('.cursor/mcp.json created'),
       );
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Added project-scoped Sentry MCP configuration for Cursor.',
+        'Added project-scoped Sentry MCP configuration.',
       );
       expect(clack.log.info).toHaveBeenCalledWith(
         expect.stringContaining('reload your editor'),
@@ -249,7 +249,7 @@ describe('mcp-config', () => {
       expect(writtenContent.mcpServers).toHaveProperty('Sentry');
 
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Updated .cursor/mcp.json',
+        expect.stringContaining('.cursor/mcp.json updated'),
       );
     });
 
@@ -289,7 +289,7 @@ describe('mcp-config', () => {
       expect(writtenContent.servers?.Sentry).toHaveProperty('type', 'http');
 
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Updated .vscode/mcp.json',
+        expect.stringContaining('.vscode/mcp.json updated'),
       );
     });
 
@@ -326,7 +326,9 @@ describe('mcp-config', () => {
       expect(writtenContent.mcpServers).toHaveProperty('OtherServer');
       expect(writtenContent.mcpServers).toHaveProperty('Sentry');
 
-      expect(clack.log.success).toHaveBeenCalledWith('Updated .mcp.json');
+      expect(clack.log.success).toHaveBeenCalledWith(
+        expect.stringContaining('.mcp.json updated'),
+      );
     });
 
     it('should configure for OpenCode when selected', async () => {
@@ -367,10 +369,10 @@ describe('mcp-config', () => {
       expect(writtenContent.mcp?.Sentry?.oauth).toEqual({});
 
       expect(clack.log.success).toHaveBeenCalledWith(
-        expect.stringContaining('opencode.json'),
+        expect.stringContaining('opencode.json created'),
       );
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Added project-scoped Sentry MCP configuration for OpenCode.',
+        'Added project-scoped Sentry MCP configuration.',
       );
       expect(clack.log.info).toHaveBeenCalledWith(
         expect.stringContaining('restart OpenCode'),
@@ -412,7 +414,9 @@ describe('mcp-config', () => {
       expect(writtenContent.mcp).toHaveProperty('Sentry');
       expect(writtenContent.mcp?.Sentry).toHaveProperty('type', 'remote');
 
-      expect(clack.log.success).toHaveBeenCalledWith('Updated opencode.json');
+      expect(clack.log.success).toHaveBeenCalledWith(
+        expect.stringContaining('opencode.json updated'),
+      );
     });
 
     it('should handle file write errors gracefully for OpenCode', async () => {
@@ -649,7 +653,7 @@ describe('mcp-config', () => {
       expect(writtenContent.servers).toHaveProperty('Sentry');
 
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Updated .vscode/mcp.json',
+        expect.stringContaining('.vscode/mcp.json updated'),
       );
     });
 
@@ -959,15 +963,18 @@ describe('mcp-config', () => {
         'utf8',
       );
 
-      // Should show success messages for each (twice per editor: filename + editor-specific message)
+      // Should show consolidated success message for all created files
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Added project-scoped Sentry MCP configuration for Cursor.',
+        expect.stringContaining('.cursor/mcp.json'),
       );
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Added project-scoped Sentry MCP configuration for VS Code.',
+        expect.stringContaining('.vscode/mcp.json'),
       );
       expect(clack.log.success).toHaveBeenCalledWith(
-        'Added project-scoped Sentry MCP configuration for Claude Code.',
+        expect.stringContaining('.mcp.json'),
+      );
+      expect(clack.log.success).toHaveBeenCalledWith(
+        'Added project-scoped Sentry MCP configuration.',
       );
     });
 


### PR DESCRIPTION
This pull request refactors the MCP configuration utility to provide more consolidated and informative feedback when configuring multiple editors. Instead of logging individual success messages for each editor, the code now collects the results and outputs a single, combined summary indicating which configuration files were created or updated. The test suite is also updated to reflect these changes.

Key changes:

**Refactoring configuration functions:**

* The `addCursorMcpConfig`, `addVsCodeMcpConfig`, `addClaudeCodeMcpConfig`, and `addOpenCodeMcpConfig` functions now return a result object indicating the filename and whether the file was created or updated, instead of logging directly or returning void. [[1]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342R146-R163) [[2]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L169-R172) [[3]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L178-R190) [[4]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L199-R200) [[5]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L208-R218) [[6]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L226-R227) [[7]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L235-R245) [[8]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L256-R257)

**Consolidated logging in project-scoped configuration:**

* The main `offerProjectScopedMcpConfig` function now aggregates the results from all editor configuration functions and logs a single, consolidated success message summarizing which files were created or updated, along with a unified note about reloading or restarting editors. [[1]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342R538-R541) [[2]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342L545-R562) [[3]](diffhunk://#diff-10917aeef690c9f529c8f988cf7edf718b9c3433c9dfbcc0317b7ba48a794342R611-R636)

**Test updates:**

* Tests are updated to expect the new consolidated log messages, checking for strings containing the relevant filenames and the new summary message, instead of the previous per-editor messages. [[1]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L137-R140) [[2]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L252-R252) [[3]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L292-R292) [[4]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L329-R331) [[5]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L370-R375) [[6]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L415-R419) [[7]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L652-R656) [[8]](diffhunk://#diff-e7b1516810c38c3f7f1dce9833d0c41dc68e927121b835a3f0ace56a570ddbb9L962-R977)- Updated `addCursorMcpConfig`, `addVsCodeMcpConfig`, `addClaudeCodeMcpConfig`, and `addOpenCodeMcpConfig` functions to return an object indicating the filename and action (created/updated) instead of logging directly.
- Consolidated success messages in `offerProjectScopedMcpConfig` to provide a summary of created and updated files.
- Improved logging for better clarity and consistency across MCP configuration processes.

<img width="1644" height="408" alt="image" src="https://github.com/user-attachments/assets/348e6d0f-7569-40c7-bd55-4026b1ec325d" />
