### PR TITLE
chore(publish): Clean up changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- ref(apple): Show deprecation warning for CocoaPods package manager
-- fix(react-native): Skip native file patching when Expo CNG is detected ([#1211](https://github.com/getsentry/sentry-wizard/pull/1211))
-- feat(react-router): Add Instrumentation API support for React Router 7.9.5+ ([#1209](https://github.com/getsentry/sentry-wizard/pull/1209))
-
 ## 6.11.0
 
 ### New Features


### PR DESCRIPTION
Removing the manually added entries so that craft's auto changelog generation can kick in. This will produce the changelog mentioned in https://github.com/getsentry/sentry-wizard/pull/1234#issuecomment-3985343440.

(we can fix the small `ref`/`fix` inconsistency on the release branch or if @philprime you're fine with it, we can re-classify #1229 as a fix to avoid it in the first place)