### PR TITLE
feat(react-router): Use the stabilized instrumentation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Features
 
-- feat(react-router): Scaffold the stabilized instrumentation API (`createSentryServerInstrumentation` + `reactRouterTracingIntegration().clientInstrumentation`) instead of the experimental `useInstrumentationAPI` flag
+- feat(react-router): Use the stabilized instrumentation API (`createSentryServerInstrumentation` + `reactRouterTracingIntegration().clientInstrumentation`) instead of the experimental `useInstrumentationAPI` flag
 - feat(react-router): Use `sentryOnError` on `HydratedRouter` instead of mutating `root.tsx` ErrorBoundary
 
 ## 6.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Features
 
+- feat(react-router): Scaffold the stabilized instrumentation API (`createSentryServerInstrumentation` + `reactRouterTracingIntegration().clientInstrumentation`) instead of the experimental `useInstrumentationAPI` flag
 - feat(react-router): Use `sentryOnError` on `HydratedRouter` instead of mutating `root.tsx` ErrorBoundary
 
 ## 6.12.0

--- a/e2e-tests/tests/react-router-instrumentation-api.test.ts
+++ b/e2e-tests/tests/react-router-instrumentation-api.test.ts
@@ -88,7 +88,7 @@ describe('React Router Instrumentation API', () => {
       checkFileContents(`${projectDir}/app/entry.client.tsx`, [
         'import * as Sentry from',
         '@sentry/react-router',
-        'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
+        'const tracing = Sentry.reactRouterTracingIntegration();',
         'integrations: [tracing',
         'instrumentations={[tracing.clientInstrumentation]}',
       ]);

--- a/src/react-router/codemods/client.entry.ts
+++ b/src/react-router/codemods/client.entry.ts
@@ -43,7 +43,7 @@ export async function instrumentClientEntry(
       }
 
       initContent = `
-const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });
+const tracing = Sentry.reactRouterTracingIntegration();
 
 Sentry.init({
   dsn: "${dsn}",

--- a/src/react-router/templates.ts
+++ b/src/react-router/templates.ts
@@ -102,9 +102,7 @@ import { startTransition, StrictMode } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
-${plus(
-  `const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });`,
-)}
+${plus(`const tracing = Sentry.reactRouterTracingIntegration();`)}
 
 ${plus(`Sentry.init({
   dsn: "${dsn}",

--- a/test/react-router/codemods/client-entry.test.ts
+++ b/test/react-router/codemods/client-entry.test.ts
@@ -290,7 +290,7 @@ describe('instrumentClientEntry', () => {
       const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
       expect(modifiedContent).toContain(
-        'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
+        'const tracing = Sentry.reactRouterTracingIntegration();',
       );
       expect(modifiedContent).toContain('integrations: [tracing]');
       expect(modifiedContent).toContain(
@@ -311,7 +311,7 @@ describe('instrumentClientEntry', () => {
       const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
       expect(modifiedContent).toContain(
-        'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
+        'const tracing = Sentry.reactRouterTracingIntegration();',
       );
       expect(modifiedContent).toContain(
         'integrations: [tracing, Sentry.replayIntegration()]',
@@ -340,9 +340,7 @@ describe('instrumentClientEntry', () => {
 
       const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
-      expect(modifiedContent).not.toContain(
-        'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
-      );
+      expect(modifiedContent).not.toContain('const tracing');
       expect(modifiedContent).toContain(
         'Sentry.reactRouterTracingIntegration()',
       );

--- a/test/react-router/templates.test.ts
+++ b/test/react-router/templates.test.ts
@@ -185,7 +185,7 @@ describe('React Router Templates', () => {
         );
 
         expect(result).toContain(
-          'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
+          'const tracing = Sentry.reactRouterTracingIntegration();',
         );
         expect(result).toContain('integrations: [');
         expect(result).toContain('tracing');
@@ -208,7 +208,7 @@ describe('React Router Templates', () => {
         );
 
         expect(result).toContain(
-          'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
+          'const tracing = Sentry.reactRouterTracingIntegration();',
         );
         expect(result).toContain('tracing');
         expect(result).toContain('Sentry.replayIntegration()');
@@ -230,9 +230,7 @@ describe('React Router Templates', () => {
           true,
         );
 
-        expect(result).not.toContain(
-          'const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });',
-        );
+        expect(result).not.toContain('const tracing');
         expect(result).toContain('Sentry.reactRouterTracingIntegration()');
         expect(result).not.toContain('instrumentations');
         expect(result).toContain('onError={Sentry.sentryOnError}');


### PR DESCRIPTION
Aligns the React Router wizard with the now-stabilized instrumentation API (getsentry/sentry-javascript#21470)

The instrumentation API is the recommended path for tracing loaders/actions, and the manual `wrapServerLoader`/`wrapServerAction` wrappers are deprecated — the wizard no longer generates or suggests them.