### PR TITLE
chore(publish): Fix `release.yml` commit patterns

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,24 +10,29 @@ changelog:
       labels:
         - "Changelog: Breaking Change"
       commit_patterns:
-        - "^\w+(\(\w+\))?!:"
-    - title: New Features
+        - "^(?<type>\\w+(?:\\((?<scope>[^)]+)\\))?!:\\s*)"
+    
+    - title: Features
       labels:
         - "Changelog: Feature"
       commit_patterns:
-        - "^feat(\(\w+\))?:"
+        - "^(?<type>feat(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
+    
     - title: Bug Fixes
       labels:
         - "Changelog: Bugfix"
       commit_patterns:
-        - "^fix(\(\w+\))?:"
-    - title: Documentation 📚
+        - "^(?<type>fix(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
+        - "^Revert \""
+    
+    - title: Documentation
       labels:
         - "Changelog: Docs"
       commit_patterns:
-        - "^docs?(\(\w+\))?:"
-    - title: Internal Changes 🔧
+        - "^(?<type>docs?(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
+  
+    - title: Internal Changes
       labels:
         - "Changelog: Internal"
       commit_patterns:
-        - "^(build|ref|chore|ci)(\(\w+\))?:"
+        - "^(?<type>(?:build|refactor|meta|chore|ci|ref|perf)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"


### PR DESCRIPTION
The regexp patterns in `release.yml` were incorrect and craft couldn't parse them. This made it choose its default changelog template over our customized version. This PR fixes the patterns, by mostly following the [defaults](https://getsentry.github.io/craft/configuration/) from craft.