### PR TITLE
test(e2e): Build RN and Expo iOS/Android release projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,9 @@ jobs:
         env:
           OS_VERSION: '18.5'
           PLATFORM: 'iOS'
-        run: ./scripts/ci-ensure-runtime-loaded.sh --os-version "$OS_VERSION" --platform "$PLATFORM"
+        run:
+          ./scripts/ci-ensure-runtime-loaded.sh --os-version "$OS_VERSION"
+          --platform "$PLATFORM"
       - # This debug step is left-in on purpose, as it helps debug test failures of
         # Apple-specific functionality that relies on system paths.
         #
@@ -162,7 +164,7 @@ jobs:
     name: ${{ matrix.wizard }} E2E Tests (${{ matrix.os }})
     needs: [job_build, job_e2e_test_matrix]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -197,6 +199,19 @@ jobs:
         run: |
           flutter upgrade
           flutter pub get
+      - name: Setup Java
+        if: matrix.wizard == 'react-native' || matrix.wizard == 'expo'
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup Android SDK
+        if: matrix.wizard == 'react-native' || matrix.wizard == 'expo'
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        with:
+          packages: >-
+            platform-tools platforms;android-35 build-tools;35.0.0
+            ndk;27.1.12297006
       - name: Install dependencies with yarn
         run: yarn install --frozen-lockfile
       - name: Download built binaries from build job

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
     name: ${{ matrix.wizard }} E2E Tests (${{ matrix.os }})
     needs: [job_build, job_e2e_test_matrix]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - feat(react-router): Use `sentryOnError` on `HydratedRouter` instead of mutating `root.tsx` ErrorBoundary
 
+### Internal Changes
+
+- chore(e2e): Build React Native and Expo iOS/Android release apps in E2E tests ([#948](https://github.com/getsentry/sentry-wizard/issues/948))
+
 ## 6.12.0
 
 ### Features

--- a/e2e-tests/tests/expo.test.ts
+++ b/e2e-tests/tests/expo.test.ts
@@ -147,14 +147,10 @@ module.exports = config;`,
     expect(bundled).toBe(true);
   });
 
-  test(
-    'android release build succeeds',
-    async () => {
-      const built = await checkIfExpoAndroidBuilds(projectDir);
-      expect(built).toBe(true);
-    },
-    { timeout: 1_800_000 },
-  );
+  test('android release build succeeds', async () => {
+    const built = await checkIfExpoAndroidBuilds(projectDir);
+    expect(built).toBe(true);
+  }, 1_800_000);
 
   test.skipIf(process.platform !== 'darwin')(
     'ios release build succeeds',
@@ -162,6 +158,6 @@ module.exports = config;`,
       const built = await checkIfExpoIosBuilds(projectDir);
       expect(built).toBe(true);
     },
-    { timeout: 2_400_000 },
+    3_000_000,
   );
 });

--- a/e2e-tests/tests/expo.test.ts
+++ b/e2e-tests/tests/expo.test.ts
@@ -3,7 +3,9 @@ import {
   TEST_ARGS,
   checkFileContents,
   checkFileExists,
+  checkIfExpoAndroidBuilds,
   checkIfExpoBundles,
+  checkIfExpoIosBuilds,
   createIsolatedTestEnv,
   getWizardCommand,
 } from '../utils';
@@ -144,4 +146,22 @@ module.exports = config;`,
     const bundled = await checkIfExpoBundles(projectDir, 'web');
     expect(bundled).toBe(true);
   });
+
+  test(
+    'android release build succeeds',
+    async () => {
+      const built = await checkIfExpoAndroidBuilds(projectDir);
+      expect(built).toBe(true);
+    },
+    { timeout: 1_800_000 },
+  );
+
+  test.skipIf(process.platform !== 'darwin')(
+    'ios release build succeeds',
+    async () => {
+      const built = await checkIfExpoIosBuilds(projectDir);
+      expect(built).toBe(true);
+    },
+    { timeout: 2_400_000 },
+  );
 });

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -179,14 +179,10 @@ defaults.url=https://sentry.io/`,
     expect(bundled).toBe(true);
   });
 
-  test(
-    'android release build succeeds',
-    async () => {
-      const built = await checkIfReactNativeAndroidBuilds(projectDir);
-      expect(built).toBe(true);
-    },
-    { timeout: 1_500_000 },
-  );
+  test('android release build succeeds', async () => {
+    const built = await checkIfReactNativeAndroidBuilds(projectDir);
+    expect(built).toBe(true);
+  }, 1_500_000);
 
   test.skipIf(process.platform !== 'darwin')(
     'ios release build succeeds',
@@ -194,6 +190,6 @@ defaults.url=https://sentry.io/`,
       const built = await checkIfReactNativeIosBuilds(projectDir);
       expect(built).toBe(true);
     },
-    { timeout: 1_800_000 },
+    2_700_000,
   );
 });

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -2,7 +2,9 @@ import { Integration } from '../../lib/Constants';
 import {
   TEST_ARGS,
   checkFileContents,
+  checkIfReactNativeAndroidBuilds,
   checkIfReactNativeBundles,
+  checkIfReactNativeIosBuilds,
   createIsolatedTestEnv,
   getWizardCommand,
 } from '../utils';
@@ -176,4 +178,22 @@ defaults.url=https://sentry.io/`,
     const bundled = await checkIfReactNativeBundles(projectDir, 'ios');
     expect(bundled).toBe(true);
   });
+
+  test(
+    'android release build succeeds',
+    async () => {
+      const built = await checkIfReactNativeAndroidBuilds(projectDir);
+      expect(built).toBe(true);
+    },
+    { timeout: 1_500_000 },
+  );
+
+  test.skipIf(process.platform !== 'darwin')(
+    'ios release build succeeds',
+    async () => {
+      const built = await checkIfReactNativeIosBuilds(projectDir);
+      expect(built).toBe(true);
+    },
+    { timeout: 1_800_000 },
+  );
 });

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -556,7 +556,7 @@ export async function checkIfExpoBundles(
  */
 export async function checkIfReactNativeAndroidBuilds(
   projectDir: string,
-  debug = false,
+  debug = true,
 ): Promise<boolean> {
   const androidDir = path.join(projectDir, 'android');
 
@@ -599,7 +599,7 @@ export async function checkIfReactNativeAndroidBuilds(
  */
 export async function checkIfReactNativeIosBuilds(
   projectDir: string,
-  debug = false,
+  debug = true,
 ): Promise<boolean> {
   const iosDir = path.join(projectDir, 'ios');
 
@@ -643,7 +643,7 @@ export async function checkIfReactNativeIosBuilds(
   );
 
   const builtSuccessfully = await xcodebuildRunner.waitForStatusCode(0, {
-    timeout: 1_500_000, // 25 minutes
+    timeout: 2_400_000, // 40 minutes — RN release iOS build can be slow on CI
   });
 
   xcodebuildRunner.kill();
@@ -662,7 +662,7 @@ export async function checkIfReactNativeIosBuilds(
  */
 export async function runExpoPrebuild(
   projectDir: string,
-  debug = false,
+  debug = true,
 ): Promise<boolean> {
   const npxRunner = new ProcessRunner(
     'npx',
@@ -692,7 +692,7 @@ export async function runExpoPrebuild(
  */
 export async function checkIfExpoAndroidBuilds(
   projectDir: string,
-  debug = false,
+  debug = true,
 ): Promise<boolean> {
   const prebuilt = await runExpoPrebuild(projectDir, debug);
   if (!prebuilt) {
@@ -712,7 +712,7 @@ export async function checkIfExpoAndroidBuilds(
  */
 export async function checkIfExpoIosBuilds(
   projectDir: string,
-  debug = false,
+  debug = true,
 ): Promise<boolean> {
   const prebuilt = await runExpoPrebuild(projectDir, debug);
   if (!prebuilt) {

--- a/e2e-tests/utils/index.ts
+++ b/e2e-tests/utils/index.ts
@@ -547,6 +547,194 @@ export async function checkIfExpoBundles(
 }
 
 /**
+ * Run a release build of the React Native Android project using Gradle.
+ * Verifies the wizard's modifications to `build.gradle` haven't broken
+ * the native Android build.
+ *
+ * @param projectDir Root of the React Native project (must contain `android/`).
+ * @param debug runs the command in debug mode if true
+ */
+export async function checkIfReactNativeAndroidBuilds(
+  projectDir: string,
+  debug = false,
+): Promise<boolean> {
+  const androidDir = path.join(projectDir, 'android');
+
+  // Make sure gradlew is executable (the test app copy may have lost the bit).
+  try {
+    fs.chmodSync(path.join(androidDir, 'gradlew'), 0o755);
+  } catch {
+    // ignore — the runner will surface a clear error if gradlew can't run.
+  }
+
+  const gradleRunner = new ProcessRunner(
+    './gradlew',
+    ['assembleRelease', '--no-daemon', '-x', 'lint'],
+    {
+      cwd: androidDir,
+      debug,
+    },
+  );
+
+  const builtSuccessfully = await gradleRunner.waitForStatusCode(0, {
+    timeout: 1_200_000, // 20 minutes — first-time RN gradle builds are slow
+  });
+
+  gradleRunner.kill();
+
+  return builtSuccessfully;
+}
+
+/**
+ * Run a release build of the React Native iOS project using xcodebuild
+ * against the iPhone Simulator SDK (so no code signing is required).
+ * Verifies the wizard's modifications to the Xcode project haven't broken
+ * the native iOS build.
+ *
+ * Requires CocoaPods to have been installed (the wizard does this when run
+ * on macOS). Picks up the `.xcworkspace` from the `ios/` directory.
+ *
+ * @param projectDir Root of the React Native project (must contain `ios/`).
+ * @param debug runs the command in debug mode if true
+ */
+export async function checkIfReactNativeIosBuilds(
+  projectDir: string,
+  debug = false,
+): Promise<boolean> {
+  const iosDir = path.join(projectDir, 'ios');
+
+  const workspace = fs
+    .readdirSync(iosDir)
+    .find((name) => name.endsWith('.xcworkspace'));
+
+  if (!workspace) {
+    log.error(
+      `No .xcworkspace found in ${iosDir}. Did 'pod install' run successfully?`,
+    );
+    return false;
+  }
+
+  const scheme = workspace.replace(/\.xcworkspace$/, '');
+
+  const xcodebuildRunner = new ProcessRunner(
+    'xcodebuild',
+    [
+      '-workspace',
+      workspace,
+      '-scheme',
+      scheme,
+      '-configuration',
+      'Release',
+      '-sdk',
+      'iphonesimulator',
+      '-destination',
+      'generic/platform=iOS Simulator',
+      '-derivedDataPath',
+      'build',
+      'CODE_SIGNING_ALLOWED=NO',
+      'CODE_SIGNING_REQUIRED=NO',
+      'CODE_SIGN_IDENTITY=',
+      'build',
+    ],
+    {
+      cwd: iosDir,
+      debug,
+    },
+  );
+
+  const builtSuccessfully = await xcodebuildRunner.waitForStatusCode(0, {
+    timeout: 1_500_000, // 25 minutes
+  });
+
+  xcodebuildRunner.kill();
+
+  return builtSuccessfully;
+}
+
+/**
+ * Generate native iOS/Android projects for an Expo app via `expo prebuild`.
+ * Required before running native release builds for Expo apps, since the
+ * Sentry Expo plugin (added by the wizard to `app.json` / `app.config.json`)
+ * is applied during prebuild.
+ *
+ * @param projectDir Root of the Expo project.
+ * @param debug runs the command in debug mode if true
+ */
+export async function runExpoPrebuild(
+  projectDir: string,
+  debug = false,
+): Promise<boolean> {
+  const npxRunner = new ProcessRunner(
+    'npx',
+    ['expo', 'prebuild', '--clean', '--no-install'],
+    {
+      cwd: projectDir,
+      debug,
+    },
+  );
+
+  const succeeded = await npxRunner.waitForStatusCode(0, {
+    timeout: 300_000,
+  });
+
+  npxRunner.kill();
+
+  return succeeded;
+}
+
+/**
+ * Run a release build of an Expo app's Android project. Runs `expo prebuild`
+ * first to materialize the `android/` directory with the wizard-configured
+ * Sentry plugin applied.
+ *
+ * @param projectDir Root of the Expo project.
+ * @param debug runs the command in debug mode if true
+ */
+export async function checkIfExpoAndroidBuilds(
+  projectDir: string,
+  debug = false,
+): Promise<boolean> {
+  const prebuilt = await runExpoPrebuild(projectDir, debug);
+  if (!prebuilt) {
+    return false;
+  }
+
+  return checkIfReactNativeAndroidBuilds(projectDir, debug);
+}
+
+/**
+ * Run a release build of an Expo app's iOS project. Runs `expo prebuild` and
+ * `pod install` first so the wizard-configured Sentry Expo plugin is applied
+ * to the generated Xcode project.
+ *
+ * @param projectDir Root of the Expo project.
+ * @param debug runs the command in debug mode if true
+ */
+export async function checkIfExpoIosBuilds(
+  projectDir: string,
+  debug = false,
+): Promise<boolean> {
+  const prebuilt = await runExpoPrebuild(projectDir, debug);
+  if (!prebuilt) {
+    return false;
+  }
+
+  const podRunner = new ProcessRunner('pod', ['install'], {
+    cwd: path.join(projectDir, 'ios'),
+    debug,
+  });
+  const podsInstalled = await podRunner.waitForStatusCode(0, {
+    timeout: 600_000,
+  });
+  podRunner.kill();
+  if (!podsInstalled) {
+    return false;
+  }
+
+  return checkIfReactNativeIosBuilds(projectDir, debug);
+}
+
+/**
  * Check if the project runs on dev mode
  * @param projectDir
  * @param expectedOutput


### PR DESCRIPTION
Closes getsentry/sentry-wizard#948

The idea here is to add end-to-end coverage that ensures the React Native and Expo wizards won't break the native iOS or Android projects when patching `build.gradle` or the Xcode project.