### PR TITLE
feat(nextjs): Add --non-interactive flag for headless CLI operation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,8 @@ module.exports = {
             assertFunctionNames: [
               'expect',
               'checkFileContents',
+              'checkFileDoesNotContain',
+              'checkFileDoesNotExist',
               'checkSentryProperties',
               'checkPackageJson',
               'checkIfBuilds',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Features
-
-- feat(nextjs): Add `--skip-auth` flag for headless CLI operation ([#TBD](https://github.com/getsentry/sentry-wizard/pull/TBD))
-
-  The Next.js wizard now supports a `--skip-auth` mode that scaffolds all Sentry files with environment
-  variable placeholders instead of connecting to Sentry for authentication. This enables fully headless
-  CLI operation where configuration values can be populated later (e.g., by an AI agent or CI/CD).
-
-  New CLI flags:
-
-  - `--skip-auth`: Skip Sentry authentication and use env var placeholders
-  - `--tracing`: Enable performance/tracing (with `--skip-auth`)
-  - `--replay`: Enable Session Replay (with `--skip-auth`)
-  - `--logs`: Enable Sentry Logs (with `--skip-auth`)
-  - `--tunnel-route`: Enable tunnel route (with `--skip-auth`)
-  - `--mcp-cursor`: Add MCP config for Cursor (with `--skip-auth`)
-  - `--mcp-vscode`: Add MCP config for VS Code (with `--skip-auth`)
-  - `--mcp-claude`: Add MCP config for Claude Code (with `--skip-auth`)
-  - `--mcp-opencode`: Add MCP config for OpenCode (with `--skip-auth`)
-  - `--mcp-jetbrains`: Show MCP config for JetBrains IDEs (with `--skip-auth`)
-
-  Example usage:
-
-  ```bash
-  npx @sentry/wizard -i nextjs --skip-auth --tracing --replay --logs --mcp-opencode --ignore-git-changes
-  ```
-
-  When using `--skip-auth`, the wizard:
-
-  - Creates config files with `process.env.SENTRY_DSN` / `process.env.NEXT_PUBLIC_SENTRY_DSN`
-  - Uses `process.env.SENTRY_ORG` and `process.env.SENTRY_PROJECT` in next.config
-  - Creates `.env.example` documenting required environment variables
-  - Skips example page creation, CI setup, and turbopack warning
-  - Uses base MCP URL (`mcp.sentry.dev/mcp`) without project scope
-
 ## 6.10.0
 
 - chore(deps): Upgrade `@sentry/node` from v7 to v10.29.0 ([#1126](https://github.com/getsentry/sentry-wizard/pull/1126))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- feat(nextjs): Add `--skip-auth` flag for headless CLI operation ([#TBD](https://github.com/getsentry/sentry-wizard/pull/TBD))
+
+  The Next.js wizard now supports a `--skip-auth` mode that scaffolds all Sentry files with environment
+  variable placeholders instead of connecting to Sentry for authentication. This enables fully headless
+  CLI operation where configuration values can be populated later (e.g., by an AI agent or CI/CD).
+
+  New CLI flags:
+
+  - `--skip-auth`: Skip Sentry authentication and use env var placeholders
+  - `--tracing`: Enable performance/tracing (with `--skip-auth`)
+  - `--replay`: Enable Session Replay (with `--skip-auth`)
+  - `--logs`: Enable Sentry Logs (with `--skip-auth`)
+  - `--tunnel-route`: Enable tunnel route (with `--skip-auth`)
+  - `--mcp-cursor`: Add MCP config for Cursor (with `--skip-auth`)
+  - `--mcp-vscode`: Add MCP config for VS Code (with `--skip-auth`)
+  - `--mcp-claude`: Add MCP config for Claude Code (with `--skip-auth`)
+  - `--mcp-opencode`: Add MCP config for OpenCode (with `--skip-auth`)
+  - `--mcp-jetbrains`: Show MCP config for JetBrains IDEs (with `--skip-auth`)
+
+  Example usage:
+
+  ```bash
+  npx @sentry/wizard -i nextjs --skip-auth --tracing --replay --logs --mcp-opencode --ignore-git-changes
+  ```
+
+  When using `--skip-auth`, the wizard:
+
+  - Creates config files with `process.env.SENTRY_DSN` / `process.env.NEXT_PUBLIC_SENTRY_DSN`
+  - Uses `process.env.SENTRY_ORG` and `process.env.SENTRY_PROJECT` in next.config
+  - Creates `.env.example` documenting required environment variables
+  - Skips example page creation, CI setup, and turbopack warning
+  - Uses base MCP URL (`mcp.sentry.dev/mcp`) without project scope
+
 ## 6.10.0
 
 - chore(deps): Upgrade `@sentry/node` from v7 to v10.29.0 ([#1126](https://github.com/getsentry/sentry-wizard/pull/1126))

--- a/bin.ts
+++ b/bin.ts
@@ -163,35 +163,37 @@ const argv = yargs(hideBin(process.argv), process.cwd())
     'non-interactive': {
       default: false,
       describe:
-        'Run in non-interactive mode. Skips all prompts and uses environment variable placeholders for auth.',
+        '[NextJS only] Run in non-interactive mode. Skips all prompts and uses environment variable placeholders for auth.',
       type: 'boolean',
     },
     tracing: {
       describe:
-        'Enable performance/tracing monitoring. When set, skips the tracing prompt.',
+        '[NextJS only] Enable performance/tracing monitoring. When set, skips the tracing prompt.',
       type: 'boolean',
     },
     replay: {
-      describe: 'Enable Session Replay. When set, skips the replay prompt.',
+      describe:
+        '[NextJS only] Enable Session Replay. When set, skips the replay prompt.',
       type: 'boolean',
     },
     logs: {
-      describe: 'Enable Sentry Logs. When set, skips the logs prompt.',
+      describe:
+        '[NextJS only] Enable Sentry Logs. When set, skips the logs prompt.',
       type: 'boolean',
     },
     'tunnel-route': {
       describe:
-        'Enable tunnel route for ad-blocker circumvention. When set, skips the tunnel route prompt.',
+        '[NextJS only] Enable tunnel route for ad-blocker circumvention. When set, skips the tunnel route prompt.',
       type: 'boolean',
     },
     'example-page': {
       describe:
-        'Create an example page to test Sentry. When set, skips the example page prompt.',
+        '[NextJS only] Create an example page to test Sentry. When set, skips the example page prompt.',
       type: 'boolean',
     },
     mcp: {
       describe:
-        'Add MCP (Model Context Protocol) config for specified IDE(s). Options: cursor, vscode, claude, opencode, jetbrains',
+        '[NextJS only] Add MCP (Model Context Protocol) config for specified IDE(s). Options: cursor, vscode, claude, opencode, jetbrains',
       type: 'array',
       choices: ['cursor', 'vscode', 'claude', 'opencode', 'jetbrains'],
     },

--- a/bin.ts
+++ b/bin.ts
@@ -160,10 +160,10 @@ const argv = yargs(hideBin(process.argv), process.cwd())
         'Enable Spotlight for local development. This does not require a Sentry account or project.',
       type: 'boolean',
     },
-    'skip-auth': {
+    'non-interactive': {
       default: false,
       describe:
-        'Skip Sentry authentication and use environment variable placeholders. Enables fully headless CLI operation.',
+        'Run in non-interactive mode. Skips all prompts and uses environment variable placeholders for auth.',
       type: 'boolean',
     },
     tracing: {

--- a/bin.ts
+++ b/bin.ts
@@ -167,50 +167,33 @@ const argv = yargs(hideBin(process.argv), process.cwd())
       type: 'boolean',
     },
     tracing: {
-      default: false,
-      describe: 'Enable performance/tracing monitoring (used with --skip-auth)',
+      describe:
+        'Enable performance/tracing monitoring. When set, skips the tracing prompt.',
       type: 'boolean',
     },
     replay: {
-      default: false,
-      describe: 'Enable Session Replay (used with --skip-auth)',
+      describe: 'Enable Session Replay. When set, skips the replay prompt.',
       type: 'boolean',
     },
     logs: {
-      default: false,
-      describe: 'Enable Sentry Logs (used with --skip-auth)',
+      describe: 'Enable Sentry Logs. When set, skips the logs prompt.',
       type: 'boolean',
     },
     'tunnel-route': {
-      default: false,
       describe:
-        'Enable tunnel route for ad-blocker circumvention (used with --skip-auth)',
+        'Enable tunnel route for ad-blocker circumvention. When set, skips the tunnel route prompt.',
       type: 'boolean',
     },
-    'mcp-cursor': {
-      default: false,
-      describe: 'Add MCP config for Cursor (used with --skip-auth)',
+    'example-page': {
+      describe:
+        'Create an example page to test Sentry. When set, skips the example page prompt.',
       type: 'boolean',
     },
-    'mcp-vscode': {
-      default: false,
-      describe: 'Add MCP config for VS Code (used with --skip-auth)',
-      type: 'boolean',
-    },
-    'mcp-claude': {
-      default: false,
-      describe: 'Add MCP config for Claude Code (used with --skip-auth)',
-      type: 'boolean',
-    },
-    'mcp-opencode': {
-      default: false,
-      describe: 'Add MCP config for OpenCode (used with --skip-auth)',
-      type: 'boolean',
-    },
-    'mcp-jetbrains': {
-      default: false,
-      describe: 'Show MCP config for JetBrains IDEs (used with --skip-auth)',
-      type: 'boolean',
+    mcp: {
+      describe:
+        'Add MCP (Model Context Protocol) config for specified IDE(s). Options: cursor, vscode, claude, opencode, jetbrains',
+      type: 'array',
+      choices: ['cursor', 'vscode', 'claude', 'opencode', 'jetbrains'],
     },
     'xcode-project-dir': xcodeProjectDirOption,
     ...PRESELECTED_PROJECT_OPTIONS,

--- a/bin.ts
+++ b/bin.ts
@@ -160,6 +160,58 @@ const argv = yargs(hideBin(process.argv), process.cwd())
         'Enable Spotlight for local development. This does not require a Sentry account or project.',
       type: 'boolean',
     },
+    'skip-auth': {
+      default: false,
+      describe:
+        'Skip Sentry authentication and use environment variable placeholders. Enables fully headless CLI operation.',
+      type: 'boolean',
+    },
+    tracing: {
+      default: false,
+      describe: 'Enable performance/tracing monitoring (used with --skip-auth)',
+      type: 'boolean',
+    },
+    replay: {
+      default: false,
+      describe: 'Enable Session Replay (used with --skip-auth)',
+      type: 'boolean',
+    },
+    logs: {
+      default: false,
+      describe: 'Enable Sentry Logs (used with --skip-auth)',
+      type: 'boolean',
+    },
+    'tunnel-route': {
+      default: false,
+      describe:
+        'Enable tunnel route for ad-blocker circumvention (used with --skip-auth)',
+      type: 'boolean',
+    },
+    'mcp-cursor': {
+      default: false,
+      describe: 'Add MCP config for Cursor (used with --skip-auth)',
+      type: 'boolean',
+    },
+    'mcp-vscode': {
+      default: false,
+      describe: 'Add MCP config for VS Code (used with --skip-auth)',
+      type: 'boolean',
+    },
+    'mcp-claude': {
+      default: false,
+      describe: 'Add MCP config for Claude Code (used with --skip-auth)',
+      type: 'boolean',
+    },
+    'mcp-opencode': {
+      default: false,
+      describe: 'Add MCP config for OpenCode (used with --skip-auth)',
+      type: 'boolean',
+    },
+    'mcp-jetbrains': {
+      default: false,
+      describe: 'Show MCP config for JetBrains IDEs (used with --skip-auth)',
+      type: 'boolean',
+    },
     'xcode-project-dir': xcodeProjectDirOption,
     ...PRESELECTED_PROJECT_OPTIONS,
   })

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -54,6 +54,23 @@ describe('--help command', () => {
             --spotlight           Enable Spotlight for local development. This does
                                   not require a Sentry account or project.
                                                             [boolean] [default: false]
+            --non-interactive     Run in non-interactive mode. Skips all prompts and
+                                  uses environment variable placeholders for auth.
+                                                            [boolean] [default: false]
+            --tracing             Enable performance/tracing monitoring. When set,
+                                  skips the tracing prompt.                  [boolean]
+            --replay              Enable Session Replay. When set, skips the replay
+                                  prompt.                                    [boolean]
+            --logs                Enable Sentry Logs. When set, skips the logs prompt.
+                                                                             [boolean]
+            --tunnel-route        Enable tunnel route for ad-blocker circumvention.
+                                  When set, skips the tunnel route prompt.   [boolean]
+            --example-page        Create an example page to test Sentry. When set,
+                                  skips the example page prompt.             [boolean]
+            --mcp                 Add MCP (Model Context Protocol) config for
+                                  specified IDE(s). Options: cursor, vscode, claude,
+                                  opencode, jetbrains
+              [array] [choices: "cursor", "vscode", "claude", "opencode", "jetbrains"]
             --version             Show version number                        [boolean]
       "
     `);

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -68,9 +68,9 @@ describe('--help command', () => {
                                   prompt.                                    [boolean]
             --example-page        [NextJS only] Create an example page to test Sentry.
                                   When set, skips the example page prompt.   [boolean]
-            --mcp                 [NextJS only] Add MCP (Model Context Protocol) config
-                                  for specified IDE(s). Options: cursor, vscode,
-                                  claude, opencode, jetbrains
+            --mcp                 [NextJS only] Add MCP (Model Context Protocol)
+                                  config for specified IDE(s). Options: cursor,
+                                  vscode, claude, opencode, jetbrains
               [array] [choices: "cursor", "vscode", "claude", "opencode", "jetbrains"]
             --version             Show version number                        [boolean]
       "

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -54,22 +54,23 @@ describe('--help command', () => {
             --spotlight           Enable Spotlight for local development. This does
                                   not require a Sentry account or project.
                                                             [boolean] [default: false]
-            --non-interactive     Run in non-interactive mode. Skips all prompts and
-                                  uses environment variable placeholders for auth.
-                                                            [boolean] [default: false]
-            --tracing             Enable performance/tracing monitoring. When set,
-                                  skips the tracing prompt.                  [boolean]
-            --replay              Enable Session Replay. When set, skips the replay
+            --non-interactive     [NextJS only] Run in non-interactive mode. Skips all
+                                  prompts and uses environment variable placeholders
+                                  for auth.                 [boolean] [default: false]
+            --tracing             [NextJS only] Enable performance/tracing monitoring.
+                                  When set, skips the tracing prompt.        [boolean]
+            --replay              [NextJS only] Enable Session Replay. When set, skips
+                                  the replay prompt.                         [boolean]
+            --logs                [NextJS only] Enable Sentry Logs. When set, skips
+                                  the logs prompt.                           [boolean]
+            --tunnel-route        [NextJS only] Enable tunnel route for ad-blocker
+                                  circumvention. When set, skips the tunnel route
                                   prompt.                                    [boolean]
-            --logs                Enable Sentry Logs. When set, skips the logs prompt.
-                                                                             [boolean]
-            --tunnel-route        Enable tunnel route for ad-blocker circumvention.
-                                  When set, skips the tunnel route prompt.   [boolean]
-            --example-page        Create an example page to test Sentry. When set,
-                                  skips the example page prompt.             [boolean]
-            --mcp                 Add MCP (Model Context Protocol) config for
-                                  specified IDE(s). Options: cursor, vscode, claude,
-                                  opencode, jetbrains
+            --example-page        [NextJS only] Create an example page to test Sentry.
+                                  When set, skips the example page prompt.   [boolean]
+            --mcp                 [NextJS only] Add MCP (Model Context Protocol) config
+                                  for specified IDE(s). Options: cursor, vscode,
+                                  claude, opencode, jetbrains
               [array] [choices: "cursor", "vscode", "claude", "opencode", "jetbrains"]
             --version             Show version number                        [boolean]
       "

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -259,9 +259,10 @@ describe('NextJS Non-Interactive Mode with MCP', () => {
   });
 
   test('OpenCode MCP config is created with base URL (no org/project scope)', () => {
-    checkFileExists(`${projectDir}/.opencode/mcp.json`);
-    checkFileContents(`${projectDir}/.opencode/mcp.json`, [
-      '"mcpServers"',
+    // OpenCode uses opencode.json at project root, not .opencode/mcp.json
+    checkFileExists(`${projectDir}/opencode.json`);
+    checkFileContents(`${projectDir}/opencode.json`, [
+      '"mcp"',
       '"Sentry"',
       'https://mcp.sentry.dev/mcp',
     ]);
@@ -358,6 +359,6 @@ describe('NextJS Non-Interactive Mode - Minimal', () => {
   test('no MCP config files created when --mcp not provided', () => {
     expect(fs.existsSync(`${projectDir}/.cursor/mcp.json`)).toBe(false);
     expect(fs.existsSync(`${projectDir}/.vscode/mcp.json`)).toBe(false);
-    expect(fs.existsSync(`${projectDir}/.opencode/mcp.json`)).toBe(false);
+    expect(fs.existsSync(`${projectDir}/opencode.json`)).toBe(false);
   });
 });

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -65,6 +65,7 @@ describe('NextJS Non-Interactive Mode', () => {
       '--logs',
       '--example-page',
       '--disable-telemetry',
+      '--ignore-git-changes',
     ].join(' ');
 
     wizardExitCode = await withEnv({
@@ -222,6 +223,7 @@ describe('NextJS Non-Interactive Mode with MCP', () => {
       '--mcp',
       'opencode',
       '--disable-telemetry',
+      '--ignore-git-changes',
     ].join(' ');
 
     wizardExitCode = await withEnv({
@@ -282,6 +284,7 @@ describe('NextJS Non-Interactive Mode - Minimal', () => {
       integration,
       '--non-interactive',
       '--disable-telemetry',
+      '--ignore-git-changes',
     ].join(' ');
 
     wizardExitCode = await withEnv({

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -1,0 +1,105 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Integration } from '../../lib/Constants';
+import { createIsolatedTestEnv } from '../utils';
+import {
+  checkFileContents,
+  checkFileExists,
+  checkIfBuilds,
+  checkPackageJson,
+} from '../utils';
+import { describe, beforeAll, afterAll, test, expect } from 'vitest';
+
+//@ts-expect-error - clifty is ESM only
+import { withEnv } from 'clifty';
+
+describe('NextJS Non-Interactive Mode', () => {
+  const integration = Integration.nextjs;
+  let wizardExitCode: number;
+
+  const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
+
+  beforeAll(async () => {
+    const binName = process.env.SENTRY_WIZARD_E2E_TEST_BIN
+      ? ['dist-bin', `sentry-wizard-${process.platform}-${process.arch}`]
+      : ['dist', 'bin.js'];
+    const binPath = path.join(__dirname, '..', '..', ...binName);
+
+    // Run wizard in non-interactive mode with all features enabled
+    const command = [
+      binPath,
+      '-i',
+      integration,
+      '--non-interactive',
+      '--tracing',
+      '--replay',
+      '--logs',
+      '--example-page',
+      '--disable-telemetry',
+    ].join(' ');
+
+    wizardExitCode = await withEnv({
+      cwd: projectDir,
+      debug: true,
+    })
+      .defineInteraction()
+      .expectOutput('Running in non-interactive mode')
+      .expectOutput('Successfully installed the Sentry Next.js SDK!')
+      .run(command);
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+
+  test('exits with exit code 0', () => {
+    expect(wizardExitCode).toBe(0);
+  });
+
+  test('package.json is updated correctly', () => {
+    checkPackageJson(projectDir, '@sentry/nextjs');
+  });
+
+  test('.env.example is created with placeholder values', () => {
+    checkFileExists(`${projectDir}/.env.example`);
+    checkFileContents(
+      `${projectDir}/.env.example`,
+      'SENTRY_AUTH_TOKEN=your-auth-token',
+    );
+  });
+
+  test('instrumentation file is created', () => {
+    const hasJs = fs.existsSync(`${projectDir}/src/instrumentation.js`);
+    const hasTs = fs.existsSync(`${projectDir}/src/instrumentation.ts`);
+    expect(hasJs || hasTs).toBe(true);
+  });
+
+  test('sentry.client.config is created', () => {
+    const hasJs = fs.existsSync(`${projectDir}/sentry.client.config.js`);
+    const hasTs = fs.existsSync(`${projectDir}/sentry.client.config.ts`);
+    expect(hasJs || hasTs).toBe(true);
+  });
+
+  test('sentry.server.config is created', () => {
+    const hasJs = fs.existsSync(`${projectDir}/sentry.server.config.js`);
+    const hasTs = fs.existsSync(`${projectDir}/sentry.server.config.ts`);
+    expect(hasJs || hasTs).toBe(true);
+  });
+
+  test('sentry.edge.config is created', () => {
+    const hasJs = fs.existsSync(`${projectDir}/sentry.edge.config.js`);
+    const hasTs = fs.existsSync(`${projectDir}/sentry.edge.config.ts`);
+    expect(hasJs || hasTs).toBe(true);
+  });
+
+  test('example page is created', () => {
+    const hasExample =
+      fs.existsSync(`${projectDir}/app/sentry-example-page`) ||
+      fs.existsSync(`${projectDir}/src/app/sentry-example-page`);
+    expect(hasExample).toBe(true);
+  });
+
+  test('builds correctly', async () => {
+    await checkIfBuilds(projectDir);
+  });
+});

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -234,10 +234,10 @@ describe('NextJS Non-Interactive Mode with MCP', () => {
     })
       .defineInteraction()
       .expectOutput('Running in non-interactive mode')
-      .expectOutput('Adding MCP configurations')
-      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!', {
+      .expectOutput('Adding MCP configurations', {
         timeout: 240_000, // npm install can take a while in CI
       })
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
       .run(command);
   });
 

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -7,6 +7,7 @@ import {
   checkFileExists,
   checkIfBuilds,
   checkPackageJson,
+  createFile,
   createIsolatedTestEnv,
 } from '../utils';
 import { describe, beforeAll, afterAll, test, expect } from 'vitest';
@@ -24,6 +25,23 @@ function getWizardBinPath(): string {
   return path.join(__dirname, '..', '..', ...binName);
 }
 
+/**
+ * Create a minimal package-lock.json to ensure npm is auto-detected as the package manager.
+ * This is necessary for non-interactive mode since we can't prompt for package manager selection.
+ */
+function createPackageLockForNpm(projectDir: string): void {
+  const packageLock = {
+    name: 'nextjs-test-app',
+    lockfileVersion: 3,
+    requires: true,
+    packages: {},
+  };
+  createFile(
+    path.join(projectDir, 'package-lock.json'),
+    JSON.stringify(packageLock, null, 2),
+  );
+}
+
 describe('NextJS Non-Interactive Mode', () => {
   const integration = Integration.nextjs;
   let wizardExitCode: number;
@@ -31,6 +49,9 @@ describe('NextJS Non-Interactive Mode', () => {
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
 
   beforeAll(async () => {
+    // Create package-lock.json so npm is auto-detected (avoids package manager prompt)
+    createPackageLockForNpm(projectDir);
+
     const binPath = getWizardBinPath();
 
     // Run wizard in non-interactive mode with all features enabled
@@ -184,6 +205,9 @@ describe('NextJS Non-Interactive Mode with MCP', () => {
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
 
   beforeAll(async () => {
+    // Create package-lock.json so npm is auto-detected (avoids package manager prompt)
+    createPackageLockForNpm(projectDir);
+
     const binPath = getWizardBinPath();
 
     // Run wizard in non-interactive mode with MCP configuration
@@ -245,6 +269,9 @@ describe('NextJS Non-Interactive Mode - Minimal', () => {
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
 
   beforeAll(async () => {
+    // Create package-lock.json so npm is auto-detected (avoids package manager prompt)
+    createPackageLockForNpm(projectDir);
+
     const binPath = getWizardBinPath();
 
     // Run wizard in non-interactive mode with NO feature flags

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -1,17 +1,28 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Integration } from '../../lib/Constants';
-import { createIsolatedTestEnv } from '../utils';
 import {
   checkFileContents,
+  checkFileDoesNotExist,
   checkFileExists,
   checkIfBuilds,
   checkPackageJson,
+  createIsolatedTestEnv,
 } from '../utils';
 import { describe, beforeAll, afterAll, test, expect } from 'vitest';
 
 //@ts-expect-error - clifty is ESM only
 import { withEnv } from 'clifty';
+
+/**
+ * Helper to get the wizard binary path
+ */
+function getWizardBinPath(): string {
+  const binName = process.env.SENTRY_WIZARD_E2E_TEST_BIN
+    ? ['dist-bin', `sentry-wizard-${process.platform}-${process.arch}`]
+    : ['dist', 'bin.js'];
+  return path.join(__dirname, '..', '..', ...binName);
+}
 
 describe('NextJS Non-Interactive Mode', () => {
   const integration = Integration.nextjs;
@@ -20,10 +31,7 @@ describe('NextJS Non-Interactive Mode', () => {
   const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
 
   beforeAll(async () => {
-    const binName = process.env.SENTRY_WIZARD_E2E_TEST_BIN
-      ? ['dist-bin', `sentry-wizard-${process.platform}-${process.arch}`]
-      : ['dist', 'bin.js'];
-    const binPath = path.join(__dirname, '..', '..', ...binName);
+    const binPath = getWizardBinPath();
 
     // Run wizard in non-interactive mode with all features enabled
     const command = [
@@ -44,7 +52,7 @@ describe('NextJS Non-Interactive Mode', () => {
     })
       .defineInteraction()
       .expectOutput('Running in non-interactive mode')
-      .expectOutput('Successfully installed the Sentry Next.js SDK!')
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
       .run(command);
   });
 
@@ -62,10 +70,16 @@ describe('NextJS Non-Interactive Mode', () => {
 
   test('.env.example is created with placeholder values', () => {
     checkFileExists(`${projectDir}/.env.example`);
-    checkFileContents(
-      `${projectDir}/.env.example`,
-      'SENTRY_AUTH_TOKEN=your-auth-token',
-    );
+    checkFileContents(`${projectDir}/.env.example`, [
+      'NEXT_PUBLIC_SENTRY_DSN=',
+      'SENTRY_ORG=',
+      'SENTRY_PROJECT=',
+      'SENTRY_AUTH_TOKEN=',
+    ]);
+  });
+
+  test('.env.sentry-build-plugin should NOT exist in non-interactive mode', () => {
+    checkFileDoesNotExist(`${projectDir}/.env.sentry-build-plugin`);
   });
 
   test('instrumentation file is created', () => {
@@ -74,22 +88,54 @@ describe('NextJS Non-Interactive Mode', () => {
     expect(hasJs || hasTs).toBe(true);
   });
 
-  test('sentry.client.config is created', () => {
-    const hasJs = fs.existsSync(`${projectDir}/sentry.client.config.js`);
-    const hasTs = fs.existsSync(`${projectDir}/sentry.client.config.ts`);
+  test('instrumentation-client file is created and uses env var for DSN', () => {
+    const hasJs = fs.existsSync(`${projectDir}/src/instrumentation-client.js`);
+    const hasTs = fs.existsSync(`${projectDir}/src/instrumentation-client.ts`);
     expect(hasJs || hasTs).toBe(true);
+
+    const filePath = hasTs
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+    checkFileContents(filePath, 'process.env.NEXT_PUBLIC_SENTRY_DSN');
   });
 
-  test('sentry.server.config is created', () => {
+  test('sentry.server.config is created and uses env var for DSN', () => {
     const hasJs = fs.existsSync(`${projectDir}/sentry.server.config.js`);
     const hasTs = fs.existsSync(`${projectDir}/sentry.server.config.ts`);
     expect(hasJs || hasTs).toBe(true);
+
+    const filePath = hasTs
+      ? `${projectDir}/sentry.server.config.ts`
+      : `${projectDir}/sentry.server.config.js`;
+    checkFileContents(filePath, 'process.env.NEXT_PUBLIC_SENTRY_DSN');
   });
 
-  test('sentry.edge.config is created', () => {
+  test('sentry.edge.config is created and uses env var for DSN', () => {
     const hasJs = fs.existsSync(`${projectDir}/sentry.edge.config.js`);
     const hasTs = fs.existsSync(`${projectDir}/sentry.edge.config.ts`);
     expect(hasJs || hasTs).toBe(true);
+
+    const filePath = hasTs
+      ? `${projectDir}/sentry.edge.config.ts`
+      : `${projectDir}/sentry.edge.config.js`;
+    checkFileContents(filePath, 'process.env.NEXT_PUBLIC_SENTRY_DSN');
+  });
+
+  test('next.config uses env vars for org and project', () => {
+    const hasJs = fs.existsSync(`${projectDir}/next.config.js`);
+    const hasMjs = fs.existsSync(`${projectDir}/next.config.mjs`);
+    const hasTs = fs.existsSync(`${projectDir}/next.config.ts`);
+    expect(hasJs || hasMjs || hasTs).toBe(true);
+
+    const filePath = hasTs
+      ? `${projectDir}/next.config.ts`
+      : hasMjs
+      ? `${projectDir}/next.config.mjs`
+      : `${projectDir}/next.config.js`;
+    checkFileContents(filePath, [
+      'process.env.SENTRY_ORG',
+      'process.env.SENTRY_PROJECT',
+    ]);
   });
 
   test('example page is created', () => {
@@ -99,7 +145,183 @@ describe('NextJS Non-Interactive Mode', () => {
     expect(hasExample).toBe(true);
   });
 
+  test('instrumentation-client contains tracing config (--tracing flag)', () => {
+    const filePath = fs.existsSync(
+      `${projectDir}/src/instrumentation-client.ts`,
+    )
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+    checkFileContents(filePath, 'tracesSampleRate');
+  });
+
+  test('instrumentation-client contains replay config (--replay flag)', () => {
+    const filePath = fs.existsSync(
+      `${projectDir}/src/instrumentation-client.ts`,
+    )
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+    checkFileContents(filePath, 'replayIntegration');
+  });
+
+  test('instrumentation-client contains logs config (--logs flag)', () => {
+    const filePath = fs.existsSync(
+      `${projectDir}/src/instrumentation-client.ts`,
+    )
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+    checkFileContents(filePath, 'enableLogs: true');
+  });
+
   test('builds correctly', async () => {
     await checkIfBuilds(projectDir);
+  });
+});
+
+describe('NextJS Non-Interactive Mode with MCP', () => {
+  const integration = Integration.nextjs;
+  let wizardExitCode: number;
+
+  const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
+
+  beforeAll(async () => {
+    const binPath = getWizardBinPath();
+
+    // Run wizard in non-interactive mode with MCP configuration
+    const command = [
+      binPath,
+      '-i',
+      integration,
+      '--non-interactive',
+      '--tracing',
+      '--mcp',
+      'cursor',
+      '--mcp',
+      'opencode',
+      '--disable-telemetry',
+    ].join(' ');
+
+    wizardExitCode = await withEnv({
+      cwd: projectDir,
+      debug: true,
+    })
+      .defineInteraction()
+      .expectOutput('Running in non-interactive mode')
+      .expectOutput('Adding MCP configurations')
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
+      .run(command);
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+
+  test('exits with exit code 0', () => {
+    expect(wizardExitCode).toBe(0);
+  });
+
+  test('Cursor MCP config is created with base URL (no org/project scope)', () => {
+    checkFileExists(`${projectDir}/.cursor/mcp.json`);
+    checkFileContents(`${projectDir}/.cursor/mcp.json`, [
+      '"mcpServers"',
+      '"Sentry"',
+      'https://mcp.sentry.dev/mcp',
+    ]);
+  });
+
+  test('OpenCode MCP config is created with base URL (no org/project scope)', () => {
+    checkFileExists(`${projectDir}/.opencode/mcp.json`);
+    checkFileContents(`${projectDir}/.opencode/mcp.json`, [
+      '"mcpServers"',
+      '"Sentry"',
+      'https://mcp.sentry.dev/mcp',
+    ]);
+  });
+});
+
+describe('NextJS Non-Interactive Mode - Minimal', () => {
+  const integration = Integration.nextjs;
+  let wizardExitCode: number;
+
+  const { projectDir, cleanup } = createIsolatedTestEnv('nextjs-15-test-app');
+
+  beforeAll(async () => {
+    const binPath = getWizardBinPath();
+
+    // Run wizard in non-interactive mode with NO feature flags
+    // This tests the default behavior where features are disabled
+    const command = [
+      binPath,
+      '-i',
+      integration,
+      '--non-interactive',
+      '--disable-telemetry',
+    ].join(' ');
+
+    wizardExitCode = await withEnv({
+      cwd: projectDir,
+      debug: true,
+    })
+      .defineInteraction()
+      .expectOutput('Running in non-interactive mode')
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
+      .run(command);
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+
+  test('exits with exit code 0', () => {
+    expect(wizardExitCode).toBe(0);
+  });
+
+  test('package.json is updated correctly', () => {
+    checkPackageJson(projectDir, '@sentry/nextjs');
+  });
+
+  test('instrumentation-client does NOT contain tracing config when --tracing not provided', () => {
+    const filePath = fs.existsSync(
+      `${projectDir}/src/instrumentation-client.ts`,
+    )
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).not.toContain('tracesSampleRate');
+  });
+
+  test('instrumentation-client does NOT contain replay config when --replay not provided', () => {
+    const filePath = fs.existsSync(
+      `${projectDir}/src/instrumentation-client.ts`,
+    )
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).not.toContain('replayIntegration');
+  });
+
+  test('instrumentation-client does NOT contain logs config when --logs not provided', () => {
+    const filePath = fs.existsSync(
+      `${projectDir}/src/instrumentation-client.ts`,
+    )
+      ? `${projectDir}/src/instrumentation-client.ts`
+      : `${projectDir}/src/instrumentation-client.js`;
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).not.toContain('enableLogs');
+  });
+
+  test('example page is NOT created when --example-page not provided', () => {
+    const hasExample =
+      fs.existsSync(`${projectDir}/app/sentry-example-page`) ||
+      fs.existsSync(`${projectDir}/src/app/sentry-example-page`);
+    expect(hasExample).toBe(false);
+  });
+
+  test('no MCP config files created when --mcp not provided', () => {
+    expect(fs.existsSync(`${projectDir}/.cursor/mcp.json`)).toBe(false);
+    expect(fs.existsSync(`${projectDir}/.vscode/mcp.json`)).toBe(false);
+    expect(fs.existsSync(`${projectDir}/.opencode/mcp.json`)).toBe(false);
   });
 });

--- a/e2e-tests/tests/nextjs-non-interactive.test.ts
+++ b/e2e-tests/tests/nextjs-non-interactive.test.ts
@@ -74,7 +74,9 @@ describe('NextJS Non-Interactive Mode', () => {
     })
       .defineInteraction()
       .expectOutput('Running in non-interactive mode')
-      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!', {
+        timeout: 240_000, // npm install can take a while in CI
+      })
       .run(command);
   });
 
@@ -233,7 +235,9 @@ describe('NextJS Non-Interactive Mode with MCP', () => {
       .defineInteraction()
       .expectOutput('Running in non-interactive mode')
       .expectOutput('Adding MCP configurations')
-      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!', {
+        timeout: 240_000, // npm install can take a while in CI
+      })
       .run(command);
   });
 
@@ -293,7 +297,9 @@ describe('NextJS Non-Interactive Mode - Minimal', () => {
     })
       .defineInteraction()
       .expectOutput('Running in non-interactive mode')
-      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!')
+      .expectOutput('Successfully scaffolded the Sentry Next.js SDK!', {
+        timeout: 240_000, // npm install can take a while in CI
+      })
       .run(command);
   });
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -574,7 +574,7 @@ ${chalk.yellow('Next steps:')}
       `${packageManagerForOutro.runScriptCommand} dev`,
     )})
 
-${chalk.dim('Environment variables needed:')}
+${chalk.cyan('Environment variables needed:')}
   - NEXT_PUBLIC_SENTRY_DSN
   - SENTRY_ORG
   - SENTRY_PROJECT

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -618,43 +618,46 @@ async function createOrMergeNextJsFiles(
   const dsn = selectedProject.keys[0].dsn.public;
 
   // Build list of features to prompt for (only those not provided via CLI)
+  // In non-interactive mode, skip prompting entirely - unprovided flags default to false
   const featuresToPrompt: Array<{
     id: 'performance' | 'replay' | 'logs';
     prompt: string;
     enabledHint: string;
   }> = [];
 
-  if (wizardOptions.tracing === undefined) {
-    featuresToPrompt.push({
-      id: 'performance',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Tracing',
-      )} to track the performance of your application?`,
-      enabledHint: 'recommended',
-    });
+  if (!wizardOptions.nonInteractive) {
+    if (wizardOptions.tracing === undefined) {
+      featuresToPrompt.push({
+        id: 'performance',
+        prompt: `Do you want to enable ${chalk.bold(
+          'Tracing',
+        )} to track the performance of your application?`,
+        enabledHint: 'recommended',
+      });
+    }
+
+    if (wizardOptions.replay === undefined) {
+      featuresToPrompt.push({
+        id: 'replay',
+        prompt: `Do you want to enable ${chalk.bold(
+          'Session Replay',
+        )} to get a video-like reproduction of errors during a user session?`,
+        enabledHint: 'recommended, but increases bundle size',
+      });
+    }
+
+    if (wizardOptions.logs === undefined) {
+      featuresToPrompt.push({
+        id: 'logs',
+        prompt: `Do you want to enable ${chalk.bold(
+          'Logs',
+        )} to send your application logs to Sentry?`,
+        enabledHint: 'recommended',
+      });
+    }
   }
 
-  if (wizardOptions.replay === undefined) {
-    featuresToPrompt.push({
-      id: 'replay',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Session Replay',
-      )} to get a video-like reproduction of errors during a user session?`,
-      enabledHint: 'recommended, but increases bundle size',
-    });
-  }
-
-  if (wizardOptions.logs === undefined) {
-    featuresToPrompt.push({
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    });
-  }
-
-  // Prompt for features not provided via CLI
+  // Prompt for features not provided via CLI (empty in non-interactive mode)
   const promptedFeatures =
     featuresToPrompt.length > 0
       ? await featureSelectionPrompt(featuresToPrompt)

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -178,7 +178,10 @@ export async function runNextjsWizardWithTelemetry(
     });
 
   // Determine tunnel route setting - use CLI flag if provided, otherwise prompt
-  const tunnelRoute = options.tunnelRoute ?? (await askShouldSetTunnelRoute());
+  // In non-interactive mode, default to false if not explicitly set
+  const tunnelRoute =
+    options.tunnelRoute ??
+    (nonInteractive ? false : await askShouldSetTunnelRoute());
 
   const { logsEnabled } = await traceStep('configure-sdk', async () => {
     return await createOrMergeNextJsFiles(

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -11,11 +11,7 @@ export function getSentryEnvExampleContents(): string {
 # Copy this file to .env.local and fill in the values from your Sentry project.
 
 # Your Sentry DSN (from Project Settings > Client Keys)
-# Used on the server-side
-SENTRY_DSN=
-
-# Your Sentry DSN for client-side (same value as SENTRY_DSN)
-# The NEXT_PUBLIC_ prefix exposes this to the browser
+# The NEXT_PUBLIC_ prefix exposes this to the browser for client-side error reporting
 NEXT_PUBLIC_SENTRY_DSN=
 
 # Your Sentry organization slug (from Organization Settings)
@@ -205,7 +201,10 @@ export function getSentryServersideConfigContents(
 
   const spotlightOptions = getSpotlightOption(spotlight);
 
-  const dsnValue = useEnvVars ? 'process.env.SENTRY_DSN' : `"${dsn}"`;
+  // Use NEXT_PUBLIC_SENTRY_DSN for consistency - it works on both server and client
+  const dsnValue = useEnvVars
+    ? 'process.env.NEXT_PUBLIC_SENTRY_DSN'
+    : `"${dsn}"`;
 
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `${primer}

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -758,10 +758,16 @@ export function getInstrumentationClientHookCopyPasteSnippet(
     logs: boolean;
   },
   spotlight = false,
+  useEnvVars = false,
 ) {
   return makeCodeSnippet(true, (_unchanged, plus) => {
     return plus(
-      getInstrumentationClientFileContents(dsn, selectedFeaturesMap, spotlight),
+      getInstrumentationClientFileContents(
+        dsn,
+        selectedFeaturesMap,
+        spotlight,
+        useEnvVars,
+      ),
     );
   });
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -75,11 +75,8 @@ type Args = {
   replay?: boolean;
   logs?: boolean;
   tunnelRoute?: boolean;
-  mcpCursor?: boolean;
-  mcpVscode?: boolean;
-  mcpClaude?: boolean;
-  mcpOpencode?: boolean;
-  mcpJetbrains?: boolean;
+  examplePage?: boolean;
+  mcp?: string[];
 };
 
 function preSelectedProjectArgsToObject(
@@ -174,11 +171,8 @@ export async function run(argv: Args) {
     replay: finalArgs.replay,
     logs: finalArgs.logs,
     tunnelRoute: finalArgs.tunnelRoute,
-    mcpCursor: finalArgs.mcpCursor,
-    mcpVscode: finalArgs.mcpVscode,
-    mcpClaude: finalArgs.mcpClaude,
-    mcpOpencode: finalArgs.mcpOpencode,
-    mcpJetbrains: finalArgs.mcpJetbrains,
+    examplePage: finalArgs.examplePage,
+    mcp: finalArgs.mcp,
   };
 
   switch (integration) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -68,6 +68,18 @@ type Args = {
   comingFrom?: string;
   ignoreGitChanges?: boolean;
   xcodeProjectDir?: string;
+
+  // Headless mode options
+  skipAuth?: boolean;
+  tracing?: boolean;
+  replay?: boolean;
+  logs?: boolean;
+  tunnelRoute?: boolean;
+  mcpCursor?: boolean;
+  mcpVscode?: boolean;
+  mcpClaude?: boolean;
+  mcpOpencode?: boolean;
+  mcpJetbrains?: boolean;
 };
 
 function preSelectedProjectArgsToObject(
@@ -156,6 +168,17 @@ export async function run(argv: Args) {
     comingFrom: finalArgs.comingFrom,
     ignoreGitChanges: finalArgs.ignoreGitChanges,
     spotlight: finalArgs.spotlight,
+    // Headless mode options
+    skipAuth: finalArgs.skipAuth,
+    tracing: finalArgs.tracing,
+    replay: finalArgs.replay,
+    logs: finalArgs.logs,
+    tunnelRoute: finalArgs.tunnelRoute,
+    mcpCursor: finalArgs.mcpCursor,
+    mcpVscode: finalArgs.mcpVscode,
+    mcpClaude: finalArgs.mcpClaude,
+    mcpOpencode: finalArgs.mcpOpencode,
+    mcpJetbrains: finalArgs.mcpJetbrains,
   };
 
   switch (integration) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -70,7 +70,7 @@ type Args = {
   xcodeProjectDir?: string;
 
   // Headless mode options
-  skipAuth?: boolean;
+  nonInteractive?: boolean;
   tracing?: boolean;
   replay?: boolean;
   logs?: boolean;
@@ -166,7 +166,7 @@ export async function run(argv: Args) {
     ignoreGitChanges: finalArgs.ignoreGitChanges,
     spotlight: finalArgs.spotlight,
     // Headless mode options
-    skipAuth: finalArgs.skipAuth,
+    nonInteractive: finalArgs.nonInteractive,
     tracing: finalArgs.tracing,
     replay: finalArgs.replay,
     logs: finalArgs.logs,

--- a/src/utils/clack/mcp-config.ts
+++ b/src/utils/clack/mcp-config.ts
@@ -143,7 +143,7 @@ function getGenericMcpJsonSnippet(
   return JSON.stringify(obj, null, 2);
 }
 
-async function addCursorMcpConfig(
+export async function addCursorMcpConfig(
   orgSlug?: string,
   projectSlug?: string,
 ): Promise<void> {
@@ -172,7 +172,7 @@ async function addCursorMcpConfig(
   }
 }
 
-async function addVsCodeMcpConfig(
+export async function addVsCodeMcpConfig(
   orgSlug?: string,
   projectSlug?: string,
 ): Promise<void> {
@@ -202,7 +202,7 @@ async function addVsCodeMcpConfig(
   }
 }
 
-async function addClaudeCodeMcpConfig(
+export async function addClaudeCodeMcpConfig(
   orgSlug?: string,
   projectSlug?: string,
 ): Promise<void> {
@@ -229,7 +229,7 @@ async function addClaudeCodeMcpConfig(
   }
 }
 
-async function addOpenCodeMcpConfig(
+export async function addOpenCodeMcpConfig(
   orgSlug?: string,
   projectSlug?: string,
 ): Promise<void> {
@@ -296,7 +296,7 @@ async function copyToClipboard(text: string): Promise<boolean> {
 /**
  * Shows MCP configuration for JetBrains IDEs with copy-to-clipboard option
  */
-async function showJetBrainsMcpConfig(
+export async function showJetBrainsMcpConfig(
   orgSlug?: string,
   projectSlug?: string,
 ): Promise<void> {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -91,11 +91,11 @@ export type WizardOptions = {
   spotlight?: boolean;
 
   /**
-   * Skip Sentry authentication and use environment variable placeholders.
-   * Enables fully headless CLI operation where an agent can populate values later.
-   * This can be passed via the `--skip-auth` arg.
+   * Run in non-interactive mode. Skips all prompts and uses environment variable
+   * placeholders for authentication. Enables fully headless CLI operation.
+   * This can be passed via the `--non-interactive` arg.
    */
-  skipAuth?: boolean;
+  nonInteractive?: boolean;
 
   /**
    * Enable performance/tracing monitoring.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -99,66 +99,46 @@ export type WizardOptions = {
 
   /**
    * Enable performance/tracing monitoring.
-   * Used with --skip-auth for headless mode.
+   * When set, skips the tracing prompt.
    * This can be passed via the `--tracing` arg.
    */
   tracing?: boolean;
 
   /**
    * Enable Session Replay.
-   * Used with --skip-auth for headless mode.
+   * When set, skips the replay prompt.
    * This can be passed via the `--replay` arg.
    */
   replay?: boolean;
 
   /**
    * Enable Sentry Logs.
-   * Used with --skip-auth for headless mode.
+   * When set, skips the logs prompt.
    * This can be passed via the `--logs` arg.
    */
   logs?: boolean;
 
   /**
    * Enable tunnel route for ad-blocker circumvention.
-   * Used with --skip-auth for headless mode.
+   * When set, skips the tunnel route prompt.
    * This can be passed via the `--tunnel-route` arg.
    */
   tunnelRoute?: boolean;
 
   /**
-   * Add MCP config for Cursor.
-   * Used with --skip-auth for headless mode.
-   * This can be passed via the `--mcp-cursor` arg.
+   * Create an example page to test Sentry.
+   * When set, skips the example page prompt.
+   * This can be passed via the `--example-page` arg.
    */
-  mcpCursor?: boolean;
+  examplePage?: boolean;
 
   /**
-   * Add MCP config for VS Code.
-   * Used with --skip-auth for headless mode.
-   * This can be passed via the `--mcp-vscode` arg.
+   * MCP (Model Context Protocol) providers to configure.
+   * Options: cursor, vscode, claude, opencode, jetbrains
+   * This can be passed via the `--mcp` arg.
+   * Example: `--mcp cursor --mcp vscode` or `--mcp cursor,vscode`
    */
-  mcpVscode?: boolean;
-
-  /**
-   * Add MCP config for Claude Code.
-   * Used with --skip-auth for headless mode.
-   * This can be passed via the `--mcp-claude` arg.
-   */
-  mcpClaude?: boolean;
-
-  /**
-   * Add MCP config for OpenCode.
-   * Used with --skip-auth for headless mode.
-   * This can be passed via the `--mcp-opencode` arg.
-   */
-  mcpOpencode?: boolean;
-
-  /**
-   * Show MCP config for JetBrains IDEs.
-   * Used with --skip-auth for headless mode.
-   * This can be passed via the `--mcp-jetbrains` arg.
-   */
-  mcpJetbrains?: boolean;
+  mcp?: string[];
 };
 
 export interface Feature {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -89,6 +89,76 @@ export type WizardOptions = {
    * This can be passed via the `--spotlight` arg.
    */
   spotlight?: boolean;
+
+  /**
+   * Skip Sentry authentication and use environment variable placeholders.
+   * Enables fully headless CLI operation where an agent can populate values later.
+   * This can be passed via the `--skip-auth` arg.
+   */
+  skipAuth?: boolean;
+
+  /**
+   * Enable performance/tracing monitoring.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--tracing` arg.
+   */
+  tracing?: boolean;
+
+  /**
+   * Enable Session Replay.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--replay` arg.
+   */
+  replay?: boolean;
+
+  /**
+   * Enable Sentry Logs.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--logs` arg.
+   */
+  logs?: boolean;
+
+  /**
+   * Enable tunnel route for ad-blocker circumvention.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--tunnel-route` arg.
+   */
+  tunnelRoute?: boolean;
+
+  /**
+   * Add MCP config for Cursor.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--mcp-cursor` arg.
+   */
+  mcpCursor?: boolean;
+
+  /**
+   * Add MCP config for VS Code.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--mcp-vscode` arg.
+   */
+  mcpVscode?: boolean;
+
+  /**
+   * Add MCP config for Claude Code.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--mcp-claude` arg.
+   */
+  mcpClaude?: boolean;
+
+  /**
+   * Add MCP config for OpenCode.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--mcp-opencode` arg.
+   */
+  mcpOpencode?: boolean;
+
+  /**
+   * Show MCP config for JetBrains IDEs.
+   * Used with --skip-auth for headless mode.
+   * This can be passed via the `--mcp-jetbrains` arg.
+   */
+  mcpJetbrains?: boolean;
 };
 
 export interface Feature {


### PR DESCRIPTION
## Summary

Adds support for fully headless/automated Sentry setup without browser authentication. This enables CI/CD pipelines and AI agents to scaffold Sentry configuration with environment variable placeholders that can be populated later.

## New CLI Flags

| Flag | Description |
|------|-------------|
| `--skip-auth` | Skip Sentry authentication, use env var placeholders |
| `--tracing` | Enable performance/tracing monitoring |
| `--replay` | Enable Session Replay |
| `--logs` | Enable Sentry Logs |
| `--tunnel-route` | Enable tunnel route for ad-blocker circumvention |
| `--mcp-cursor` | Add MCP config for Cursor |
| `--mcp-vscode` | Add MCP config for VS Code |
| `--mcp-claude` | Add MCP config for Claude Code |
| `--mcp-opencode` | Add MCP config for OpenCode |
| `--mcp-jetbrains` | Show MCP config for JetBrains IDEs |

## Example Usage

```bash
npx @sentry/wizard -i nextjs \
  --skip-auth \
  --tracing \
  --replay \
  --logs \
  --mcp-opencode \
  --ignore-git-changes
```

## Behavior in `--skip-auth` Mode

- Config files use `process.env.SENTRY_DSN` / `process.env.NEXT_PUBLIC_SENTRY_DSN`
- `next.config.js` uses `process.env.SENTRY_ORG` and `process.env.SENTRY_PROJECT`
- Creates `.env.example` documenting all required environment variables
- MCP configs use base URL (`mcp.sentry.dev/mcp`) without project scope
- Skips: example page creation, CI setup prompts, turbopack warning
- Feature flags default to `false` (must be explicitly enabled)

## Generated `.env.example`

```bash
# Sentry Configuration
SENTRY_DSN=
NEXT_PUBLIC_SENTRY_DSN=
SENTRY_ORG=
SENTRY_PROJECT=
SENTRY_AUTH_TOKEN=
```

## Use Cases

1. **AI Agent Setup**: Agents can run the wizard headlessly and populate env vars programmatically
2. **CI/CD Scaffolding**: Set up Sentry structure in pipelines without interactive prompts
3. **Template Projects**: Create project templates with Sentry pre-configured for env vars

## Testing

- [x] `yarn build` passes
- [x] `yarn lint` passes
- [x] `yarn test` passes
- [x] Manual testing with `--skip-auth` flag in test Next.js project