### PR TITLE
chore(test): Migrate NextJS e2e tests to use clifty

### DIFF
--- a/e2e-tests/tests/nextjs-14.test.ts
+++ b/e2e-tests/tests/nextjs-14.test.ts
@@ -10,18 +10,19 @@ import {
   checkPackageJson,
   getWizardCommand,
 } from '../utils';
-import { afterAll, beforeAll, describe, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 //@ts-expect-error - clifty is ESM only
 import { KEYS, withEnv } from 'clifty';
 
 describe('NextJS-14', () => {
   const integration = Integration.nextjs;
+  let wizardExitCode: number;
 
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-14-test-app');
 
   beforeAll(async () => {
-    await withEnv({
+    wizardExitCode = await withEnv({
       cwd: projectDir,
     })
       .defineInteraction()
@@ -57,6 +58,10 @@ describe('NextJS-14', () => {
 
   afterAll(() => {
     cleanup();
+  });
+
+  test('exits with exit code 0', () => {
+    expect(wizardExitCode).toBe(0);
   });
 
   test('package.json is updated correctly', () => {

--- a/e2e-tests/tests/nextjs-15.test.ts
+++ b/e2e-tests/tests/nextjs-15.test.ts
@@ -23,11 +23,12 @@ import { KEYS, withEnv } from 'clifty';
 
 describe('NextJS-15', () => {
   const integration = Integration.nextjs;
+  let wizardExitCode: number;
 
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
 
   beforeAll(async () => {
-    await withEnv({
+    wizardExitCode = await withEnv({
       cwd: projectDir,
     })
       .defineInteraction()
@@ -64,6 +65,10 @@ describe('NextJS-15', () => {
 
   afterAll(() => {
     cleanup();
+  });
+
+  test('exits with exit code 0', () => {
+    expect(wizardExitCode).toBe(0);
   });
 
   test('package.json is updated correctly', () => {

--- a/e2e-tests/tests/nextjs-16.test.ts
+++ b/e2e-tests/tests/nextjs-16.test.ts
@@ -18,6 +18,7 @@ import { KEYS, withEnv } from 'clifty';
 
 describe('NextJS-16 with Prettier, Biome, and ESLint', () => {
   const integration = Integration.nextjs;
+  let wizardExitCode: number;
 
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-16-test-app');
 
@@ -25,7 +26,7 @@ describe('NextJS-16 with Prettier, Biome, and ESLint', () => {
     initGit(projectDir);
     revertLocalChanges(projectDir);
 
-    await withEnv({
+    wizardExitCode = await withEnv({
       cwd: projectDir,
     })
       .defineInteraction()
@@ -67,6 +68,10 @@ describe('NextJS-16 with Prettier, Biome, and ESLint', () => {
 
   afterAll(() => {
     cleanup();
+  });
+
+  test('exits with exit code 0', () => {
+    expect(wizardExitCode).toBe(0);
   });
 
   test('package.json is updated correctly', () => {


### PR DESCRIPTION
This PR migrates the NextJS 14, 15 and 16 tests to use clifty to define and execute wizard CLI interactions. This should make the tests a lot more readable, reduce flakes (🤞) and avoid a bunch of no longer necessary variables between wizard steps. 