### PR TITLE
test(macos): Increase test timeouts

### DIFF
--- a/test/apple/macos-system-helper.test.ts
+++ b/test/apple/macos-system-helper.test.ts
@@ -125,8 +125,8 @@ describe('MacOSSystemHelpers', () => {
           ),
         );
       },
-      // Increased timeout to 10 seconds due to timeout errors for Node 18 and Node 20
-      10000,
+      // Increased timeout to 20 seconds due to timeout errors for Node 18 and Node 20
+      20_000,
     );
 
     test.runIf(process.platform !== 'darwin')(


### PR DESCRIPTION
The `readXcodeBuildSettings > should return the build settings` flakes every now and then with a timeout.

Full disclosure: I'm not sure if this is a reasonable fix!  However, it looks like, `readXcodeBuildSettings` expectedly takes a while to complete. So I doubled the timeout to check if this gets rid of the flakes. Let me know if there's a better way to fix this!

EDIT: Example flake: https://github.com/getsentry/sentry-wizard/actions/runs/20601611749/job/59168314440#step:6:192