### PR TITLE
fix(release): Add semver fields to changelog categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,34 +5,40 @@ changelog:
   categories:
     - title: Important Changes
       labels:
-        - "Changelog: Important Change"
+        - 'Changelog: Important Change'
+      semver: minor
     - title: Breaking Changes
       labels:
-        - "Changelog: Breaking Change"
+        - 'Changelog: Breaking Change'
       commit_patterns:
         - "^(?<type>\\w+(?:\\((?<scope>[^)]+)\\))?!:\\s*)"
-    
+      semver: major
+
     - title: Features
       labels:
-        - "Changelog: Feature"
+        - 'Changelog: Feature'
       commit_patterns:
         - "^(?<type>feat(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
-    
+      semver: minor
+
     - title: Bug Fixes
       labels:
-        - "Changelog: Bugfix"
+        - 'Changelog: Bugfix'
       commit_patterns:
         - "^(?<type>fix(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
-        - "^Revert \""
-    
+        - '^Revert "'
+      semver: patch
+
     - title: Documentation
       labels:
-        - "Changelog: Docs"
+        - 'Changelog: Docs'
       commit_patterns:
         - "^(?<type>docs?(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
-  
+      semver: patch
+
     - title: Internal Changes
       labels:
-        - "Changelog: Internal"
+        - 'Changelog: Internal'
       commit_patterns:
         - "^(?<type>(?:build|refactor|meta|chore|ci|ref|perf)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
+      semver: patch


### PR DESCRIPTION
## Summary

- Adds `semver` fields to all changelog categories in `.github/release.yml`
- Fixes the "None" semver impact shown in changelog preview comments (e.g., [#1191](https://github.com/getsentry/sentry-wizard/pull/1191))

## Background

Craft uses the `semver` field in `.github/release.yml` categories to determine the suggested version bump for PRs. Without these fields, PRs are correctly categorized in the changelog but don't contribute to version bump detection.

This was discovered when investigating why PR #1191 (a `feat:` commit) showed "None" for semver impact in the changelog preview comment.

## Changes

Added `semver` mappings following conventional commit semantics:

| Category | Semver |
|----------|--------|
| Important Changes | `minor` |
| Breaking Changes | `major` |
| Features | `minor` |
| Bug Fixes | `patch` |
| Documentation | `patch` |
| Internal Changes | `patch` |