### PR TITLE
chore(sentry-cli): Upgrade to 2.58.6

### DIFF
--- a/src/sourcemaps/tools/sentry-cli.ts
+++ b/src/sourcemaps/tools/sentry-cli.ts
@@ -35,7 +35,7 @@ export async function configureSentryCLI(
   const packageDotJson = await getPackageDotJson();
 
   await installPackage({
-    packageName: '@sentry/cli@^2',
+    packageName: '@sentry/cli@2.58.6',
     alreadyInstalled: hasPackageInstalled('@sentry/cli', packageDotJson),
   });
 

--- a/src/sourcemaps/tools/wrangler.ts
+++ b/src/sourcemaps/tools/wrangler.ts
@@ -66,7 +66,7 @@ Otherwise, let's proceed with the Wrangler setup.`,
   }
 
   await installPackage({
-    packageName: '@sentry/cli@^2',
+    packageName: '@sentry/cli@2.58.6',
     alreadyInstalled: hasPackageInstalled(
       '@sentry/cli',
       await getPackageDotJson(),


### PR DESCRIPTION
Upgrade sentry-cli to [2.58.6](https://github.com/getsentry/sentry-cli/releases/tag/2.58.6), which includes security fixes.