### PR TITLE
feat(apple): Add Apple Snapshots wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Features
 
+- feat(apple): Add Apple Snapshots wizard for SnapshotPreviews Xcode setup
 - feat(react-router): Use the stabilized instrumentation API (`createSentryServerInstrumentation` + `reactRouterTracingIntegration().clientInstrumentation`) instead of the experimental `useInstrumentationAPI` flag
 - feat(react-router): Use `sentryOnError` on `HydratedRouter` instead of mutating `root.tsx` ErrorBoundary
 

--- a/bin.ts
+++ b/bin.ts
@@ -63,7 +63,7 @@ const PRESELECTED_PROJECT_OPTIONS: Record<string, yargs.Options> = {
 const xcodeProjectDirOption: yargs.Options = {
   default: undefined,
   describe:
-    'Path to the project containing the Xcode project file. Only applies to the Apple wizard.',
+    'Path to the project containing the Xcode project file. Applies to the Apple and Apple Snapshots wizards.',
   type: 'string',
   // This is a hidden option because it is used as an internal option
   hidden: true,

--- a/bin.ts
+++ b/bin.ts
@@ -94,6 +94,12 @@ const argv = yargs(hideBin(process.argv), process.cwd())
         'Do not fallback to prompting user asking questions\nenv: SENTRY_WIZARD_QUIET',
       type: 'boolean',
     },
+    'non-interactive': {
+      default: false,
+      describe:
+        'Run in non-interactive mode, useful for agentic setup',
+      type: 'boolean',
+    },
     i: {
       alias: 'integration',
       choices: Object.keys(Integration),
@@ -161,6 +167,18 @@ const argv = yargs(hideBin(process.argv), process.cwd())
       type: 'boolean',
     },
     'xcode-project-dir': xcodeProjectDirOption,
+    'app-target': {
+      default: undefined,
+      describe:
+        'Xcode application target that hosts Swift previews.',
+      type: 'string',
+    },
+    'hosted-test-target': {
+      default: undefined,
+      describe:
+        'Hosted XCTest target to configure.',
+      type: 'string',
+    },
     ...PRESELECTED_PROJECT_OPTIONS,
   })
   // This prevents `yargs` from trying to read the local package.json

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -29,9 +29,9 @@ describe('--help command', () => {
                                   env: SENTRY_WIZARD_QUIET  [boolean] [default: false]
         -i, --integration         Choose the integration to setup
                                   env: SENTRY_WIZARD_INTEGRATION
-           [choices: "reactNative", "flutter", "ios", "android", "cordova", "angular",
-                   "cloudflare", "electron", "nextjs", "nuxt", "remix", "reactRouter",
-                                                            "sveltekit", "sourcemaps"]
+               [choices: "reactNative", "flutter", "ios", "appleSnapshots", "android",
+            "cordova", "angular", "cloudflare", "electron", "nextjs", "nuxt", "remix",
+                                             "reactRouter", "sveltekit", "sourcemaps"]
         -p, --platform            Choose platform(s)
                                   env: SENTRY_WIZARD_PLATFORM
                                                    [array] [choices: "ios", "android"]

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -27,6 +27,8 @@ describe('--help command', () => {
                                                             [boolean] [default: false]
             --quiet               Do not fallback to prompting user asking questions
                                   env: SENTRY_WIZARD_QUIET  [boolean] [default: false]
+            --non-interactive     Run in non-interactive mode, useful for agentic
+                                  setup                     [boolean] [default: false]
         -i, --integration         Choose the integration to setup
                                   env: SENTRY_WIZARD_INTEGRATION
                [choices: "reactNative", "flutter", "ios", "appleSnapshots", "android",
@@ -54,6 +56,9 @@ describe('--help command', () => {
             --spotlight           Enable Spotlight for local development. This does
                                   not require a Sentry account or project.
                                                             [boolean] [default: false]
+            --app-target          Xcode application target that hosts Swift previews.
+                                                                              [string]
+            --hosted-test-target  Hosted XCTest target to configure.          [string]
             --version             Show version number                        [boolean]
       "
     `);

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -3,6 +3,7 @@ export enum Integration {
   reactNative = 'reactNative',
   flutter = 'flutter',
   ios = 'ios',
+  appleSnapshots = 'appleSnapshots',
   android = 'android',
   cordova = 'cordova',
   angular = 'angular',
@@ -67,6 +68,8 @@ export function getIntegrationDescription(type: string): string {
       return 'Configure Source Maps Upload';
     case Integration.ios:
       return 'iOS';
+    case Integration.appleSnapshots:
+      return 'Apple Snapshots';
     case Integration.cloudflare:
       return 'Cloudflare';
     default:
@@ -101,6 +104,8 @@ export function mapIntegrationToPlatform(type: string): string | undefined {
     case Integration.cloudflare:
       return 'node-cloudflare-workers';
     case Integration.ios:
+      return 'iOS';
+    case Integration.appleSnapshots:
       return 'iOS';
     default:
       throw new Error(`Unknown integration ${type}`);

--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -16,7 +16,7 @@ import { configurePackageManager } from './configure-package-manager';
 import { configureSentryCLI } from './configure-sentry-cli';
 import { configureXcodeProject } from './configure-xcode-project';
 import { injectCodeSnippet } from './inject-code-snippet';
-import { lookupXcodeProject } from './lookup-xcode-project';
+import { lookupXcodeProject, selectXcodeTarget } from './lookup-xcode-project';
 import { AppleWizardOptions } from './options';
 import { abortIfSpotlightNotSupported } from '../utils/abort-if-sportlight-not-supported';
 
@@ -57,9 +57,8 @@ async function runAppleWizardWithTelementry(
   // Step - Xcode Project Lookup
   // This step should be run before the Sentry Project and API Key step
   // because it can abort the wizard if no Xcode project is found.
-  const { xcProject, target } = await lookupXcodeProject({
-    projectDir,
-  });
+  const xcProject = await lookupXcodeProject({ projectDir });
+  const target = await selectXcodeTarget(xcProject);
 
   // Step - Sentry Project and API Key
   const projectData = await getOrAskForProjectData(options, 'apple-ios');

--- a/src/apple/check-installed-cli.ts
+++ b/src/apple/check-installed-cli.ts
@@ -8,6 +8,7 @@ import { debug } from '../utils/debug';
 
 export async function checkInstalledCLI(
   declineWarning = "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+  nonInteractive?: boolean,
 ): Promise<boolean> {
   debug(`Checking if sentry-cli is installed`);
   const hasCli = bash.hasSentryCLI();
@@ -16,6 +17,13 @@ export async function checkInstalledCLI(
     // If the CLI is installed, we don't need to ask the user to install it and can exit early.
     debug(`sentry-cli is installed`);
     return true;
+  }
+
+  if (nonInteractive) {
+    debug(`sentry-cli is not installed; skipping install prompt`);
+    clack.log.warn(declineWarning);
+    Sentry.setTag('CLI-Installed', false);
+    return false;
   }
 
   debug(`sentry-cli is not installed, asking user to install it`);

--- a/src/apple/check-installed-cli.ts
+++ b/src/apple/check-installed-cli.ts
@@ -6,14 +6,16 @@ import * as bash from '../utils/bash';
 import { askToInstallSentryCLI } from '../utils/clack';
 import { debug } from '../utils/debug';
 
-export async function checkInstalledCLI() {
+export async function checkInstalledCLI(
+  declineWarning = "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+): Promise<boolean> {
   debug(`Checking if sentry-cli is installed`);
   const hasCli = bash.hasSentryCLI();
   Sentry.setTag('has-cli', hasCli);
   if (hasCli) {
     // If the CLI is installed, we don't need to ask the user to install it and can exit early.
     debug(`sentry-cli is installed`);
-    return;
+    return true;
   }
 
   debug(`sentry-cli is not installed, asking user to install it`);
@@ -24,11 +26,11 @@ export async function checkInstalledCLI() {
     debug(`User agreed to install sentry-cli`);
     await bash.installSentryCLI();
     Sentry.setTag('CLI-Installed', true);
-  } else {
-    debug(`User declined to install sentry-cli`);
-    clack.log.warn(
-      "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
-    );
-    Sentry.setTag('CLI-Installed', false);
+    return true;
   }
+
+  debug(`User declined to install sentry-cli`);
+  clack.log.warn(declineWarning);
+  Sentry.setTag('CLI-Installed', false);
+  return false;
 }

--- a/src/apple/configure-xcode-project.ts
+++ b/src/apple/configure-xcode-project.ts
@@ -1,5 +1,9 @@
 import { traceStep } from '../telemetry';
 import { SentryProjectData } from '../utils/types';
+import {
+  SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+  sentrySwiftPackageProductSpec,
+} from './sentry-swift-package';
 import { XcodeProject } from './xcode-manager';
 
 export function configureXcodeProject({
@@ -14,6 +18,18 @@ export function configureXcodeProject({
   shouldUseSPM: boolean;
 }) {
   traceStep('Update Xcode project', () => {
-    xcProject.updateXcodeProject(project, target, shouldUseSPM, true);
+    xcProject.updateXcodeProject(
+      project,
+      target,
+      shouldUseSPM
+        ? {
+            product: sentrySwiftPackageProductSpec,
+            existingFrameworkComment:
+              SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+            successMessage: 'Added Sentry SPM dependency to your project',
+          }
+        : undefined,
+      true,
+    );
   });
 }

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -13,8 +13,10 @@ import { XcodeProject } from './xcode-manager';
 
 export async function lookupXcodeProject({
   projectDir,
+  nonInteractive,
 }: {
   projectDir: string;
+  nonInteractive?: boolean;
 }): Promise<XcodeProject> {
   debug(`Looking for Xcode project in directory: ${chalk.cyan(projectDir)}`);
   const xcodeProjFiles = searchXcodeProjectAtPath(projectDir);
@@ -39,6 +41,18 @@ export async function lookupXcodeProject({
   } else {
     debug(`Found multiple Xcode projects, asking user to choose one`);
     Sentry.setTag('multiple-projects', true);
+
+    if (nonInteractive) {
+      clack.log.error(
+        [
+          'Multiple Xcode projects found in non-interactive mode.',
+          `Available projects: ${xcodeProjFiles.join(', ')}.`,
+          'Run from a directory with a single .xcodeproj or pass --xcode-project-dir with a narrower project directory.',
+        ].join(' '),
+      );
+      return await abort();
+    }
+
     xcodeProjFile = (
       await traceStep('Choose Xcode project', () =>
         askForItemSelection(

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -15,10 +15,7 @@ export async function lookupXcodeProject({
   projectDir,
 }: {
   projectDir: string;
-}): Promise<{
-  xcProject: XcodeProject;
-  target: string;
-}> {
+}): Promise<XcodeProject> {
   debug(`Looking for Xcode project in directory: ${chalk.cyan(projectDir)}`);
   const xcodeProjFiles = searchXcodeProjectAtPath(projectDir);
   if (xcodeProjFiles.length === 0) {
@@ -34,8 +31,6 @@ export async function lookupXcodeProject({
     )} candidates for Xcode project`,
   );
 
-  // In case there is only one Xcode project, we can use that one.
-  // Otherwise, we need to ask the user which one they want to use.
   let xcodeProjFile: string;
   if (xcodeProjFiles.length === 1) {
     debug(`Found exactly one Xcode project, using it`);
@@ -54,7 +49,6 @@ export async function lookupXcodeProject({
     ).value;
   }
 
-  // Load the pbxproj file
   const pathToPbxproj = path.join(projectDir, xcodeProjFile, 'project.pbxproj');
   debug(`Loading Xcode project pbxproj at path: ${chalk.cyan(pathToPbxproj)}`);
   if (!fs.existsSync(pathToPbxproj)) {
@@ -63,41 +57,49 @@ export async function lookupXcodeProject({
     return await abort();
   }
 
-  const xcProject = new XcodeProject(pathToPbxproj);
-  const availableTargets = xcProject.getAllTargets();
-  if (availableTargets.length == 0) {
-    clack.log.error(`No suitable Xcode target found in ${xcodeProjFile}`);
+  return new XcodeProject(pathToPbxproj);
+}
+
+export async function selectXcodeTarget(
+  xcProject: XcodeProject,
+  {
+    targetNames = xcProject.getAllTargets(),
+    noTargetMessage = `No suitable Xcode target found in ${path.basename(
+      xcProject.xcodeprojPath,
+    )}`,
+    promptMessage = 'Which target do you want to add Sentry to?',
+  }: {
+    targetNames?: string[];
+    noTargetMessage?: string;
+    promptMessage?: string;
+  } = {},
+): Promise<string> {
+  if (targetNames.length === 0) {
+    clack.log.error(noTargetMessage);
     Sentry.setTag('No-Target', true);
     return await abort();
   }
   debug(
     `Found ${chalk.cyan(
-      availableTargets.length.toString(),
+      targetNames.length.toString(),
     )} targets in Xcode project`,
   );
 
-  // Step - Lookup Xcode Target
   let target: string;
-  if (availableTargets.length == 1) {
+  if (targetNames.length === 1) {
     debug(`Found exactly one target, using it`);
     Sentry.setTag('multiple-targets', false);
-    target = availableTargets[0];
+    target = targetNames[0];
   } else {
     debug(`Found multiple targets, asking user to choose one`);
     Sentry.setTag('multiple-targets', true);
     target = (
       await traceStep('Choose target', () =>
-        askForItemSelection(
-          availableTargets,
-          'Which target do you want to add Sentry to?',
-        ),
+        askForItemSelection(targetNames, promptMessage),
       )
     ).value;
   }
   debug(`Selected target: ${chalk.cyan(target)}`);
 
-  return {
-    xcProject,
-    target,
-  };
+  return target;
 }

--- a/src/apple/options.ts
+++ b/src/apple/options.ts
@@ -3,3 +3,9 @@ import { WizardOptions } from '../utils/types';
 export interface AppleWizardOptions extends WizardOptions {
   projectDir: string | undefined;
 }
+
+export interface AppleSnapshotsWizardOptions extends AppleWizardOptions {
+  appTarget?: string;
+  hostedTestTarget?: string;
+  nonInteractive?: boolean;
+}

--- a/src/apple/sentry-swift-package.ts
+++ b/src/apple/sentry-swift-package.ts
@@ -1,0 +1,21 @@
+import type {
+  SwiftPackageProductSpec,
+  SwiftPackageSpec,
+} from './xcode-manager';
+
+export const SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT =
+  'Sentry in Frameworks';
+
+export const sentrySwiftPackageSpec: SwiftPackageSpec = {
+  repositoryURL: 'https://github.com/getsentry/sentry-cocoa/',
+  requirement: {
+    kind: 'upToNextMajorVersion',
+    minimumVersion: '8.0.0',
+  },
+  commentName: 'sentry-cocoa',
+};
+
+export const sentrySwiftPackageProductSpec: SwiftPackageProductSpec = {
+  package: sentrySwiftPackageSpec,
+  productName: 'Sentry',
+};

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -1,0 +1,196 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+
+import { withTelemetry } from '../../telemetry';
+import {
+  abortIfCancelled,
+  confirmContinueIfNoOrDirtyGitRepo,
+  printWelcome,
+} from '../../utils/clack';
+import { lookupXcodeProject, selectXcodeTarget } from '../lookup-xcode-project';
+import type { AppleWizardOptions } from '../options';
+import type { XcodeProject } from '../xcode-manager';
+import { checkInstalledCLISnapshots } from './snapshots-cli-preflight';
+import { configureSnapshotPreviewsXcodeProject } from './configure-snapshotpreviews-xcode-project';
+import { ensureSnapshotTestFile } from './snapshot-test-file';
+import { resolveSnapshotVerificationSchemeName } from './snapshot-verification-scheme';
+import {
+  SNAPSHOTPREVIEWS_MINIMUM_VERSION,
+  SNAPSHOTPREVIEWS_PACKAGE_URL,
+  SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT,
+  SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
+} from './snapshotpreviews-package';
+
+export async function runAppleSnapshotsWizard(
+  options: AppleWizardOptions,
+): Promise<void> {
+  return withTelemetry(
+    {
+      enabled: options.telemetryEnabled,
+      integration: 'appleSnapshots',
+      wizardOptions: options,
+    },
+    () => runAppleSnapshotsWizardWithTelemetry(options),
+  );
+}
+
+async function runAppleSnapshotsWizardWithTelemetry(
+  options: AppleWizardOptions,
+): Promise<void> {
+  const projectDir = options.projectDir ?? process.cwd();
+
+  printWelcome({
+    wizardName: 'Sentry Apple Snapshots Wizard',
+    promoCode: options.promoCode,
+  });
+
+  await confirmContinueIfNoOrDirtyGitRepo({
+    ignoreGitChanges: options.ignoreGitChanges,
+    cwd: projectDir,
+  });
+
+  clack.log.info(
+    [
+      `Apple Snapshots setup will use ${SNAPSHOTPREVIEWS_PACKAGE_URL}`,
+      `${SNAPSHOTPREVIEWS_MINIMUM_VERSION}+ and link`,
+      `${SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT} to the hosted XCTest`,
+      `target and ${SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT} to the selected`,
+      'app target if it declares Swift previews.',
+    ].join(' '),
+  );
+
+  const xcProject = await lookupXcodeProject({ projectDir });
+
+  const appTargetName = await selectXcodeTarget(xcProject, {
+    noTargetMessage: 'No application target found.',
+    promptMessage: 'Which app target hosts your Swift previews?',
+  });
+
+  const hostedTestTargetNames =
+    xcProject.getHostedUnitTestTargetNamesForApplicationTarget(appTargetName);
+  const hostedTestTargetName = await selectXcodeTarget(xcProject, {
+    targetNames: hostedTestTargetNames,
+    noTargetMessage: [
+      `No hosted unit-test target was found for ${appTargetName}.`,
+      'Please configure a unit-test target with TEST_HOST pointing at that app target, then run the wizard again.',
+    ].join(' '),
+    promptMessage: 'Which test target should render SnapshotPreviews?',
+  });
+
+  const selectedTargetHasSwiftPreviews = targetHasSwiftPreviews(
+    xcProject,
+    appTargetName,
+  );
+
+  if (!selectedTargetHasSwiftPreviews) {
+    clack.log.warn(
+      'No Swift previews were found. SnapshotPreviews needs Swift previews or an existing image generator to produce useful snapshots.',
+    );
+    const continueWithoutPreviews = await abortIfCancelled(
+      clack.confirm({
+        message: 'Do you want to continue with SnapshotPreviews setup anyway?',
+        initialValue: false,
+      }),
+    );
+    if (!continueWithoutPreviews) {
+      clack.outro('Apple Snapshots setup cancelled.');
+      return;
+    }
+  }
+
+  const previewTargetNames = selectedTargetHasSwiftPreviews
+    ? [appTargetName]
+    : [];
+
+  if (previewTargetNames.length) {
+    clack.log.info(
+      [
+        `${SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT} will be linked to the selected`,
+        'app target. Import SnapshotPreferences in Swift preview files only',
+        'if you want to use SnapshotPreviews modifiers.',
+      ].join(' '),
+    );
+  }
+
+  if (fs.existsSync(path.join(projectDir, 'Package.swift'))) {
+    clack.log.info(
+      [
+        'Detected Package.swift. This wizard does not edit SwiftPM manifests.',
+        `If SwiftPM preview targets use SnapshotPreferences modifiers, add`,
+        `the ${SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT} product dependency to those`,
+        'targets in Package.swift.',
+      ].join(' '),
+    );
+  }
+
+  const packageResult = configureSnapshotPreviewsXcodeProject({
+    xcodeProject: xcProject,
+    hostedTestTargetName,
+    previewTargetNames,
+  });
+
+  if (!packageResult.linked) {
+    clack.log.error(
+      'SnapshotPreviews package products could not be linked to the selected targets. Please check the Xcode project target build phases and try again.',
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return;
+  }
+
+  const snapshotTestResult = ensureSnapshotTestFile({
+    xcodeProject: xcProject,
+    hostedTestTargetName,
+  });
+  if (!snapshotTestResult.included) {
+    clack.log.error(
+      'SnapshotPreviews test file could not be added to the selected XCTest target. Please check the target Sources build phase and try again.',
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return;
+  }
+
+  if (snapshotTestResult.changed || packageResult.changed) {
+    xcProject.write();
+    clack.log.success('Updated the Xcode project for SnapshotPreviews.');
+  } else {
+    clack.log.info('SnapshotPreviews Xcode project setup is already present.');
+  }
+
+  await checkInstalledCLISnapshots({
+    projectDir,
+    verificationGuidance: {
+      appId: xcProject.getBundleIdentifierForTarget(appTargetName),
+      hostedTestTargetName,
+      projectDir,
+      projectPath: xcProject.xcodeprojPath,
+      schemeName: resolveSnapshotVerificationSchemeName({
+        hostedTestTargetName,
+        xcodeprojPath: xcProject.xcodeprojPath,
+      }),
+    },
+  });
+
+  clack.outro(
+    'Apple Snapshots setup complete. No Sentry auth, DSN, runtime SDK, dSYM, or CI workflow files were configured.',
+  );
+}
+
+function targetHasSwiftPreviews(
+  xcodeProject: XcodeProject,
+  targetName: string,
+): boolean {
+  const sourceFiles = xcodeProject.getSourceFilesForTarget(targetName) ?? [];
+  return sourceFiles.some((filePath) => {
+    if (!filePath.endsWith('.swift') || !fs.existsSync(filePath)) {
+      return false;
+    }
+
+    const contents = fs.readFileSync(filePath, 'utf8');
+    return (
+      contents.includes('#Preview') || contents.includes('PreviewProvider')
+    );
+  });
+}

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -18,6 +18,7 @@ import { checkInstalledCLISnapshots } from './snapshots-cli-preflight';
 import { configureSnapshotPreviewsXcodeProject } from './configure-snapshotpreviews-xcode-project';
 import {
   ensureSnapshotTestFile,
+  snapshotTestClassName,
   snapshotTestTemplate,
 } from './snapshot-test-file';
 import { resolveSnapshotVerificationSchemeName } from './snapshot-verification-scheme';
@@ -54,6 +55,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
   await confirmContinueIfNoOrDirtyGitRepo({
     ignoreGitChanges: options.ignoreGitChanges,
     cwd: projectDir,
+    nonInteractive: options.nonInteractive,
   });
 
   clack.log.info(
@@ -66,7 +68,10 @@ async function runAppleSnapshotsWizardWithTelemetry(
     ].join(' '),
   );
 
-  const xcProject = await lookupXcodeProject({ projectDir });
+  const xcProject = await lookupXcodeProject({
+    projectDir,
+    nonInteractive: options.nonInteractive,
+  });
 
   const appTargetName = await resolveAppTargetName(xcProject, options);
   if (!appTargetName) {
@@ -91,15 +96,23 @@ async function runAppleSnapshotsWizardWithTelemetry(
     clack.log.warn(
       'No Swift previews were found. SnapshotPreviews needs Swift previews or an existing image generator to produce useful snapshots.',
     );
-    const continueWithoutPreviews = await abortIfCancelled(
-      clack.confirm({
-        message: 'Do you want to continue with SnapshotPreviews setup anyway?',
-        initialValue: false,
-      }),
-    );
-    if (!continueWithoutPreviews) {
-      clack.outro('Apple Snapshots setup cancelled.');
-      return;
+
+    if (options.nonInteractive) {
+      clack.log.info(
+        'Continuing without Swift previews in non-interactive mode. Add Swift previews to the app target to generate useful snapshots.',
+      );
+    } else {
+      const continueWithoutPreviews = await abortIfCancelled(
+        clack.confirm({
+          message:
+            'Do you want to continue with SnapshotPreviews setup anyway?',
+          initialValue: false,
+        }),
+      );
+      if (!continueWithoutPreviews) {
+        clack.outro('Apple Snapshots setup cancelled.');
+        return;
+      }
     }
   }
 
@@ -163,6 +176,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
 
   await checkInstalledCLISnapshots({
     projectDir,
+    nonInteractive: options.nonInteractive,
     verificationGuidance: {
       appId: xcProject.getBundleIdentifierForTarget(appTargetName),
       hostedTestTargetName,
@@ -175,7 +189,9 @@ async function runAppleSnapshotsWizardWithTelemetry(
     },
   });
 
-  clack.outro('Apple Snapshots setup complete.');
+  clack.outro(
+    'Apple Snapshots setup complete. No Sentry auth, DSN, runtime SDK, dSYM, or CI workflow files were configured.',
+  );
 }
 
 async function resolveAppTargetName(
@@ -256,7 +272,7 @@ async function resolveHostedTestTargetName(
     clack.log.error(
       [
         `No hosted XCTest target was found for ${appTargetName}.`,
-        manualAppleSnapshotsSetupInstructions(appTargetName),
+        manualAppleSnapshotsSetupInstructions({ appTargetName }),
       ].join('\n'),
     );
     clack.outro('Apple Snapshots setup did not complete.');
@@ -301,7 +317,10 @@ async function selectHostedTestTargetName({
           hostedTestTargetNames,
         )}.`,
         'Pass --hosted-test-target <target-name> to select the target explicitly.',
-        manualAppleSnapshotsSetupInstructions(appTargetName),
+        manualAppleSnapshotsSetupInstructions({
+          appTargetName,
+          hostedTestTargetName: hostedTestTargetNames[0],
+        }),
       ].join('\n'),
     );
     clack.outro('Apple Snapshots setup did not complete.');
@@ -314,14 +333,27 @@ async function selectHostedTestTargetName({
   return selection.value;
 }
 
-function manualAppleSnapshotsSetupInstructions(appTargetName: string): string {
+function manualAppleSnapshotsSetupInstructions({
+  appTargetName,
+  hostedTestTargetName,
+}: {
+  appTargetName: string;
+  hostedTestTargetName?: string;
+}): string {
+  const exampleHostedTestTargetName = hostedTestTargetName ?? 'AppTests';
+  const sourceFileInstruction = hostedTestTargetName
+    ? '3. Add this XCTest source file to the hosted XCTest target:'
+    : `3. Add this XCTest source file to the hosted XCTest target. This example assumes the hosted XCTest target is named ${exampleHostedTestTargetName}:`;
+
   return [
     'Manual setup:',
     `1. Add the ${SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT} package product to the hosted XCTest target for ${appTargetName}.`,
     `2. Add the ${SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT} package product to ${appTargetName} if its Swift previews use SnapshotPreviews modifiers.`,
-    '3. Add this XCTest source file to the hosted XCTest target:',
+    sourceFileInstruction,
     '```swift',
-    snapshotTestTemplate('SnapshotPreviewsSnapshotTest').trimEnd(),
+    snapshotTestTemplate(
+      snapshotTestClassName(exampleHostedTestTargetName),
+    ).trimEnd(),
     '```',
     '4. Run the hosted XCTest target with xcodebuild.',
   ].join('\n');

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -7,15 +7,19 @@ import clack from '@clack/prompts';
 import { withTelemetry } from '../../telemetry';
 import {
   abortIfCancelled,
+  askForItemSelection,
   confirmContinueIfNoOrDirtyGitRepo,
   printWelcome,
 } from '../../utils/clack';
 import { lookupXcodeProject, selectXcodeTarget } from '../lookup-xcode-project';
-import type { AppleWizardOptions } from '../options';
+import type { AppleSnapshotsWizardOptions } from '../options';
 import type { XcodeProject } from '../xcode-manager';
 import { checkInstalledCLISnapshots } from './snapshots-cli-preflight';
 import { configureSnapshotPreviewsXcodeProject } from './configure-snapshotpreviews-xcode-project';
-import { ensureSnapshotTestFile } from './snapshot-test-file';
+import {
+  ensureSnapshotTestFile,
+  snapshotTestTemplate,
+} from './snapshot-test-file';
 import { resolveSnapshotVerificationSchemeName } from './snapshot-verification-scheme';
 import {
   SNAPSHOTPREVIEWS_MINIMUM_VERSION,
@@ -25,7 +29,7 @@ import {
 } from './snapshotpreviews-package';
 
 export async function runAppleSnapshotsWizard(
-  options: AppleWizardOptions,
+  options: AppleSnapshotsWizardOptions,
 ): Promise<void> {
   return withTelemetry(
     {
@@ -38,7 +42,7 @@ export async function runAppleSnapshotsWizard(
 }
 
 async function runAppleSnapshotsWizardWithTelemetry(
-  options: AppleWizardOptions,
+  options: AppleSnapshotsWizardOptions,
 ): Promise<void> {
   const projectDir = options.projectDir ?? process.cwd();
 
@@ -64,21 +68,19 @@ async function runAppleSnapshotsWizardWithTelemetry(
 
   const xcProject = await lookupXcodeProject({ projectDir });
 
-  const appTargetName = await selectXcodeTarget(xcProject, {
-    noTargetMessage: 'No application target found.',
-    promptMessage: 'Which app target hosts your Swift previews?',
-  });
+  const appTargetName = await resolveAppTargetName(xcProject, options);
+  if (!appTargetName) {
+    return;
+  }
 
-  const hostedTestTargetNames =
-    xcProject.getHostedUnitTestTargetNamesForApplicationTarget(appTargetName);
-  const hostedTestTargetName = await selectXcodeTarget(xcProject, {
-    targetNames: hostedTestTargetNames,
-    noTargetMessage: [
-      `No hosted unit-test target was found for ${appTargetName}.`,
-      'Please configure a unit-test target with TEST_HOST pointing at that app target, then run the wizard again.',
-    ].join(' '),
-    promptMessage: 'Which test target should render SnapshotPreviews?',
-  });
+  const hostedTestTargetName = await resolveHostedTestTargetName(
+    xcProject,
+    appTargetName,
+    options,
+  );
+  if (!hostedTestTargetName) {
+    return;
+  }
 
   const selectedTargetHasSwiftPreviews = targetHasSwiftPreviews(
     xcProject,
@@ -173,9 +175,160 @@ async function runAppleSnapshotsWizardWithTelemetry(
     },
   });
 
-  clack.outro(
-    'Apple Snapshots setup complete. No Sentry auth, DSN, runtime SDK, dSYM, or CI workflow files were configured.',
+  clack.outro('Apple Snapshots setup complete.');
+}
+
+async function resolveAppTargetName(
+  xcodeProject: XcodeProject,
+  options: AppleSnapshotsWizardOptions,
+): Promise<string | undefined> {
+  const appTargetNames = xcodeProject.getAllTargets();
+  if (options.appTarget) {
+    if (appTargetNames.includes(options.appTarget)) {
+      return options.appTarget;
+    }
+
+    clack.log.error(
+      `Xcode app target ${
+        options.appTarget
+      } was not found. Available app targets: ${formatList(appTargetNames)}.`,
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return undefined;
+  }
+
+  if (options.nonInteractive && appTargetNames.length !== 1) {
+    clack.log.error(
+      [
+        'Could not automatically select an Xcode app target in non-interactive mode.',
+        `Available app targets: ${formatList(appTargetNames)}.`,
+        'Pass --app-target <target-name> to select the app target that hosts your Swift previews.',
+      ].join(' '),
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return undefined;
+  }
+
+  return await selectXcodeTarget(xcodeProject, {
+    targetNames: appTargetNames,
+    noTargetMessage: 'No application target found.',
+    promptMessage: 'Which app target hosts your Swift previews?',
+  });
+}
+
+async function resolveHostedTestTargetName(
+  xcodeProject: XcodeProject,
+  appTargetName: string,
+  options: AppleSnapshotsWizardOptions,
+): Promise<string | undefined> {
+  const hostedTestTargetNames = xcodeProject.getHostedUnitTestTargetNames();
+  if (options.hostedTestTarget) {
+    if (hostedTestTargetNames.includes(options.hostedTestTarget)) {
+      return options.hostedTestTarget;
+    }
+
+    clack.log.error(
+      [
+        `Hosted XCTest target ${options.hostedTestTarget} was not found or does not define TEST_HOST.`,
+        `Available hosted XCTest targets: ${formatList(
+          hostedTestTargetNames,
+        )}.`,
+      ].join(' '),
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return undefined;
+  }
+
+  const inferredHostedTestTargetNames =
+    xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget(
+      appTargetName,
+    );
+  if (inferredHostedTestTargetNames.length > 0) {
+    return await selectHostedTestTargetName({
+      appTargetName,
+      hostedTestTargetNames: inferredHostedTestTargetNames,
+      nonInteractive: options.nonInteractive,
+      promptMessage: 'Which test target should render SnapshotPreviews?',
+    });
+  }
+
+  if (hostedTestTargetNames.length === 0) {
+    clack.log.error(
+      [
+        `No hosted XCTest target was found for ${appTargetName}.`,
+        manualAppleSnapshotsSetupInstructions(appTargetName),
+      ].join('\n'),
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return undefined;
+  }
+
+  clack.log.warn(
+    [
+      `Could not automatically match a hosted XCTest target to ${appTargetName}.`,
+      'This can happen when TEST_HOST uses Xcode build-setting macros for the app bundle or executable name.',
+    ].join(' '),
   );
+
+  return await selectHostedTestTargetName({
+    appTargetName,
+    hostedTestTargetNames,
+    nonInteractive: options.nonInteractive,
+    promptMessage: 'Which hosted XCTest target should render SnapshotPreviews?',
+  });
+}
+
+async function selectHostedTestTargetName({
+  appTargetName,
+  hostedTestTargetNames,
+  nonInteractive,
+  promptMessage,
+}: {
+  appTargetName: string;
+  hostedTestTargetNames: string[];
+  nonInteractive: boolean | undefined;
+  promptMessage: string;
+}): Promise<string | undefined> {
+  if (hostedTestTargetNames.length === 1) {
+    return hostedTestTargetNames[0];
+  }
+
+  if (nonInteractive) {
+    clack.log.error(
+      [
+        `Could not automatically select the hosted XCTest target for ${appTargetName} in non-interactive mode.`,
+        `Available hosted XCTest targets: ${formatList(
+          hostedTestTargetNames,
+        )}.`,
+        'Pass --hosted-test-target <target-name> to select the target explicitly.',
+        manualAppleSnapshotsSetupInstructions(appTargetName),
+      ].join('\n'),
+    );
+    clack.outro('Apple Snapshots setup did not complete.');
+    return undefined;
+  }
+
+  const selection = await abortIfCancelled(
+    askForItemSelection(hostedTestTargetNames, promptMessage),
+  );
+  return selection.value;
+}
+
+function manualAppleSnapshotsSetupInstructions(appTargetName: string): string {
+  return [
+    'Manual setup:',
+    `1. Add the ${SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT} package product to the hosted XCTest target for ${appTargetName}.`,
+    `2. Add the ${SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT} package product to ${appTargetName} if its Swift previews use SnapshotPreviews modifiers.`,
+    '3. Add this XCTest source file to the hosted XCTest target:',
+    '```swift',
+    snapshotTestTemplate('SnapshotPreviewsSnapshotTest').trimEnd(),
+    '```',
+    '4. Run the hosted XCTest target with xcodebuild.',
+  ].join('\n');
+}
+
+function formatList(values: string[]): string {
+  return values.length > 0 ? values.join(', ') : 'none';
 }
 
 function targetHasSwiftPreviews(

--- a/src/apple/snapshots/configure-snapshotpreviews-xcode-project.ts
+++ b/src/apple/snapshots/configure-snapshotpreviews-xcode-project.ts
@@ -1,0 +1,62 @@
+import type {
+  SwiftPackageProductSpec,
+  SwiftPackageSpec,
+  XcodeProject,
+} from '../xcode-manager';
+import {
+  SNAPSHOTPREVIEWS_MINIMUM_VERSION,
+  SNAPSHOTPREVIEWS_PACKAGE_URL,
+  SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT,
+  SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
+} from './snapshotpreviews-package';
+
+export const snapshotPreviewsPackageSpec: SwiftPackageSpec = {
+  repositoryURL: SNAPSHOTPREVIEWS_PACKAGE_URL,
+  requirement: {
+    kind: 'upToNextMajorVersion',
+    minimumVersion: SNAPSHOTPREVIEWS_MINIMUM_VERSION,
+  },
+  commentName: 'SnapshotPreviews',
+};
+
+export const snapshottingTestsProductSpec: SwiftPackageProductSpec = {
+  package: snapshotPreviewsPackageSpec,
+  productName: SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
+};
+
+export const snapshotPreferencesProductSpec: SwiftPackageProductSpec = {
+  package: snapshotPreviewsPackageSpec,
+  productName: SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT,
+};
+
+export function configureSnapshotPreviewsXcodeProject({
+  xcodeProject,
+  hostedTestTargetName,
+  previewTargetNames = [],
+}: {
+  xcodeProject: XcodeProject;
+  hostedTestTargetName: string;
+  previewTargetNames?: string[];
+}): { changed: boolean; linked: boolean } {
+  if (!xcodeProject.getUnitTestTargetNames().includes(hostedTestTargetName)) {
+    return { changed: false, linked: false };
+  }
+
+  const linkResults = [
+    xcodeProject.ensureSwiftPackageProductLinked(
+      hostedTestTargetName,
+      snapshottingTestsProductSpec,
+    ),
+    ...previewTargetNames.map((previewTargetName) =>
+      xcodeProject.ensureSwiftPackageProductLinked(
+        previewTargetName,
+        snapshotPreferencesProductSpec,
+      ),
+    ),
+  ];
+
+  return {
+    changed: linkResults.some((result) => result.changed),
+    linked: linkResults.every((result) => result.linked),
+  };
+}

--- a/src/apple/snapshots/snapshot-test-file.ts
+++ b/src/apple/snapshots/snapshot-test-file.ts
@@ -1,0 +1,128 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { XcodeProject } from '../xcode-manager';
+
+const SNAPSHOT_TEST_IMPORT = 'import SnapshottingTests';
+const SNAPSHOT_TEST_SUPERCLASS = ': SnapshotTest';
+
+export function ensureSnapshotTestFile({
+  xcodeProject,
+  hostedTestTargetName,
+}: {
+  xcodeProject: XcodeProject;
+  hostedTestTargetName: string;
+}): { changed: boolean; included: boolean; filePath?: string } {
+  const existingSnapshotTestFile = findExistingSnapshotTestFile(
+    xcodeProject,
+    hostedTestTargetName,
+  );
+  if (existingSnapshotTestFile) {
+    return {
+      changed: false,
+      included: true,
+      filePath: existingSnapshotTestFile,
+    };
+  }
+
+  const className = snapshotTestClassName(hostedTestTargetName);
+  const filePath = path.join(
+    getSnapshotTestDirectory(xcodeProject, hostedTestTargetName),
+    `${className}.swift`,
+  );
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const fileCreated = !fs.existsSync(filePath);
+  if (fileCreated) {
+    fs.writeFileSync(filePath, snapshotTestTemplate(className), 'utf8');
+  }
+
+  const membership = xcodeProject.addSwiftSourceFileToTarget({
+    targetName: hostedTestTargetName,
+    filePath,
+  });
+
+  if (!membership.included) {
+    if (fileCreated) {
+      fs.unlinkSync(filePath);
+    }
+
+    return { changed: false, included: false };
+  }
+
+  return {
+    changed: fileCreated || membership.changed,
+    included: true,
+    filePath,
+  };
+}
+
+export function snapshotTestClassName(hostedTestTargetName: string): string {
+  return `${swiftSafeTypeName(hostedTestTargetName)}SnapshotTest`;
+}
+
+export function snapshotTestTemplate(className: string): string {
+  return `${SNAPSHOT_TEST_IMPORT}
+
+final class ${className}: SnapshotTest {
+  override class func snapshotPreviews() -> [String]? { nil }
+  override class func excludedSnapshotPreviews() -> [String]? { nil }
+  override class func snapshotPreviewModules() -> [String]? { nil }
+  override class func excludedSnapshotPreviewModules() -> [String]? { nil }
+}
+`;
+}
+
+export function swiftSafeTypeName(value: string): string {
+  const words = value.split(/[^A-Za-z0-9]+/).filter((word) => word.length > 0);
+  const typeName = words
+    .map((word) => `${word[0].toUpperCase()}${word.slice(1)}`)
+    .join('');
+
+  if (!typeName) {
+    return 'Snapshots';
+  }
+
+  return /^[0-9]/.test(typeName) ? `_${typeName}` : typeName;
+}
+
+function findExistingSnapshotTestFile(
+  xcodeProject: XcodeProject,
+  hostedTestTargetName: string,
+): string | undefined {
+  const sourceFiles =
+    xcodeProject.getSourceFilesForTarget(hostedTestTargetName);
+  return sourceFiles?.find((filePath) => {
+    if (!filePath.endsWith('.swift') || !fs.existsSync(filePath)) {
+      return false;
+    }
+
+    const contents = fs.readFileSync(filePath, 'utf8');
+    return (
+      contents.includes(SNAPSHOT_TEST_IMPORT) &&
+      contents.includes(SNAPSHOT_TEST_SUPERCLASS)
+    );
+  });
+}
+
+function getSnapshotTestDirectory(
+  xcodeProject: XcodeProject,
+  hostedTestTargetName: string,
+): string {
+  const synchronizedRootGroupPath =
+    xcodeProject.getSynchronizedRootGroupPathsForTarget(
+      hostedTestTargetName,
+    )[0];
+  if (synchronizedRootGroupPath) {
+    return synchronizedRootGroupPath;
+  }
+
+  const existingSwiftFile = xcodeProject
+    .getSourceFilesForTarget(hostedTestTargetName)
+    ?.find((filePath) => filePath.endsWith('.swift'));
+  if (existingSwiftFile) {
+    return path.dirname(existingSwiftFile);
+  }
+
+  return path.join(xcodeProject.baseDir, hostedTestTargetName);
+}

--- a/src/apple/snapshots/snapshot-verification-scheme.ts
+++ b/src/apple/snapshots/snapshot-verification-scheme.ts
@@ -1,0 +1,199 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import xml from 'xml-js';
+
+type SnapshotVerificationSchemeOptions = {
+  hostedTestTargetName: string;
+  xcodeprojPath: string;
+};
+
+type ExplicitScheme = {
+  name: string;
+  testTargetNames: string[];
+};
+
+export function resolveSnapshotVerificationSchemeName({
+  hostedTestTargetName,
+  xcodeprojPath,
+}: SnapshotVerificationSchemeOptions): string | undefined {
+  try {
+    const explicitSchemes = getExplicitSchemes(xcodeprojPath);
+    const matchingExplicitSchemes = explicitSchemes.filter((scheme) =>
+      scheme.testTargetNames.includes(hostedTestTargetName),
+    );
+    const matchingExplicitSchemeNames = uniqueStrings(
+      matchingExplicitSchemes.map((scheme) => scheme.name),
+    );
+    if (matchingExplicitSchemeNames.length === 1) {
+      return matchingExplicitSchemeNames[0];
+    }
+
+    const explicitSchemeNames = uniqueStrings(
+      explicitSchemes.map((scheme) => scheme.name),
+    );
+    if (explicitSchemeNames.length === 1) {
+      return explicitSchemeNames[0];
+    }
+
+    const managedSchemeNames = getManagedSchemeNames(xcodeprojPath);
+    if (managedSchemeNames.length === 1) {
+      return managedSchemeNames[0];
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getExplicitSchemes(xcodeprojPath: string): ExplicitScheme[] {
+  return getSchemeFilePaths(xcodeprojPath).flatMap((schemePath) => {
+    const schemeName = path.basename(schemePath, '.xcscheme');
+    const testTargetNames = readSchemeTestTargetNames(schemePath);
+    return schemeName ? [{ name: schemeName, testTargetNames }] : [];
+  });
+}
+
+function getSchemeFilePaths(xcodeprojPath: string): string[] {
+  return [
+    path.join(xcodeprojPath, 'xcshareddata', 'xcschemes'),
+    path.join(xcodeprojPath, 'xcuserdata'),
+  ].flatMap((schemeDirectory) =>
+    findFilesWithExtension(schemeDirectory, '.xcscheme'),
+  );
+}
+
+function readSchemeTestTargetNames(schemePath: string): string[] {
+  try {
+    const scheme = xml.xml2js(fs.readFileSync(schemePath, 'utf8'), {
+      compact: true,
+    });
+    const testAction = getChild(getChild(scheme, 'Scheme'), 'TestAction');
+    const targetNames = new Set<string>();
+    collectBlueprintNames(testAction, targetNames);
+    return [...targetNames];
+  } catch {
+    return [];
+  }
+}
+
+function getManagedSchemeNames(xcodeprojPath: string): string[] {
+  return uniqueStrings(
+    findFilesWithName(xcodeprojPath, 'xcschememanagement.plist').flatMap(
+      readManagedSchemeNames,
+    ),
+  );
+}
+
+function readManagedSchemeNames(plistPath: string): string[] {
+  try {
+    const plist = xml.xml2js(fs.readFileSync(plistPath, 'utf8'), {
+      compact: true,
+    });
+    return collectElementText(plist, 'key').flatMap(parseManagedSchemeName);
+  } catch {
+    return [];
+  }
+}
+
+function parseManagedSchemeName(key: string): string[] {
+  const match = /^(.+)\.xcscheme(?:_.+)?$/.exec(key);
+  return match ? [match[1]] : [];
+}
+
+function findFilesWithExtension(
+  directory: string,
+  extension: string,
+): string[] {
+  return findFiles(directory, (filePath) => filePath.endsWith(extension));
+}
+
+function findFilesWithName(directory: string, fileName: string): string[] {
+  return findFiles(
+    directory,
+    (filePath) => path.basename(filePath) === fileName,
+  );
+}
+
+function findFiles(
+  directory: string,
+  predicate: (filePath: string) => boolean,
+): string[] {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  try {
+    return fs
+      .readdirSync(directory, { withFileTypes: true })
+      .flatMap((entry) => {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          return findFiles(entryPath, predicate);
+        }
+
+        return predicate(entryPath) ? [entryPath] : [];
+      });
+  } catch {
+    return [];
+  }
+}
+
+function getChild(node: unknown, childName: string): unknown {
+  return isRecord(node) ? node[childName] : undefined;
+}
+
+function collectBlueprintNames(node: unknown, targetNames: Set<string>): void {
+  if (Array.isArray(node)) {
+    node.forEach((item) => collectBlueprintNames(item, targetNames));
+    return;
+  }
+
+  if (!isRecord(node)) {
+    return;
+  }
+
+  const attributes = node._attributes;
+  if (isRecord(attributes) && typeof attributes.BlueprintName === 'string') {
+    targetNames.add(attributes.BlueprintName);
+  }
+
+  Object.values(node).forEach((value) =>
+    collectBlueprintNames(value, targetNames),
+  );
+}
+
+function collectElementText(node: unknown, elementName: string): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item) => collectElementText(item, elementName));
+  }
+
+  if (!isRecord(node)) {
+    return [];
+  }
+
+  return Object.entries(node).flatMap(([key, value]) => {
+    const childText = key === elementName ? collectTextValues(value) : [];
+    return childText.concat(collectElementText(value, elementName));
+  });
+}
+
+function collectTextValues(node: unknown): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap(collectTextValues);
+  }
+
+  if (!isRecord(node)) {
+    return [];
+  }
+
+  return typeof node._text === 'string' ? [node._text] : [];
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/apple/snapshots/snapshot-verification-scheme.ts
+++ b/src/apple/snapshots/snapshot-verification-scheme.ts
@@ -28,13 +28,6 @@ export function resolveSnapshotVerificationSchemeName({
       return matchingExplicitSchemeNames[0];
     }
 
-    const explicitSchemeNames = uniqueStrings(
-      explicitSchemes.map((scheme) => scheme.name),
-    );
-    if (explicitSchemeNames.length === 1) {
-      return explicitSchemeNames[0];
-    }
-
     const managedSchemeNames = getManagedSchemeNames(xcodeprojPath);
     if (managedSchemeNames.length === 1) {
       return managedSchemeNames[0];

--- a/src/apple/snapshots/snapshotpreviews-package.ts
+++ b/src/apple/snapshots/snapshotpreviews-package.ts
@@ -1,0 +1,8 @@
+export const SNAPSHOTPREVIEWS_PACKAGE_URL =
+  'https://github.com/getsentry/SnapshotPreviews';
+
+export const SNAPSHOTPREVIEWS_MINIMUM_VERSION = '0.17.0';
+
+export const SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT = 'SnapshottingTests';
+
+export const SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT = 'SnapshotPreferences';

--- a/src/apple/snapshots/snapshots-cli-preflight.ts
+++ b/src/apple/snapshots/snapshots-cli-preflight.ts
@@ -1,0 +1,146 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// @ts-expect-error - clack is ESM and TS complains about that. It works though
+import clack from '@clack/prompts';
+import * as Sentry from '@sentry/node';
+import * as bash from '../../utils/bash';
+import { checkInstalledCLI } from '../check-installed-cli';
+import * as fastlane from '../fastlane';
+import { snapshotTestClassName } from './snapshot-test-file';
+
+type SnapshotVerificationGuidance = {
+  appId?: string;
+  hostedTestTargetName: string;
+  projectDir: string;
+  projectPath: string;
+  schemeName?: string;
+};
+
+export async function checkInstalledCLISnapshots({
+  projectDir,
+  verificationGuidance,
+}: {
+  projectDir: string;
+  verificationGuidance: SnapshotVerificationGuidance;
+}): Promise<void> {
+  const hasCli = await checkInstalledCLI(
+    "Without sentry-cli, you won't be able to upload snapshots to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+  );
+
+  if (hasCli) {
+    verifySnapshotsUploadCommand();
+  }
+
+  printSnapshotsUploadGuidance({
+    fastlaneGuidance: getSnapshotFastlaneGuidance(projectDir),
+    verificationGuidance,
+  });
+}
+
+export function getSnapshotFastlaneGuidance(projectDir: string) {
+  const fastfilePath = fastlane.fastFile(projectDir) ?? undefined;
+  if (!fastfilePath) {
+    return {
+      hasUploadLane: false,
+      hasSentryUploadAction: false,
+    };
+  }
+
+  const contents = fs.readFileSync(fastfilePath, 'utf8');
+  return {
+    fastfilePath,
+    hasUploadLane: /lane\s+:upload_sentry_snapshots\b/.test(contents),
+    hasSentryUploadAction: /\bsentry_upload_snapshots\s*\(/.test(contents),
+  };
+}
+
+function verifySnapshotsUploadCommand(): void {
+  try {
+    bash.executeSync('sentry-cli snapshots upload --help');
+    Sentry.setTag('sentry-cli-snapshots-upload', true);
+    clack.log.success('sentry-cli snapshots upload is available.');
+  } catch {
+    Sentry.setTag('sentry-cli-snapshots-upload', false);
+    clack.log.warn(
+      'sentry-cli is installed, but this version does not expose `sentry-cli snapshots upload`. Please update sentry-cli before uploading snapshots.',
+    );
+  }
+}
+
+function printSnapshotsUploadGuidance({
+  fastlaneGuidance,
+  verificationGuidance,
+}: {
+  fastlaneGuidance: ReturnType<typeof getSnapshotFastlaneGuidance>;
+  verificationGuidance: SnapshotVerificationGuidance;
+}): void {
+  if (fastlaneGuidance.fastfilePath && fastlaneGuidance.hasUploadLane) {
+    clack.log.info(
+      [
+        'Detected existing Fastlane snapshots upload support.',
+        buildSnapshotExportCommand(verificationGuidance),
+        'Then verify upload with:',
+        'bundle exec fastlane ios upload_sentry_snapshots path:"$PWD/snapshot-images"',
+      ].join('\n'),
+    );
+    return;
+  }
+
+  if (fastlaneGuidance.fastfilePath && fastlaneGuidance.hasSentryUploadAction) {
+    clack.log.info(
+      [
+        'Detected a Fastlane lane that calls sentry_upload_snapshots.',
+        'After exporting snapshots, run that existing lane with your snapshot image path.',
+        'If you are unsure which lane to use, fall back to sentry-cli snapshots upload below.',
+      ].join('\n'),
+    );
+  }
+
+  clack.log.info(
+    [
+      buildSnapshotExportCommand(verificationGuidance),
+      '',
+      'After SnapshotPreviews exports images, verify local upload with:',
+      'sentry-cli snapshots upload "$PWD/snapshot-images" \\',
+      '  --org your-org \\',
+      '  --project your-ios-project \\',
+      verificationGuidance.appId
+        ? `  --app-id ${verificationGuidance.appId}`
+        : '  --app-id YOUR_APP_BUNDLE_ID # replace with your app bundle identifier',
+      '',
+      'Auth comes from SENTRY_AUTH_TOKEN or --auth-token. CI workflow setup is documented at https://docs.sentry.io/platforms/apple/snapshots/#step-3-integrate-into-ci; this wizard does not write workflow files.',
+    ].join('\n'),
+  );
+}
+
+function buildSnapshotExportCommand(
+  guidance: SnapshotVerificationGuidance,
+): string {
+  return [
+    `From ${quoteShell(guidance.projectDir)}, export snapshots with:`,
+    'TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="$PWD/snapshot-images" \\',
+    'xcodebuild test \\',
+    `  -project ${quoteShell(
+      path.relative(guidance.projectDir, guidance.projectPath) ||
+        guidance.projectPath,
+    )} \\`,
+    `  -scheme ${
+      guidance.schemeName ? quoteShell(guidance.schemeName) : '<scheme>'
+    } \\`,
+    "  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \\",
+    `  -only-testing:${quoteShell(
+      `${guidance.hostedTestTargetName}/${snapshotTestClassName(
+        guidance.hostedTestTargetName,
+      )}`,
+    )} \\`,
+    '  CODE_SIGNING_ALLOWED=NO \\',
+    '  | xcpretty',
+  ].join('\n');
+}
+
+function quoteShell(value: string): string {
+  return /^[A-Za-z0-9_./:-]+$/.test(value)
+    ? value
+    : `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/apple/snapshots/snapshots-cli-preflight.ts
+++ b/src/apple/snapshots/snapshots-cli-preflight.ts
@@ -19,13 +19,16 @@ type SnapshotVerificationGuidance = {
 
 export async function checkInstalledCLISnapshots({
   projectDir,
+  nonInteractive,
   verificationGuidance,
 }: {
   projectDir: string;
+  nonInteractive?: boolean;
   verificationGuidance: SnapshotVerificationGuidance;
 }): Promise<void> {
   const hasCli = await checkInstalledCLI(
     "Without sentry-cli, you won't be able to upload snapshots to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+    nonInteractive,
   );
 
   if (hasCli) {

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -255,11 +255,23 @@ export class XcodeProject {
     return Object.keys(targets)
       .filter((key) => {
         const value = targets[key];
+        return this.isUnitTestTargetEntry(key, value);
+      })
+      .map((key) => {
+        return (targets[key] as PBXNativeTarget).name;
+      });
+  }
+
+  public getHostedUnitTestTargetNames(): string[] {
+    const targets = this.objects.PBXNativeTarget ?? {};
+    return Object.keys(targets)
+      .filter((key) => {
+        const value = targets[key];
         return (
-          !key.endsWith('_comment') &&
-          typeof value !== 'string' &&
-          unquote(value.productType) ===
-            'com.apple.product-type.bundle.unit-test'
+          this.isUnitTestTargetEntry(key, value) &&
+          this.getTargetBuildSettings(value).some((buildSettings) =>
+            Boolean(unquote(buildSettings.TEST_HOST).trim()),
+          )
         );
       })
       .map((key) => {
@@ -682,6 +694,18 @@ export class XcodeProject {
       `Found ${filesInSynchronizedRootGroups.length} files in synchronized root groups for target: ${targetName}`,
     );
     return [...filesInBuildPhase, ...filesInSynchronizedRootGroups];
+  }
+
+  private isUnitTestTargetEntry(
+    key: string,
+    value: PBXNativeTarget | string | undefined,
+  ): value is PBXNativeTarget {
+    return (
+      !key.endsWith('_comment') &&
+      typeof value !== 'string' &&
+      value !== undefined &&
+      unquote(value.productType) === 'com.apple.product-type.bundle.unit-test'
+    );
   }
 
   private getTargetBuildSettings(

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -6,6 +6,7 @@
 import * as clack from '@clack/prompts';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { lt, valid } from 'semver';
 import { debug } from '../utils/debug';
 import type { SentryProjectData } from '../utils/types';
 import * as templates from './templates';
@@ -31,6 +32,106 @@ interface ProjectFile {
   key?: string;
   name: string;
   path: string;
+}
+
+export type SwiftPackageSpec = {
+  repositoryURL: string;
+  requirement: {
+    kind: 'upToNextMajorVersion';
+    minimumVersion: string;
+  };
+  commentName: string;
+};
+
+export type SwiftPackageProductSpec = {
+  package: SwiftPackageSpec;
+  productName: string;
+};
+
+function unquote(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/"/g, '') : '';
+}
+
+function stripAppExtension(value: string | undefined): string | undefined {
+  return value?.endsWith('.app') ? value.slice(0, -'.app'.length) : value;
+}
+
+function resolveBuildSettingValue(
+  value: unknown,
+  targetName: string,
+): string | undefined {
+  const resolvedValue = unquote(value)
+    .replace(/\$\(TARGET_NAME\)/g, targetName)
+    .replace(/\$\{TARGET_NAME\}/g, targetName)
+    .trim();
+
+  return resolvedValue && !resolvedValue.includes('$')
+    ? resolvedValue
+    : undefined;
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter(Boolean))] as string[];
+}
+
+function testHostReferencesApplication(
+  testHost: unknown,
+  appHostCandidates: ApplicationHostCandidates,
+): boolean {
+  const resolvedTestHost = unquote(testHost);
+  if (!resolvedTestHost) {
+    return false;
+  }
+
+  const referencesAppBundle = appHostCandidates.bundleNames.some((bundleName) =>
+    containsPathSegment(resolvedTestHost, `${bundleName}.app`),
+  );
+  if (!referencesAppBundle) {
+    return false;
+  }
+
+  return appHostCandidates.executableNames.some((executableName) =>
+    containsPathSegment(resolvedTestHost, executableName),
+  );
+}
+
+function containsPathSegment(value: string, segment: string): boolean {
+  return new RegExp(`(^|/)${escapeRegExp(segment)}(/|$)`).test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeSwiftPackageRepositoryURL(value: unknown): string {
+  return unquote(value).replace(/\/+$/, '');
+}
+
+function shouldUpdatePackageRequirement(
+  existingRequirement: unknown,
+  requestedRequirement: SwiftPackageSpec['requirement'],
+): boolean {
+  if (!existingRequirement || typeof existingRequirement !== 'object') {
+    return true;
+  }
+
+  const requirement = existingRequirement as Record<string, unknown>;
+  if (requirement.kind !== requestedRequirement.kind) {
+    return true;
+  }
+
+  const existingMinimumVersion = requirement.minimumVersion;
+  if (typeof existingMinimumVersion !== 'string') {
+    return true;
+  }
+
+  const existingVersion = valid(existingMinimumVersion);
+  const requestedVersion = valid(requestedRequirement.minimumVersion);
+  if (!existingVersion || !requestedVersion) {
+    return existingMinimumVersion !== requestedRequirement.minimumVersion;
+  }
+
+  return lt(existingVersion, requestedVersion);
 }
 
 function setDebugInformationFormatAndSandbox(
@@ -84,123 +185,16 @@ function setDebugInformationFormatAndSandbox(
   }
 }
 
-function addSentrySPM(proj: Project, targetName: string): void {
-  const xcObjects = proj.hash.project.objects;
+export type SwiftPackageProductLinkOptions = {
+  product: SwiftPackageProductSpec;
+  existingFrameworkComment?: string;
+  successMessage?: string;
+};
 
-  const sentryFrameworkUUID = proj.generateUuid();
-  const sentrySPMUUID = proj.generateUuid();
-
-  // Check whether xcObjects already have sentry framework
-  if (xcObjects.PBXFrameworksBuildPhase) {
-    for (const key in xcObjects.PBXFrameworksBuildPhase || {}) {
-      const frameworkBuildPhase = xcObjects.PBXFrameworksBuildPhase[key];
-      if (key.endsWith('_comment') || typeof frameworkBuildPhase === 'string') {
-        // Ignore comments
-        continue;
-      }
-      for (const framework of frameworkBuildPhase.files ?? []) {
-        // We identify the Sentry framework by the comment "Sentry in Frameworks",
-        // which is set by this manager in previous runs.
-        if (framework.comment === 'Sentry in Frameworks') {
-          return;
-        }
-      }
-    }
-  }
-
-  if (!xcObjects.PBXBuildFile) {
-    xcObjects.PBXBuildFile = {};
-  }
-  xcObjects.PBXBuildFile[sentryFrameworkUUID] = {
-    isa: 'PBXBuildFile',
-    productRef: sentrySPMUUID,
-    productRef_comment: 'Sentry',
-  };
-  xcObjects.PBXBuildFile[`${sentryFrameworkUUID}_comment`] =
-    'Sentry in Frameworks';
-
-  if (!xcObjects.PBXFrameworksBuildPhase) {
-    xcObjects.PBXFrameworksBuildPhase = {};
-  }
-  for (const key in xcObjects.PBXFrameworksBuildPhase) {
-    const value = xcObjects.PBXFrameworksBuildPhase[key];
-    if (key.endsWith('_comment') || typeof value === 'string') {
-      // Ignore comments
-      continue;
-    }
-
-    const frameworks = value.files ?? [];
-    frameworks.push({
-      value: sentryFrameworkUUID,
-      comment: 'Sentry in Frameworks',
-    });
-    value.files = frameworks;
-
-    xcObjects.PBXFrameworksBuildPhase[key] = value;
-  }
-
-  if (!xcObjects.PBXNativeTarget) {
-    xcObjects.PBXNativeTarget = {};
-  }
-  const targetKey = Object.keys(xcObjects.PBXNativeTarget || {}).filter(
-    (key) => {
-      const value = xcObjects.PBXNativeTarget?.[key];
-      return (
-        !key.endsWith('_comment') &&
-        typeof value !== 'string' &&
-        value?.name === targetName
-      );
-    },
-  )[0];
-  const target = xcObjects.PBXNativeTarget[targetKey] as PBXNativeTarget;
-
-  if (!target.packageProductDependencies) {
-    target.packageProductDependencies = [];
-  }
-  target.packageProductDependencies.push({
-    value: sentrySPMUUID,
-    comment: 'Sentry',
-  });
-
-  const sentrySwiftPackageUUID = proj.generateUuid();
-  const xcProject = proj.getFirstProject().firstProject;
-  if (!xcProject.packageReferences) {
-    xcProject.packageReferences = [];
-  }
-  xcProject.packageReferences.push({
-    value: sentrySwiftPackageUUID,
-    comment: 'XCRemoteSwiftPackageReference "sentry-cocoa"',
-  });
-
-  if (!xcObjects.XCRemoteSwiftPackageReference) {
-    xcObjects.XCRemoteSwiftPackageReference = {};
-  }
-
-  xcObjects.XCRemoteSwiftPackageReference[sentrySwiftPackageUUID] = {
-    isa: 'XCRemoteSwiftPackageReference',
-    repositoryURL: '"https://github.com/getsentry/sentry-cocoa/"',
-    requirement: {
-      kind: 'upToNextMajorVersion',
-      minimumVersion: '8.0.0',
-    },
-  };
-  xcObjects.XCRemoteSwiftPackageReference[`${sentrySwiftPackageUUID}_comment`] =
-    'XCRemoteSwiftPackageReference "sentry-cocoa"';
-
-  if (!xcObjects.XCSwiftPackageProductDependency) {
-    xcObjects.XCSwiftPackageProductDependency = {};
-  }
-  xcObjects.XCSwiftPackageProductDependency[sentrySPMUUID] = {
-    isa: 'XCSwiftPackageProductDependency',
-    package: sentrySwiftPackageUUID,
-    package_comment: 'XCRemoteSwiftPackageReference "sentry-cocoa"',
-    productName: 'Sentry',
-  };
-  xcObjects.XCSwiftPackageProductDependency[`${sentrySPMUUID}_comment`] =
-    'Sentry';
-
-  clack.log.step('Added Sentry SPM dependency to your project');
-}
+type ApplicationHostCandidates = {
+  bundleNames: string[];
+  executableNames: string[];
+};
 
 export class XcodeProject {
   /**
@@ -256,10 +250,142 @@ export class XcodeProject {
       });
   }
 
+  public getUnitTestTargetNames(): string[] {
+    const targets = this.objects.PBXNativeTarget ?? {};
+    return Object.keys(targets)
+      .filter((key) => {
+        const value = targets[key];
+        return (
+          !key.endsWith('_comment') &&
+          typeof value !== 'string' &&
+          unquote(value.productType) ===
+            'com.apple.product-type.bundle.unit-test'
+        );
+      })
+      .map((key) => {
+        return (targets[key] as PBXNativeTarget).name;
+      });
+  }
+
+  public getHostedUnitTestTargetNamesForApplicationTarget(
+    appTargetName: string,
+  ): string[] {
+    const appTarget = this.findNativeTargetByName(appTargetName);
+    if (!appTarget) {
+      return [];
+    }
+
+    const appHostCandidates = this.getApplicationHostCandidates(appTarget);
+    const targets = this.objects.PBXNativeTarget ?? {};
+    return Object.keys(targets)
+      .filter((key) => {
+        const value = targets[key];
+        return (
+          !key.endsWith('_comment') &&
+          typeof value !== 'string' &&
+          unquote(value.productType) ===
+            'com.apple.product-type.bundle.unit-test' &&
+          this.getTargetBuildSettings(value).some((buildSettings) =>
+            testHostReferencesApplication(
+              buildSettings.TEST_HOST,
+              appHostCandidates,
+            ),
+          )
+        );
+      })
+      .map((key) => {
+        return (targets[key] as PBXNativeTarget).name;
+      });
+  }
+
+  public getBundleIdentifierForTarget(targetName: string): string | undefined {
+    const target = this.findNativeTargetByName(targetName);
+    if (!target) {
+      return undefined;
+    }
+
+    return this.getTargetBuildSettings(target.obj)
+      .map((buildSettings) => {
+        return unquote(buildSettings.PRODUCT_BUNDLE_IDENTIFIER);
+      })
+      .find(Boolean);
+  }
+
+  /**
+   * Idempotently links a Swift package product to one target dependency list
+   * and Frameworks build phase. Returns whether the pbxproj graph changed and
+   * whether the product is linked after the operation.
+   */
+  public ensureSwiftPackageProductLinked(
+    targetName: string,
+    product: SwiftPackageProductSpec,
+  ): { changed: boolean; linked: boolean } {
+    const target = this.findNativeTargetByName(targetName);
+    if (!target) {
+      debug(`Target not found: ${targetName}`);
+      return { changed: false, linked: false };
+    }
+
+    const frameworksBuildPhase = this.findFrameworksBuildPhaseInTarget(
+      target.obj,
+    );
+    if (!frameworksBuildPhase) {
+      debug(`Frameworks build phase not found for target: ${targetName}`);
+      return { changed: false, linked: false };
+    }
+
+    let changed = false;
+
+    // Ensure the remote Swift package object exists.
+    const packageReference = this.ensureSwiftPackageReference(product.package);
+    changed = packageReference.changed || changed;
+
+    // Attach the Swift package object to the root Xcode project.
+    changed =
+      this.ensureProjectSwiftPackageReference(
+        packageReference.packageRefId,
+        product.package.commentName,
+      ) || changed;
+
+    // Ensure the package product dependency object exists.
+    const productDependency = this.ensureSwiftPackageProductDependency(
+      packageReference.packageRefId,
+      product,
+    );
+    changed = productDependency.changed || changed;
+
+    if (!target.obj.packageProductDependencies) {
+      target.obj.packageProductDependencies = [];
+    }
+
+    // Attach the package product dependency to the selected target.
+    if (
+      !target.obj.packageProductDependencies.some((dependency) => {
+        return dependency.value === productDependency.productDependencyId;
+      })
+    ) {
+      target.obj.packageProductDependencies.push({
+        value: productDependency.productDependencyId,
+        comment: product.productName,
+      });
+      changed = true;
+    }
+
+    // Link the package product in the target Frameworks build phase.
+    changed =
+      this.ensureFrameworksBuildFile(
+        frameworksBuildPhase,
+        productDependency.productDependencyId,
+        product,
+      ) || changed;
+
+    return { changed, linked: true };
+  }
+
   public updateXcodeProject(
     sentryProject: SentryProjectData,
     target: string,
-    addSPMReference: boolean,
+    swiftPackageProduct?: SwiftPackageProductLinkOptions,
     uploadSource = true,
   ): void {
     this.addUploadSymbolsScript({
@@ -270,11 +396,25 @@ export class XcodeProject {
     if (uploadSource) {
       setDebugInformationFormatAndSandbox(this.project, target);
     }
-    if (addSPMReference) {
-      addSentrySPM(this.project, target);
+    if (
+      swiftPackageProduct &&
+      !(
+        swiftPackageProduct.existingFrameworkComment &&
+        this.hasFrameworkBuildFileCommentInTarget(
+          target,
+          swiftPackageProduct.existingFrameworkComment,
+        )
+      )
+    ) {
+      const result = this.ensureSwiftPackageProductLinked(
+        target,
+        swiftPackageProduct.product,
+      );
+      if (result.changed && swiftPackageProduct.successMessage) {
+        clack.log.step(swiftPackageProduct.successMessage);
+      }
     }
-    const newContent = this.project.writeSync();
-    fs.writeFileSync(this.pbxprojPath, newContent);
+    this.write();
   }
 
   addUploadSymbolsScript({
@@ -389,6 +529,116 @@ export class XcodeProject {
     }
   }
 
+  public write(): void {
+    const newContent = this.project.writeSync();
+    fs.writeFileSync(this.pbxprojPath, newContent);
+  }
+
+  public getSynchronizedRootGroupPathsForTarget(targetName: string): string[] {
+    const nativeTarget = this.findNativeTargetByName(targetName);
+    if (!nativeTarget) {
+      return [];
+    }
+
+    return (nativeTarget.obj.fileSystemSynchronizedGroups ?? []).reduce(
+      (groupPaths, group) => {
+        const groupObj =
+          this.objects.PBXFileSystemSynchronizedRootGroup?.[group.value];
+        if (!groupObj || typeof groupObj !== 'object') {
+          return groupPaths;
+        }
+
+        const groupPath = this.resolveAbsolutePathOfSynchronizedRootGroup({
+          id: group.value,
+          obj: groupObj,
+        });
+        if (!groupPath) {
+          return groupPaths;
+        }
+
+        return groupPaths.concat(groupPath);
+      },
+      new Array<string>(),
+    );
+  }
+
+  /**
+   * Ensures a Swift file is compiled by a target, either through an Xcode
+   * synchronized root group or an explicit Sources build phase entry.
+   */
+  public addSwiftSourceFileToTarget(args: {
+    targetName: string;
+    filePath: string;
+  }): { changed: boolean; included: boolean } {
+    const nativeTarget = this.findNativeTargetByName(args.targetName);
+    const defaultResult = { changed: false, included: false };
+    if (!nativeTarget) {
+      debug(`Target not found: ${args.targetName}`);
+      return defaultResult;
+    }
+
+    const absoluteFilePath = args.filePath;
+    if (
+      this.isFileIncludedBySynchronizedRootGroup(nativeTarget, absoluteFilePath)
+    ) {
+      return {
+        changed: false,
+        included: true,
+      };
+    }
+
+    const sourceBuildPhase = this.findSourceBuildPhaseInTarget(
+      nativeTarget.obj,
+    );
+    if (!sourceBuildPhase) {
+      debug(`Sources build phase not found for target: ${args.targetName}`);
+      return defaultResult;
+    }
+
+    const fileReference = this.ensureSwiftFileReference(absoluteFilePath);
+    const sourceBuildPhaseFiles = sourceBuildPhase.obj.files ?? [];
+    const existingBuildFileReference = sourceBuildPhaseFiles.find((file) => {
+      const buildFile = this.objects.PBXBuildFile?.[file.value];
+      return (
+        buildFile &&
+        typeof buildFile !== 'string' &&
+        buildFile.fileRef === fileReference.fileReferenceId
+      );
+    });
+
+    if (existingBuildFileReference) {
+      return {
+        changed: fileReference.changed,
+        included: true,
+      };
+    }
+
+    if (!this.objects.PBXBuildFile) {
+      this.objects.PBXBuildFile = {};
+    }
+
+    const buildFileId = this.project.generateUuid();
+    const fileName = path.basename(absoluteFilePath);
+    this.objects.PBXBuildFile[buildFileId] = {
+      isa: 'PBXBuildFile',
+      fileRef: fileReference.fileReferenceId,
+      fileRef_comment: fileName,
+    };
+    this.objects.PBXBuildFile[
+      `${buildFileId}_comment`
+    ] = `${fileName} in Sources`;
+
+    sourceBuildPhase.obj.files = [
+      ...sourceBuildPhaseFiles,
+      {
+        value: buildFileId,
+        comment: `${fileName} in Sources`,
+      },
+    ];
+
+    return { changed: true, included: true };
+  }
+
   /**
    * Retrieves all source files associated with a specific target in the Xcode project.
    * This is used to find files where we can inject Sentry initialization code.
@@ -432,6 +682,409 @@ export class XcodeProject {
       `Found ${filesInSynchronizedRootGroups.length} files in synchronized root groups for target: ${targetName}`,
     );
     return [...filesInBuildPhase, ...filesInSynchronizedRootGroups];
+  }
+
+  private getTargetBuildSettings(
+    target: PBXNativeTarget,
+  ): Record<string, unknown>[] {
+    const buildConfigurationListId = target.buildConfigurationList;
+    if (!buildConfigurationListId) {
+      return [];
+    }
+
+    const configurationList = this.objects.XCConfigurationList?.[
+      buildConfigurationListId
+    ] as XCConfigurationList | undefined;
+    if (!configurationList || typeof configurationList === 'string') {
+      return [];
+    }
+
+    return (configurationList.buildConfigurations ?? []).reduce(
+      (buildSettings, buildConfiguration) => {
+        const configuration =
+          this.objects.XCBuildConfiguration?.[buildConfiguration.value];
+        if (!configuration || typeof configuration === 'string') {
+          return buildSettings;
+        }
+
+        return buildSettings.concat(configuration.buildSettings ?? {});
+      },
+      new Array<Record<string, unknown>>(),
+    );
+  }
+
+  private getApplicationHostCandidates(
+    target: XcodeProjectObjectWithId<PBXNativeTarget>,
+  ): ApplicationHostCandidates {
+    const buildSettings = this.getTargetBuildSettings(target.obj);
+    const productReferencePath = this.getProductReferencePath(target.obj);
+    const productReferenceName = stripAppExtension(productReferencePath);
+    const targetProductName = resolveBuildSettingValue(
+      target.obj.productName,
+      target.obj.name,
+    );
+    const buildSettingProductNames = buildSettings.flatMap((settings) => [
+      resolveBuildSettingValue(settings.PRODUCT_NAME, target.obj.name),
+      stripAppExtension(
+        resolveBuildSettingValue(settings.FULL_PRODUCT_NAME, target.obj.name),
+      ),
+      stripAppExtension(
+        resolveBuildSettingValue(settings.WRAPPER_NAME, target.obj.name),
+      ),
+    ]);
+    const buildSettingExecutableNames = buildSettings.map((settings) =>
+      resolveBuildSettingValue(settings.EXECUTABLE_NAME, target.obj.name),
+    );
+
+    return {
+      bundleNames: uniqueStrings([
+        target.obj.name,
+        targetProductName,
+        productReferenceName,
+        ...buildSettingProductNames,
+      ]),
+      executableNames: uniqueStrings([
+        target.obj.name,
+        targetProductName,
+        productReferenceName,
+        ...buildSettingExecutableNames,
+      ]),
+    };
+  }
+
+  private getProductReferencePath(target: PBXNativeTarget): string | undefined {
+    if (!target.productReference) {
+      return undefined;
+    }
+
+    const productReference =
+      this.objects.PBXFileReference?.[target.productReference];
+    if (!productReference || typeof productReference === 'string') {
+      return undefined;
+    }
+
+    return unquote(productReference.path);
+  }
+
+  private hasFrameworkBuildFileCommentInTarget(
+    targetName: string,
+    comment: string,
+  ): boolean {
+    const target = this.findNativeTargetByName(targetName);
+    if (!target) {
+      return false;
+    }
+
+    const frameworksBuildPhase = this.findFrameworksBuildPhaseInTarget(
+      target.obj,
+    );
+    return (frameworksBuildPhase?.files ?? []).some((framework) => {
+      return framework.comment === comment;
+    });
+  }
+
+  private ensureSwiftPackageReference(packageSpec: SwiftPackageSpec): {
+    packageRefId: string;
+    changed: boolean;
+  } {
+    if (!this.objects.XCRemoteSwiftPackageReference) {
+      this.objects.XCRemoteSwiftPackageReference = {};
+    }
+
+    const packageReferences = this.objects
+      .XCRemoteSwiftPackageReference as Record<string, unknown>;
+    const requestedRepositoryURL = normalizeSwiftPackageRepositoryURL(
+      packageSpec.repositoryURL,
+    );
+    const existingPackageReference = Object.entries(packageReferences).find(
+      ([id, value]) => {
+        if (id.endsWith('_comment') || typeof value !== 'object') {
+          return false;
+        }
+
+        const packageReference = value as Record<string, unknown>;
+        return (
+          normalizeSwiftPackageRepositoryURL(packageReference.repositoryURL) ===
+          requestedRepositoryURL
+        );
+      },
+    );
+
+    if (existingPackageReference) {
+      const packageReference = existingPackageReference[1] as Record<
+        string,
+        unknown
+      >;
+      if (
+        shouldUpdatePackageRequirement(
+          packageReference.requirement,
+          packageSpec.requirement,
+        )
+      ) {
+        packageReference.requirement = packageSpec.requirement;
+        return { packageRefId: existingPackageReference[0], changed: true };
+      }
+
+      return { packageRefId: existingPackageReference[0], changed: false };
+    }
+
+    const packageRefId = this.project.generateUuid();
+    packageReferences[packageRefId] = {
+      isa: 'XCRemoteSwiftPackageReference',
+      repositoryURL: `"${packageSpec.repositoryURL}"`,
+      requirement: packageSpec.requirement,
+    };
+    packageReferences[`${packageRefId}_comment`] =
+      this.swiftPackageReferenceComment(packageSpec.commentName);
+
+    return { packageRefId, changed: true };
+  }
+
+  private ensureProjectSwiftPackageReference(
+    packageRefId: string,
+    commentName: string,
+  ): boolean {
+    const xcodeProject = this.project.getFirstProject().firstProject as {
+      packageReferences?: { value: string; comment?: string }[];
+    };
+    if (!xcodeProject.packageReferences) {
+      xcodeProject.packageReferences = [];
+    }
+
+    if (
+      xcodeProject.packageReferences.some((packageReference) => {
+        return packageReference.value === packageRefId;
+      })
+    ) {
+      return false;
+    }
+
+    xcodeProject.packageReferences.push({
+      value: packageRefId,
+      comment: this.swiftPackageReferenceComment(commentName),
+    });
+    return true;
+  }
+
+  private ensureSwiftPackageProductDependency(
+    packageRefId: string,
+    product: SwiftPackageProductSpec,
+  ): { productDependencyId: string; changed: boolean } {
+    if (!this.objects.XCSwiftPackageProductDependency) {
+      this.objects.XCSwiftPackageProductDependency = {};
+    }
+
+    const productDependencies = this.objects
+      .XCSwiftPackageProductDependency as Record<string, unknown>;
+    const existingProductDependency = Object.entries(productDependencies).find(
+      ([id, value]) => {
+        if (id.endsWith('_comment') || typeof value !== 'object') {
+          return false;
+        }
+
+        const productDependency = value as Record<string, unknown>;
+        return (
+          productDependency.package === packageRefId &&
+          productDependency.productName === product.productName
+        );
+      },
+    );
+
+    if (existingProductDependency) {
+      return {
+        productDependencyId: existingProductDependency[0],
+        changed: false,
+      };
+    }
+
+    const productDependencyId = this.project.generateUuid();
+    productDependencies[productDependencyId] = {
+      isa: 'XCSwiftPackageProductDependency',
+      package: packageRefId,
+      package_comment: this.swiftPackageReferenceComment(
+        product.package.commentName,
+      ),
+      productName: product.productName,
+    };
+    productDependencies[`${productDependencyId}_comment`] = product.productName;
+
+    return { productDependencyId, changed: true };
+  }
+
+  private ensureFrameworksBuildFile(
+    frameworksBuildPhase: {
+      files?: { value: string; comment?: string }[];
+    },
+    productDependencyId: string,
+    product: SwiftPackageProductSpec,
+  ): boolean {
+    if (!this.objects.PBXBuildFile) {
+      this.objects.PBXBuildFile = {};
+    }
+
+    const existingFrameworkEntry = (frameworksBuildPhase.files ?? []).find(
+      (framework) => {
+        const buildFile = this.objects.PBXBuildFile?.[framework.value];
+        return (
+          buildFile &&
+          typeof buildFile !== 'string' &&
+          buildFile.productRef === productDependencyId
+        );
+      },
+    );
+    if (existingFrameworkEntry) {
+      return false;
+    }
+
+    const buildFileId = this.project.generateUuid();
+    this.objects.PBXBuildFile[buildFileId] = {
+      isa: 'PBXBuildFile',
+      productRef: productDependencyId,
+      productRef_comment: product.productName,
+    };
+    this.objects.PBXBuildFile[
+      `${buildFileId}_comment`
+    ] = `${product.productName} in Frameworks`;
+
+    if (!frameworksBuildPhase.files) {
+      frameworksBuildPhase.files = [];
+    }
+    frameworksBuildPhase.files.push({
+      value: buildFileId,
+      comment: `${product.productName} in Frameworks`,
+    });
+
+    return true;
+  }
+
+  private findFrameworksBuildPhaseInTarget(target: PBXNativeTarget):
+    | {
+        files?: { value: string; comment?: string }[];
+      }
+    | undefined {
+    for (const buildPhaseReference of target.buildPhases ?? []) {
+      const buildPhase =
+        this.objects.PBXFrameworksBuildPhase?.[buildPhaseReference.value];
+      if (buildPhase && typeof buildPhase !== 'string') {
+        return buildPhase as { files?: { value: string; comment?: string }[] };
+      }
+    }
+
+    return undefined;
+  }
+
+  private swiftPackageReferenceComment(commentName: string): string {
+    return `XCRemoteSwiftPackageReference "${commentName}"`;
+  }
+
+  private isFileIncludedBySynchronizedRootGroup(
+    nativeTarget: XcodeProjectObjectWithId<PBXNativeTarget>,
+    absoluteFilePath: string,
+  ): boolean {
+    return this.findFilesInSynchronizedRootGroups(nativeTarget).some(
+      (filePath) => filePath === absoluteFilePath,
+    );
+  }
+
+  private ensureSwiftFileReference(absoluteFilePath: string): {
+    fileReferenceId: string;
+    changed: boolean;
+  } {
+    if (!this.objects.PBXFileReference) {
+      this.objects.PBXFileReference = {};
+    }
+
+    const existingFileReference = Object.entries(
+      this.objects.PBXFileReference,
+    ).find(([id, fileReference]) => {
+      if (id.endsWith('_comment') || typeof fileReference !== 'object') {
+        return false;
+      }
+
+      const resolvedFilePath = this.resolveAbsolutePathOfFileReference({
+        id,
+        obj: fileReference,
+      });
+      return resolvedFilePath === absoluteFilePath;
+    });
+
+    if (existingFileReference) {
+      return { fileReferenceId: existingFileReference[0], changed: false };
+    }
+
+    const fileReferenceId = this.project.generateUuid();
+    const fileName = path.basename(absoluteFilePath);
+    const relativePath = path.relative(this.baseDir, absoluteFilePath);
+    this.objects.PBXFileReference[fileReferenceId] = {
+      isa: 'PBXFileReference',
+      lastKnownFileType: 'sourcecode.swift',
+      path: relativePath,
+      sourceTree: 'SOURCE_ROOT',
+    };
+    this.objects.PBXFileReference[`${fileReferenceId}_comment`] = fileName;
+
+    this.addFileReferenceToBestGroup(
+      fileReferenceId,
+      fileName,
+      absoluteFilePath,
+    );
+
+    return { fileReferenceId, changed: true };
+  }
+
+  private addFileReferenceToBestGroup(
+    fileReferenceId: string,
+    fileName: string,
+    absoluteFilePath: string,
+  ): void {
+    const parentDirectory = path.dirname(absoluteFilePath);
+    const parentGroup =
+      this.groups.find((group) => {
+        const groupPath = this.resolveAbsolutePathOfGroup(group);
+        return groupPath === parentDirectory;
+      }) ?? this.mainGroup;
+
+    if (!parentGroup) {
+      return;
+    }
+
+    if (!parentGroup.obj.children) {
+      parentGroup.obj.children = [];
+    }
+
+    if (
+      parentGroup.obj.children.some((child) => child.value === fileReferenceId)
+    ) {
+      return;
+    }
+
+    parentGroup.obj.children.push({
+      value: fileReferenceId,
+      comment: fileName,
+    });
+  }
+
+  private get mainGroup(): XcodeProjectObjectWithId<PBXGroup> | undefined {
+    const project = Object.entries(this.objects.PBXProject ?? {}).find(
+      ([id, candidate]) => {
+        return !id.endsWith('_comment') && typeof candidate === 'object';
+      },
+    )?.[1];
+    if (!project || typeof project !== 'object') {
+      return undefined;
+    }
+
+    const mainGroupId = (project as { mainGroup?: string }).mainGroup;
+    if (!mainGroupId) {
+      return undefined;
+    }
+
+    const mainGroup = this.objects.PBXGroup?.[mainGroupId];
+    if (!mainGroup || typeof mainGroup !== 'object') {
+      return undefined;
+    }
+
+    return { id: mainGroupId, obj: mainGroup };
   }
 
   // ================================ TARGET HELPERS ================================

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import { run as legacyRun } from '../lib/Setup';
 import { runAndroidWizard } from './android/android-wizard';
 import { runAngularWizard } from './angular/angular-wizard';
 import { runAppleWizard } from './apple/apple-wizard';
+import { runAppleSnapshotsWizard } from './apple/snapshots/apple-snapshots-wizard';
 import { runFlutterWizard } from './flutter/flutter-wizard';
 import { runNextjsWizard } from './nextjs/nextjs-wizard';
 import { runNuxtWizard } from './nuxt/nuxt-wizard';
@@ -26,6 +27,7 @@ type WizardIntegration =
   | 'reactNative'
   | 'flutter'
   | 'ios'
+  | 'appleSnapshots'
   | 'android'
   | 'cordova'
   | 'electron'
@@ -121,6 +123,7 @@ export async function run(argv: Args) {
           { value: 'reactNative', label: 'React Native' },
           { value: 'flutter', label: 'Flutter' },
           { value: 'ios', label: 'iOS' },
+          { value: 'appleSnapshots', label: 'Apple Snapshots' },
           { value: 'angular', label: 'Angular' },
           { value: 'android', label: 'Android' },
           { value: 'cordova', label: 'Cordova' },
@@ -169,6 +172,13 @@ export async function run(argv: Args) {
 
     case 'ios':
       await runAppleWizard({
+        ...wizardOptions,
+        projectDir: finalArgs.xcodeProjectDir,
+      });
+      break;
+
+    case 'appleSnapshots':
+      await runAppleSnapshotsWizard({
         ...wizardOptions,
         projectDir: finalArgs.xcodeProjectDir,
       });

--- a/src/run.ts
+++ b/src/run.ts
@@ -47,6 +47,7 @@ type Args = {
   skipConnect: boolean;
   debug: boolean;
   quiet: boolean;
+  nonInteractive: boolean;
   disableTelemetry: boolean;
   spotlight?: boolean;
   promoCode?: string;
@@ -70,6 +71,8 @@ type Args = {
   comingFrom?: string;
   ignoreGitChanges?: boolean;
   xcodeProjectDir?: string;
+  appTarget?: string;
+  hostedTestTarget?: string;
 };
 
 function preSelectedProjectArgsToObject(
@@ -181,6 +184,9 @@ export async function run(argv: Args) {
       await runAppleSnapshotsWizard({
         ...wizardOptions,
         projectDir: finalArgs.xcodeProjectDir,
+        appTarget: finalArgs.appTarget,
+        hostedTestTarget: finalArgs.hostedTestTarget,
+        nonInteractive: finalArgs.nonInteractive,
       });
       break;
 
@@ -225,6 +231,7 @@ export async function run(argv: Args) {
       void legacyRun(
         {
           ...argv,
+          quiet: finalArgs.quiet,
           url: argv.url ?? '',
           integration: Integration.cordova,
           platform: argv.platform ?? [],
@@ -238,6 +245,7 @@ export async function run(argv: Args) {
       void legacyRun(
         {
           ...argv,
+          quiet: finalArgs.quiet,
           url: argv.url ?? '',
           integration: Integration.electron,
           platform: argv.platform ?? [],

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -204,6 +204,7 @@ You can turn this off at any time by running ${chalk.cyanBright(
 export async function confirmContinueIfNoOrDirtyGitRepo(options: {
   ignoreGitChanges: boolean | undefined;
   cwd: string | undefined;
+  nonInteractive?: boolean;
 }): Promise<void> {
   return traceStep('check-git-status', async () => {
     if (
@@ -212,6 +213,14 @@ export async function confirmContinueIfNoOrDirtyGitRepo(options: {
       }) &&
       options.ignoreGitChanges !== true
     ) {
+      if (options.nonInteractive) {
+        clack.log.error(
+          'Project is not inside a git repository in non-interactive mode. Run from a git repository or pass --ignore-git-changes to skip this safety check.',
+        );
+        Sentry.setTag('continue-without-git', false);
+        await abort();
+      }
+
       const continueWithoutGit = await abortIfCancelled(
         clack.confirm({
           message:
@@ -242,6 +251,15 @@ ${uncommittedOrUntrackedFiles.join('\n')}
 
 The wizard will create and update files.`,
       );
+
+      if (options.nonInteractive) {
+        clack.log.error(
+          'Project has uncommitted or untracked files in non-interactive mode. Commit or stash your changes, or pass --ignore-git-changes to skip this safety check.',
+        );
+        Sentry.setTag('continue-with-dirty-repo', false);
+        await abort();
+      }
+
       const continueWithDirtyRepo = await abortIfCancelled(
         clack.confirm({
           message: 'Do you want to continue anyway?',

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -228,7 +228,9 @@ export async function confirmContinueIfNoOrDirtyGitRepo(options: {
       return;
     }
 
-    const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles();
+    const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles({
+      cwd: options.cwd,
+    });
     if (
       uncommittedOrUntrackedFiles.length &&
       options.ignoreGitChanges !== true

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -20,12 +20,15 @@ export function isInGitRepo(opts: { cwd: string | undefined }) {
   }
 }
 
-export function getUncommittedOrUntrackedFiles(): string[] {
+export function getUncommittedOrUntrackedFiles(opts?: {
+  cwd: string | undefined;
+}): string[] {
   try {
     const gitStatus = childProcess
       .execSync('git status --porcelain=v1', {
         // we only care about stdout
         stdio: ['ignore', 'pipe', 'ignore'],
+        cwd: opts?.cwd,
       })
       .toString();
 

--- a/test/apple/lookup-xcode-project.test.ts
+++ b/test/apple/lookup-xcode-project.test.ts
@@ -1,0 +1,198 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockXcodeProject = {
+  projectPath: string;
+  xcodeprojPath: string;
+  getAllTargets: () => string[];
+};
+
+const mocks = vi.hoisted(() => {
+  const targetsByProjectPath = new Map<string, string[]>();
+
+  return {
+    abort: vi.fn(() => {
+      throw new Error('abort');
+    }),
+    askForItemSelection: vi.fn(),
+    clackError: vi.fn(),
+    debug: vi.fn(),
+    searchXcodeProjectAtPath: vi.fn(),
+    setTag: vi.fn(),
+    targetsByProjectPath,
+    traceStep: vi.fn(
+      async <T>(_name: string, callback: () => Promise<T> | T): Promise<T> =>
+        await callback(),
+    ),
+    XcodeProject: vi.fn(function (this: MockXcodeProject, projectPath: string) {
+      this.projectPath = projectPath;
+      this.xcodeprojPath = path.dirname(projectPath);
+      this.getAllTargets = () => targetsByProjectPath.get(projectPath) ?? [];
+    }),
+  };
+});
+
+vi.mock('@clack/prompts', () => ({
+  default: {
+    log: {
+      error: mocks.clackError,
+    },
+  },
+}));
+
+vi.mock('@sentry/node', () => ({
+  setTag: mocks.setTag,
+}));
+
+vi.mock('../../src/apple/search-xcode-project-at-path', () => ({
+  searchXcodeProjectAtPath: mocks.searchXcodeProjectAtPath,
+}));
+
+vi.mock('../../src/apple/xcode-manager', () => ({
+  XcodeProject: mocks.XcodeProject,
+}));
+
+vi.mock('../../src/telemetry', () => ({
+  traceStep: mocks.traceStep,
+}));
+
+vi.mock('../../src/utils/clack', () => ({
+  abort: mocks.abort,
+  askForItemSelection: mocks.askForItemSelection,
+}));
+
+vi.mock('../../src/utils/debug', () => ({
+  debug: mocks.debug,
+}));
+
+import {
+  lookupXcodeProject,
+  selectXcodeTarget,
+} from '../../src/apple/lookup-xcode-project';
+
+function createProject(projectDir: string, projectName: string): string {
+  const projectPath = path.join(projectDir, projectName);
+  fs.mkdirSync(projectPath, { recursive: true });
+  const pbxprojPath = path.join(projectPath, 'project.pbxproj');
+  fs.writeFileSync(pbxprojPath, 'mock pbxproj');
+
+  return pbxprojPath;
+}
+
+function createMockXcodeProject(
+  pbxprojPath: string,
+): Parameters<typeof selectXcodeTarget>[0] {
+  const XcodeProjectConstructor = mocks.XcodeProject as unknown as {
+    new (projectPath: string): MockXcodeProject;
+  };
+
+  return new XcodeProjectConstructor(pbxprojPath) as unknown as Parameters<
+    typeof selectXcodeTarget
+  >[0];
+}
+
+describe('lookup-xcode-project', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'lookup-xcode-project-'),
+    );
+    vi.clearAllMocks();
+    mocks.targetsByProjectPath.clear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { force: true, recursive: true });
+  });
+
+  describe('lookupXcodeProject', () => {
+    it('returns an Xcode project without selecting a target', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.searchXcodeProjectAtPath.mockReturnValue(['App.xcodeproj']);
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App']);
+
+      const result = await lookupXcodeProject({ projectDir });
+
+      expect(mocks.searchXcodeProjectAtPath).toHaveBeenCalledWith(projectDir);
+      expect(mocks.XcodeProject).toHaveBeenCalledWith(pbxprojPath);
+      expect(result).toEqual(
+        expect.objectContaining({ projectPath: pbxprojPath }),
+      );
+      expect(mocks.askForItemSelection).not.toHaveBeenCalledWith(
+        ['App'],
+        'Which target do you want to add Sentry to?',
+      );
+    });
+
+    it('prompts when multiple Xcode projects are found', async () => {
+      createProject(projectDir, 'First.xcodeproj');
+      const selectedPbxprojPath = createProject(projectDir, 'Second.xcodeproj');
+      mocks.searchXcodeProjectAtPath.mockReturnValue([
+        'First.xcodeproj',
+        'Second.xcodeproj',
+      ]);
+      mocks.askForItemSelection.mockResolvedValue({
+        value: 'Second.xcodeproj',
+      });
+
+      const result = await lookupXcodeProject({ projectDir });
+
+      expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+        ['First.xcodeproj', 'Second.xcodeproj'],
+        'Which project do you want to add Sentry to?',
+      );
+      expect(result).toEqual(
+        expect.objectContaining({ projectPath: selectedPbxprojPath }),
+      );
+    });
+  });
+
+  describe('selectXcodeTarget', () => {
+    it('returns the only target without prompting', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App']);
+      const xcProject = createMockXcodeProject(pbxprojPath);
+
+      const result = await selectXcodeTarget(xcProject);
+
+      expect(result).toBe('App');
+      expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    });
+
+    it('prompts when multiple targets are available', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App', 'Widget']);
+      mocks.askForItemSelection.mockResolvedValue({ value: 'Widget' });
+      const xcProject = createMockXcodeProject(pbxprojPath);
+
+      const result = await selectXcodeTarget(xcProject);
+
+      expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+        ['App', 'Widget'],
+        'Which target do you want to add Sentry to?',
+      );
+      expect(result).toBe('Widget');
+    });
+
+    it('selects from custom target candidates', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App']);
+      mocks.askForItemSelection.mockResolvedValue({ value: 'AppUITests' });
+      const xcProject = createMockXcodeProject(pbxprojPath);
+
+      const result = await selectXcodeTarget(xcProject, {
+        targetNames: ['AppTests', 'AppUITests'],
+        promptMessage: 'Which test target should render SnapshotPreviews?',
+      });
+
+      expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+        ['AppTests', 'AppUITests'],
+        'Which test target should render SnapshotPreviews?',
+      );
+      expect(result).toBe('AppUITests');
+    });
+  });
+});

--- a/test/apple/lookup-xcode-project.test.ts
+++ b/test/apple/lookup-xcode-project.test.ts
@@ -148,6 +148,24 @@ describe('lookup-xcode-project', () => {
         expect.objectContaining({ projectPath: selectedPbxprojPath }),
       );
     });
+
+    it('fails instead of prompting when multiple Xcode projects are found in non-interactive mode', async () => {
+      createProject(projectDir, 'First.xcodeproj');
+      createProject(projectDir, 'Second.xcodeproj');
+      mocks.searchXcodeProjectAtPath.mockReturnValue([
+        'First.xcodeproj',
+        'Second.xcodeproj',
+      ]);
+
+      await expect(
+        lookupXcodeProject({ projectDir, nonInteractive: true }),
+      ).rejects.toThrow('abort');
+
+      expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+      expect(mocks.clackError).toHaveBeenCalledWith(
+        expect.stringContaining('Multiple Xcode projects found'),
+      );
+    });
   });
 
   describe('selectXcodeTarget', () => {

--- a/test/apple/snapshots/apple-snapshots-wizard.test.ts
+++ b/test/apple/snapshots/apple-snapshots-wizard.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   confirmContinueIfNoOrDirtyGitRepo: vi.fn(),
   configureSnapshotPreviewsXcodeProject: vi.fn(),
   ensureSnapshotTestFile: vi.fn(),
+  error: vi.fn(),
   info: vi.fn(),
   lookupXcodeProject: vi.fn(),
   outro: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock('@clack/prompts', () => ({
   default: {
     confirm: mocks.confirm,
     log: {
+      error: mocks.error,
       info: mocks.info,
       success: mocks.success,
       warn: mocks.warn,
@@ -75,6 +77,15 @@ vi.mock('../../../src/apple/lookup-xcode-project', () => ({
 
 vi.mock('../../../src/apple/snapshots/snapshot-test-file', () => ({
   ensureSnapshotTestFile: mocks.ensureSnapshotTestFile,
+  snapshotTestTemplate: (className: string): string => `import SnapshottingTests
+
+final class ${className}: SnapshotTest {
+  override class func snapshotPreviews() -> [String]? { nil }
+  override class func excludedSnapshotPreviews() -> [String]? { nil }
+  override class func snapshotPreviewModules() -> [String]? { nil }
+  override class func excludedSnapshotPreviewModules() -> [String]? { nil }
+}
+`,
 }));
 
 vi.mock(
@@ -129,6 +140,7 @@ describe('runAppleSnapshotsWizard', () => {
         targetName === 'App' ? [selectedPreviewFile] : [otherPreviewFile],
       ),
       getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),
@@ -167,6 +179,10 @@ describe('runAppleSnapshotsWizard', () => {
       getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
       getSourceFilesForTarget: vi.fn(() => [previewFile]),
       getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
         'AppSnapshotTests',
@@ -211,6 +227,7 @@ describe('runAppleSnapshotsWizard', () => {
         targetName === 'App' ? [selectedFile] : [otherPreviewFile],
       ),
       getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),
@@ -238,6 +255,124 @@ describe('runAppleSnapshotsWizard', () => {
     });
   });
 
+  it('uses explicit app and hosted XCTest targets without prompting', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const previewFile = path.join(tempDir, 'ContentView.swift');
+    fs.writeFileSync(previewFile, '#Preview { ContentView() }', 'utf8');
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [previewFile]),
+      getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => []),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      appTarget: 'App',
+      hostedTestTarget: 'AppTests',
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+      nonInteractive: true,
+    });
+
+    expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    expect(
+      xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget,
+    ).not.toHaveBeenCalled();
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('falls back to prompting among hosted XCTest targets when app-specific matching is inconclusive', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const previewFile = path.join(tempDir, 'ContentView.swift');
+    fs.writeFileSync(previewFile, '#Preview { ContentView() }', 'utf8');
+    mocks.askForItemSelection.mockResolvedValue({
+      value: 'AppSnapshotTests',
+    });
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [previewFile]),
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => []),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+    });
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not automatically match'),
+    );
+    expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+      ['AppTests', 'AppSnapshotTests'],
+      'Which hosted XCTest target should render SnapshotPreviews?',
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppSnapshotTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('fails with manual instructions instead of prompting when hosted XCTest fallback is ambiguous in non-interactive mode', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const xcodeProject = {
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => []),
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+      nonInteractive: true,
+    });
+
+    expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Pass --hosted-test-target <target-name>'),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Manual setup:'),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('import SnapshottingTests'),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('final class SnapshotPreviewsSnapshotTest'),
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).not.toHaveBeenCalled();
+    expect(mocks.outro).toHaveBeenCalledWith(
+      'Apple Snapshots setup did not complete.',
+    );
+  });
+
   it('wires the Apple Snapshots flow without Sentry auth/runtime/CI mutation', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
     const previewFile = path.join(tempDir, 'ContentView.swift');
@@ -247,6 +382,7 @@ describe('runAppleSnapshotsWizard', () => {
       getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
       getSourceFilesForTarget: vi.fn(() => [previewFile]),
       getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),

--- a/test/apple/snapshots/apple-snapshots-wizard.test.ts
+++ b/test/apple/snapshots/apple-snapshots-wizard.test.ts
@@ -77,6 +77,8 @@ vi.mock('../../../src/apple/lookup-xcode-project', () => ({
 
 vi.mock('../../../src/apple/snapshots/snapshot-test-file', () => ({
   ensureSnapshotTestFile: mocks.ensureSnapshotTestFile,
+  snapshotTestClassName: (hostedTestTargetName: string): string =>
+    `${hostedTestTargetName}SnapshotTest`,
   snapshotTestTemplate: (className: string): string => `import SnapshottingTests
 
 final class ${className}: SnapshotTest {
@@ -248,6 +250,45 @@ describe('runAppleSnapshotsWizard', () => {
       expect.stringContaining('No Swift previews were found'),
     );
     expect(mocks.confirm).toHaveBeenCalledTimes(1);
+    expect(mocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('Continuing without Swift previews'),
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: [],
+    });
+  });
+
+  it('continues without the Swift previews confirmation in non-interactive mode', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const selectedFile = path.join(tempDir, 'SelectedView.swift');
+    fs.writeFileSync(selectedFile, 'struct SelectedView {}', 'utf8');
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [selectedFile]),
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
+        'AppTests',
+      ]),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+      nonInteractive: true,
+    });
+
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('Continuing without Swift previews'),
+    );
     expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
       xcodeProject,
       hostedTestTargetName: 'AppTests',
@@ -281,6 +322,18 @@ describe('runAppleSnapshotsWizard', () => {
     });
 
     expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    expect(mocks.confirmContinueIfNoOrDirtyGitRepo).toHaveBeenCalledWith({
+      ignoreGitChanges: true,
+      cwd: tempDir,
+      nonInteractive: true,
+    });
+    expect(mocks.lookupXcodeProject).toHaveBeenCalledWith({
+      projectDir: tempDir,
+      nonInteractive: true,
+    });
+    expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledWith(
+      expect.objectContaining({ nonInteractive: true }),
+    );
     expect(
       xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget,
     ).not.toHaveBeenCalled();
@@ -365,7 +418,7 @@ describe('runAppleSnapshotsWizard', () => {
       expect.stringContaining('import SnapshottingTests'),
     );
     expect(mocks.error).toHaveBeenCalledWith(
-      expect.stringContaining('final class SnapshotPreviewsSnapshotTest'),
+      expect.stringContaining('final class AppTestsSnapshotTest'),
     );
     expect(mocks.configureSnapshotPreviewsXcodeProject).not.toHaveBeenCalled();
     expect(mocks.outro).toHaveBeenCalledWith(
@@ -410,9 +463,11 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.confirmContinueIfNoOrDirtyGitRepo).toHaveBeenCalledWith({
       ignoreGitChanges: true,
       cwd: tempDir,
+      nonInteractive: undefined,
     });
     expect(mocks.lookupXcodeProject).toHaveBeenCalledWith({
       projectDir: tempDir,
+      nonInteractive: undefined,
     });
     expect(mocks.confirm).not.toHaveBeenCalled();
     expect(mocks.info).toHaveBeenCalledWith(
@@ -433,6 +488,7 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.write).toHaveBeenCalledTimes(1);
     expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledWith({
       projectDir: tempDir,
+      nonInteractive: undefined,
       verificationGuidance: {
         appId: 'com.getsentry.App',
         hostedTestTargetName: 'AppTests',

--- a/test/apple/snapshots/apple-snapshots-wizard.test.ts
+++ b/test/apple/snapshots/apple-snapshots-wizard.test.ts
@@ -1,0 +1,314 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  askForItemSelection: vi.fn(),
+  checkInstalledCLISnapshots: vi.fn(),
+  confirm: vi.fn(),
+  confirmContinueIfNoOrDirtyGitRepo: vi.fn(),
+  configureSnapshotPreviewsXcodeProject: vi.fn(),
+  ensureSnapshotTestFile: vi.fn(),
+  info: vi.fn(),
+  lookupXcodeProject: vi.fn(),
+  outro: vi.fn(),
+  printWelcome: vi.fn(),
+  resolveSnapshotVerificationSchemeName: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+  withTelemetry: vi.fn(
+    async (_options: { integration: string }, callback: () => Promise<void>) =>
+      await callback(),
+  ),
+  write: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  default: {
+    confirm: mocks.confirm,
+    log: {
+      info: mocks.info,
+      success: mocks.success,
+      warn: mocks.warn,
+    },
+    outro: mocks.outro,
+  },
+}));
+
+vi.mock('../../../src/telemetry', () => ({
+  withTelemetry: mocks.withTelemetry,
+}));
+
+vi.mock('../../../src/utils/clack', () => ({
+  abortIfCancelled: async <T>(value: T | Promise<T>) => await value,
+  askForItemSelection: mocks.askForItemSelection,
+  confirmContinueIfNoOrDirtyGitRepo: mocks.confirmContinueIfNoOrDirtyGitRepo,
+  printWelcome: mocks.printWelcome,
+}));
+
+vi.mock('../../../src/apple/lookup-xcode-project', () => ({
+  lookupXcodeProject: mocks.lookupXcodeProject,
+  selectXcodeTarget: async (
+    xcodeProject: { getAllTargets: () => string[] },
+    options: {
+      targetNames?: string[];
+      promptMessage?: string;
+    } = {},
+  ): Promise<string> => {
+    const targetNames = options.targetNames ?? xcodeProject.getAllTargets();
+    if (targetNames.length === 1) {
+      return targetNames[0];
+    }
+
+    const askForItemSelection = mocks.askForItemSelection as (
+      items: string[],
+      message: string,
+    ) => Promise<{ value: string }>;
+    const selection = await askForItemSelection(
+      targetNames,
+      options.promptMessage ?? 'Which target do you want to add Sentry to?',
+    );
+    return selection.value;
+  },
+}));
+
+vi.mock('../../../src/apple/snapshots/snapshot-test-file', () => ({
+  ensureSnapshotTestFile: mocks.ensureSnapshotTestFile,
+}));
+
+vi.mock(
+  '../../../src/apple/snapshots/configure-snapshotpreviews-xcode-project',
+  () => ({
+    configureSnapshotPreviewsXcodeProject:
+      mocks.configureSnapshotPreviewsXcodeProject,
+  }),
+);
+
+vi.mock('../../../src/apple/snapshots/snapshots-cli-preflight', () => ({
+  checkInstalledCLISnapshots: mocks.checkInstalledCLISnapshots,
+}));
+
+vi.mock('../../../src/apple/snapshots/snapshot-verification-scheme', () => ({
+  resolveSnapshotVerificationSchemeName:
+    mocks.resolveSnapshotVerificationSchemeName,
+}));
+
+import { runAppleSnapshotsWizard } from '../../../src/apple/snapshots/apple-snapshots-wizard';
+
+describe('runAppleSnapshotsWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureSnapshotTestFile.mockReturnValue({
+      changed: true,
+      included: true,
+    });
+    mocks.configureSnapshotPreviewsXcodeProject.mockReturnValue({
+      changed: true,
+      linked: true,
+    });
+    mocks.resolveSnapshotVerificationSchemeName.mockReturnValue('AppScheme');
+    mocks.askForItemSelection.mockResolvedValue({ value: 'App' });
+    mocks.confirm.mockResolvedValue(false);
+  });
+
+  it('links SnapshotPreferences only to the selected app target', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const selectedPreviewFile = path.join(tempDir, 'SelectedView.swift');
+    const otherPreviewFile = path.join(tempDir, 'OtherView.swift');
+    fs.writeFileSync(
+      selectedPreviewFile,
+      '#Preview { SelectedView() }',
+      'utf8',
+    );
+    fs.writeFileSync(otherPreviewFile, '#Preview { OtherView() }', 'utf8');
+    mocks.askForItemSelection.mockResolvedValue({ value: 'App' });
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn((targetName: string) =>
+        targetName === 'App' ? [selectedPreviewFile] : [otherPreviewFile],
+      ),
+      getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
+        'AppTests',
+      ]),
+      getUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+    });
+
+    expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+      ['App', 'OtherApp'],
+      'Which app target hosts your Swift previews?',
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('prompts only among unit-test targets hosted by the selected app target', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const previewFile = path.join(tempDir, 'ContentView.swift');
+    fs.writeFileSync(previewFile, '#Preview { ContentView() }', 'utf8');
+    mocks.askForItemSelection.mockResolvedValue({
+      value: 'AppSnapshotTests',
+    });
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [previewFile]),
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+    });
+
+    expect(
+      xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget,
+    ).toHaveBeenCalledWith('App');
+    expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+      ['AppTests', 'AppSnapshotTests'],
+      'Which test target should render SnapshotPreviews?',
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppSnapshotTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('does not link SnapshotPreferences when the selected app target has no Swift previews', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const selectedFile = path.join(tempDir, 'SelectedView.swift');
+    const otherPreviewFile = path.join(tempDir, 'OtherView.swift');
+    fs.writeFileSync(selectedFile, 'struct SelectedView {}', 'utf8');
+    fs.writeFileSync(otherPreviewFile, '#Preview { OtherView() }', 'utf8');
+    mocks.askForItemSelection.mockResolvedValue({ value: 'App' });
+    mocks.confirm.mockResolvedValue(true);
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn((targetName: string) =>
+        targetName === 'App' ? [selectedFile] : [otherPreviewFile],
+      ),
+      getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
+        'AppTests',
+      ]),
+      getUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+    });
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No Swift previews were found'),
+    );
+    expect(mocks.confirm).toHaveBeenCalledTimes(1);
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: [],
+    });
+  });
+
+  it('wires the Apple Snapshots flow without Sentry auth/runtime/CI mutation', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const previewFile = path.join(tempDir, 'ContentView.swift');
+    fs.writeFileSync(previewFile, '#Preview { ContentView() }', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'Package.swift'), '', 'utf8');
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [previewFile]),
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
+        'AppTests',
+      ]),
+      getUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+    });
+
+    expect(mocks.withTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ integration: 'appleSnapshots' }),
+      expect.any(Function),
+    );
+    expect(mocks.printWelcome).toHaveBeenCalledWith({
+      wizardName: 'Sentry Apple Snapshots Wizard',
+      promoCode: 'CAM',
+    });
+    expect(mocks.confirmContinueIfNoOrDirtyGitRepo).toHaveBeenCalledWith({
+      ignoreGitChanges: true,
+      cwd: tempDir,
+    });
+    expect(mocks.lookupXcodeProject).toHaveBeenCalledWith({
+      projectDir: tempDir,
+    });
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('SnapshotPreferences in Swift preview files'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('This wizard does not edit SwiftPM manifests'),
+    );
+    expect(mocks.ensureSnapshotTestFile).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+    });
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: ['App'],
+    });
+    expect(mocks.write).toHaveBeenCalledTimes(1);
+    expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledWith({
+      projectDir: tempDir,
+      verificationGuidance: {
+        appId: 'com.getsentry.App',
+        hostedTestTargetName: 'AppTests',
+        projectDir: tempDir,
+        projectPath: path.join(tempDir, 'App.xcodeproj'),
+        schemeName: 'AppScheme',
+      },
+    });
+    expect(mocks.outro).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'No Sentry auth, DSN, runtime SDK, dSYM, or CI workflow files',
+      ),
+    );
+  });
+});

--- a/test/apple/snapshots/hosted-test-target-fixture.ts
+++ b/test/apple/snapshots/hosted-test-target-fixture.ts
@@ -1,0 +1,229 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  PBXFileReference,
+  PBXNativeTarget,
+  PBXSourcesBuildPhase,
+  XCBuildConfiguration,
+  XCConfigurationList,
+} from 'xcode';
+
+import type { XcodeProject } from '../../../src/apple/xcode-manager';
+
+export type HostedTestTargetFixtureIds = {
+  targetId: string;
+  frameworksBuildPhaseId: string;
+  sourcesBuildPhaseId?: string;
+  debugBuildConfigurationId: string;
+  releaseBuildConfigurationId: string;
+  buildConfigurationListId: string;
+  productReferenceId: string;
+};
+
+const fixtureProjectPath = path.resolve(
+  __dirname,
+  '../../../fixtures/test-applications/apple/spm-swiftui-single-target/Project.xcodeproj/project.pbxproj',
+);
+
+type HostedTestTargetFixtureOptions = {
+  name?: string;
+  hostAppName?: string;
+  testHost?: string;
+  bundleLoader?: string;
+  ids?: HostedTestTargetFixtureIds;
+  includeSourcesBuildPhase?: boolean;
+  projectObjectId: string;
+  productsGroupId: string;
+};
+
+export function copySingleTargetProjectToTemp(prefix: string): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const xcodeprojDir = path.join(tempDir, 'Project.xcodeproj');
+  fs.mkdirSync(xcodeprojDir, { recursive: true });
+  fs.mkdirSync(path.join(tempDir, 'Sources'), { recursive: true });
+  fs.copyFileSync(
+    fixtureProjectPath,
+    path.join(xcodeprojDir, 'project.pbxproj'),
+  );
+  return path.join(xcodeprojDir, 'project.pbxproj');
+}
+
+export function addHostedUnitTestTarget(
+  xcodeProject: XcodeProject,
+  options: HostedTestTargetFixtureOptions,
+): HostedTestTargetFixtureIds {
+  const name = options.name ?? 'ProjectTests';
+  const ids = options.ids ?? hostedTestTargetFixtureIds(name);
+  const hostAppName = options.hostAppName ?? 'Project';
+  const buildSettings = hostedUnitTestBuildSettings({
+    bundleLoader: options.bundleLoader,
+    hostAppName,
+    name,
+    testHost: options.testHost,
+  });
+
+  xcodeProject.objects.PBXFileReference = {
+    ...(xcodeProject.objects.PBXFileReference ?? {}),
+    [ids.productReferenceId]: {
+      isa: 'PBXFileReference',
+      explicitFileType: 'wrapper.cfbundle',
+      includeInIndex: 0,
+      path: `${name}.xctest`,
+      sourceTree: 'BUILT_PRODUCTS_DIR',
+    } as unknown as PBXFileReference,
+    [`${ids.productReferenceId}_comment`]: `${name}.xctest`,
+  };
+
+  xcodeProject.objects.PBXFrameworksBuildPhase = {
+    ...(xcodeProject.objects.PBXFrameworksBuildPhase ?? {}),
+    [ids.frameworksBuildPhaseId]: {
+      isa: 'PBXFrameworksBuildPhase',
+      buildActionMask: 2147483647,
+      files: [],
+      runOnlyForDeploymentPostprocessing: 0,
+    },
+    [`${ids.frameworksBuildPhaseId}_comment`]: 'Frameworks',
+  };
+
+  const buildPhases = [
+    ...(options.includeSourcesBuildPhase && ids.sourcesBuildPhaseId
+      ? [
+          {
+            value: ids.sourcesBuildPhaseId,
+            comment: 'Sources',
+          },
+        ]
+      : []),
+    {
+      value: ids.frameworksBuildPhaseId,
+      comment: 'Frameworks',
+    },
+  ];
+
+  if (options.includeSourcesBuildPhase && ids.sourcesBuildPhaseId) {
+    xcodeProject.objects.PBXSourcesBuildPhase = {
+      ...(xcodeProject.objects.PBXSourcesBuildPhase ?? {}),
+      [ids.sourcesBuildPhaseId]: {
+        isa: 'PBXSourcesBuildPhase',
+        buildActionMask: 2147483647,
+        files: [],
+        runOnlyForDeploymentPostprocessing: 0,
+      } as PBXSourcesBuildPhase,
+      [`${ids.sourcesBuildPhaseId}_comment`]: 'Sources',
+    };
+  }
+
+  xcodeProject.objects.PBXNativeTarget = {
+    ...(xcodeProject.objects.PBXNativeTarget ?? {}),
+    [ids.targetId]: {
+      isa: 'PBXNativeTarget',
+      buildConfigurationList: ids.buildConfigurationListId,
+      buildPhases,
+      buildRules: [],
+      dependencies: [],
+      name,
+      packageProductDependencies: [],
+      productName: name,
+      productReference: ids.productReferenceId,
+      productType: '"com.apple.product-type.bundle.unit-test"',
+    } as PBXNativeTarget,
+    [`${ids.targetId}_comment`]: name,
+  };
+
+  xcodeProject.objects.XCBuildConfiguration = {
+    ...(xcodeProject.objects.XCBuildConfiguration ?? {}),
+    [ids.debugBuildConfigurationId]: {
+      isa: 'XCBuildConfiguration',
+      buildSettings,
+      name: 'Debug',
+    } as XCBuildConfiguration,
+    [`${ids.debugBuildConfigurationId}_comment`]: 'Debug',
+    [ids.releaseBuildConfigurationId]: {
+      isa: 'XCBuildConfiguration',
+      buildSettings,
+      name: 'Release',
+    } as XCBuildConfiguration,
+    [`${ids.releaseBuildConfigurationId}_comment`]: 'Release',
+  };
+
+  xcodeProject.objects.XCConfigurationList = {
+    ...(xcodeProject.objects.XCConfigurationList ?? {}),
+    [ids.buildConfigurationListId]: {
+      isa: 'XCConfigurationList',
+      buildConfigurations: [
+        {
+          value: ids.debugBuildConfigurationId,
+          comment: 'Debug',
+        },
+        {
+          value: ids.releaseBuildConfigurationId,
+          comment: 'Release',
+        },
+      ],
+      defaultConfigurationIsVisible: 0,
+      defaultConfigurationName: 'Release',
+    } as XCConfigurationList,
+    [`${ids.buildConfigurationListId}_comment`]: `Build configuration list for PBXNativeTarget "${name}"`,
+  };
+
+  const project = xcodeProject.objects.PBXProject?.[options.projectObjectId];
+  if (project && typeof project !== 'string') {
+    project.targets = [
+      ...(project.targets ?? []),
+      {
+        value: ids.targetId,
+        comment: name,
+      },
+    ];
+  }
+
+  const productsGroup =
+    xcodeProject.objects.PBXGroup?.[options.productsGroupId];
+  if (productsGroup && typeof productsGroup !== 'string') {
+    productsGroup.children = [
+      ...(productsGroup.children ?? []),
+      {
+        value: ids.productReferenceId,
+        comment: `${name}.xctest`,
+      },
+    ];
+  }
+
+  return ids;
+}
+
+export function hostedTestTargetFixtureIds(
+  name: string,
+): HostedTestTargetFixtureIds {
+  const idPrefix = name.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+  return {
+    targetId: `${idPrefix}000000000000000001`,
+    frameworksBuildPhaseId: `${idPrefix}000000000000000002`,
+    debugBuildConfigurationId: `${idPrefix}000000000000000003`,
+    releaseBuildConfigurationId: `${idPrefix}000000000000000004`,
+    buildConfigurationListId: `${idPrefix}000000000000000005`,
+    productReferenceId: `${idPrefix}000000000000000006`,
+  };
+}
+
+function hostedUnitTestBuildSettings({
+  bundleLoader,
+  hostAppName,
+  name,
+  testHost,
+}: {
+  bundleLoader?: string;
+  hostAppName: string;
+  name: string;
+  testHost?: string;
+}): Record<string, string> {
+  return {
+    BUNDLE_LOADER: bundleLoader ?? '"$(TEST_HOST)"',
+    PRODUCT_BUNDLE_IDENTIFIER: `com.getsentry.${name}`,
+    PRODUCT_NAME: '"$(TARGET_NAME)"',
+    TEST_HOST:
+      testHost ??
+      `"$(BUILT_PRODUCTS_DIR)/${hostAppName}.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/${hostAppName}"`,
+  };
+}

--- a/test/apple/snapshots/snapshot-test-file.test.ts
+++ b/test/apple/snapshots/snapshot-test-file.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ensureSnapshotTestFile,
+  swiftSafeTypeName,
+} from '../../../src/apple/snapshots/snapshot-test-file';
+import { XcodeProject } from '../../../src/apple/xcode-manager';
+import { copySingleTargetProjectToTemp } from './hosted-test-target-fixture';
+
+vi.mock('@clack/prompts', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+}));
+
+describe('ensureSnapshotTestFile', () => {
+  it('creates a minimal SnapshotTest file and reruns without duplication', () => {
+    const xcodeProject = new XcodeProject(
+      copySingleTargetProjectToTemp('snapshot-test-file-'),
+    );
+
+    const firstResult = ensureSnapshotTestFile({
+      xcodeProject,
+      hostedTestTargetName: 'Project',
+    });
+    const secondResult = ensureSnapshotTestFile({
+      xcodeProject,
+      hostedTestTargetName: 'Project',
+    });
+
+    expect(firstResult.changed).toBe(true);
+    expect(firstResult.included).toBe(true);
+    expect(secondResult.changed).toBe(false);
+    expect(secondResult.included).toBe(true);
+    expect(firstResult.filePath).toBe(
+      path.join(xcodeProject.baseDir, 'Sources', 'ProjectSnapshotTest.swift'),
+    );
+    expect(fs.readFileSync(firstResult.filePath ?? '', 'utf8')).toContain(
+      'final class ProjectSnapshotTest: SnapshotTest',
+    );
+    expect(
+      xcodeProject
+        .getSourceFilesForTarget('Project')
+        ?.filter((filePath) => filePath.endsWith('ProjectSnapshotTest.swift')),
+    ).toHaveLength(1);
+  });
+
+  it('removes a newly created SnapshotTest file when target membership fails', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'snapshot-test-file-fail-'),
+    );
+    const xcodeProject = {
+      baseDir: tempDir,
+      addSwiftSourceFileToTarget: vi.fn(() => ({
+        changed: false,
+        included: false,
+      })),
+      getSourceFilesForTarget: vi.fn(() => []),
+      getSynchronizedRootGroupPathsForTarget: vi.fn(() => []),
+    } as unknown as XcodeProject;
+
+    const result = ensureSnapshotTestFile({
+      xcodeProject,
+      hostedTestTargetName: 'ProjectTests',
+    });
+
+    expect(result).toEqual({ changed: false, included: false });
+    expect(
+      fs.existsSync(
+        path.join(tempDir, 'ProjectTests', 'ProjectTestsSnapshotTest.swift'),
+      ),
+    ).toBe(false);
+  });
+
+  it('generates Swift-safe type names', () => {
+    expect(swiftSafeTypeName('123 My-App Tests')).toBe('_123MyAppTests');
+  });
+});

--- a/test/apple/snapshots/snapshot-verification-scheme.test.ts
+++ b/test/apple/snapshots/snapshot-verification-scheme.test.ts
@@ -1,0 +1,181 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { resolveSnapshotVerificationSchemeName } from '../../../src/apple/snapshots/snapshot-verification-scheme';
+
+function createXcodeProject(): string {
+  const projectDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'snapshot-verification-scheme-'),
+  );
+  const xcodeprojPath = path.join(projectDir, 'App.xcodeproj');
+  fs.mkdirSync(xcodeprojPath, { recursive: true });
+  return xcodeprojPath;
+}
+
+function writeScheme({
+  name,
+  testTargetNames,
+  xcodeprojPath,
+}: {
+  name: string;
+  testTargetNames: string[];
+  xcodeprojPath: string;
+}): void {
+  const schemeDirectory = path.join(xcodeprojPath, 'xcshareddata', 'xcschemes');
+  fs.mkdirSync(schemeDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(schemeDirectory, `${name}.xcscheme`),
+    getSchemeXml(testTargetNames),
+    'utf8',
+  );
+}
+
+function writeSchemeManagementPlist({
+  schemeNames,
+  xcodeprojPath,
+}: {
+  schemeNames: string[];
+  xcodeprojPath: string;
+}): void {
+  const schemeDirectory = path.join(
+    xcodeprojPath,
+    'xcuserdata',
+    'cam.xcuserdatad',
+    'xcschemes',
+  );
+  fs.mkdirSync(schemeDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(schemeDirectory, 'xcschememanagement.plist'),
+    getSchemeManagementPlistXml(schemeNames),
+    'utf8',
+  );
+}
+
+function getSchemeXml(testTargetNames: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Scheme version="1.7">
+  <TestAction>
+    <Testables>
+${testTargetNames
+  .map(
+    (testTargetName) => `      <TestableReference skipped="NO">
+        <BuildableReference
+          BlueprintIdentifier="${testTargetName.toUpperCase()}ID"
+          BlueprintName="${testTargetName}"
+          BuildableName="${testTargetName}.xctest">
+        </BuildableReference>
+      </TestableReference>`,
+  )
+  .join('\n')}
+    </Testables>
+  </TestAction>
+</Scheme>
+`;
+}
+
+function getSchemeManagementPlistXml(schemeNames: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+  <dict>
+    <key>SchemeUserState</key>
+    <dict>
+${schemeNames
+  .map(
+    (schemeName) => `      <key>${schemeName}.xcscheme_^#shared#^_</key>
+      <dict>
+        <key>orderHint</key>
+        <integer>0</integer>
+      </dict>`,
+  )
+  .join('\n')}
+    </dict>
+  </dict>
+</plist>
+`;
+}
+
+describe('resolveSnapshotVerificationSchemeName', () => {
+  it('returns the explicit scheme that contains the hosted test target', () => {
+    const xcodeprojPath = createXcodeProject();
+    writeScheme({
+      name: 'App-Staging',
+      testTargetNames: ['AppTests'],
+      xcodeprojPath,
+    });
+    writeScheme({
+      name: 'App-Production',
+      testTargetNames: ['OtherTests'],
+      xcodeprojPath,
+    });
+
+    expect(
+      resolveSnapshotVerificationSchemeName({
+        hostedTestTargetName: 'AppTests',
+        xcodeprojPath,
+      }),
+    ).toBe('App-Staging');
+  });
+
+  it('returns the only explicit scheme when test target metadata is unavailable', () => {
+    const xcodeprojPath = createXcodeProject();
+    writeScheme({
+      name: 'App-CI',
+      testTargetNames: [],
+      xcodeprojPath,
+    });
+
+    expect(
+      resolveSnapshotVerificationSchemeName({
+        hostedTestTargetName: 'AppTests',
+        xcodeprojPath,
+      }),
+    ).toBe('App-CI');
+  });
+
+  it('returns the only managed implicit scheme when no scheme file exists', () => {
+    const xcodeprojPath = createXcodeProject();
+    writeSchemeManagementPlist({
+      schemeNames: ['cake'],
+      xcodeprojPath,
+    });
+
+    expect(
+      resolveSnapshotVerificationSchemeName({
+        hostedTestTargetName: 'sausageTests',
+        xcodeprojPath,
+      }),
+    ).toBe('cake');
+  });
+
+  it('returns undefined for ambiguous schemes', () => {
+    const xcodeprojPath = createXcodeProject();
+    writeSchemeManagementPlist({
+      schemeNames: ['App-Staging', 'App-Production'],
+      xcodeprojPath,
+    });
+
+    expect(
+      resolveSnapshotVerificationSchemeName({
+        hostedTestTargetName: 'AppTests',
+        xcodeprojPath,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when scheme discovery cannot traverse the project path', () => {
+    const projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'snapshot-verification-scheme-file-'),
+    );
+    const xcodeprojPath = path.join(projectDir, 'App.xcodeproj');
+    fs.writeFileSync(xcodeprojPath, '', 'utf8');
+
+    expect(
+      resolveSnapshotVerificationSchemeName({
+        hostedTestTargetName: 'AppTests',
+        xcodeprojPath,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/test/apple/snapshots/snapshot-verification-scheme.test.ts
+++ b/test/apple/snapshots/snapshot-verification-scheme.test.ts
@@ -118,11 +118,11 @@ describe('resolveSnapshotVerificationSchemeName', () => {
     ).toBe('App-Staging');
   });
 
-  it('returns the only explicit scheme when test target metadata is unavailable', () => {
+  it('returns undefined when the only explicit scheme does not contain the hosted test target', () => {
     const xcodeprojPath = createXcodeProject();
     writeScheme({
       name: 'App-CI',
-      testTargetNames: [],
+      testTargetNames: ['OtherTests'],
       xcodeprojPath,
     });
 
@@ -131,7 +131,7 @@ describe('resolveSnapshotVerificationSchemeName', () => {
         hostedTestTargetName: 'AppTests',
         xcodeprojPath,
       }),
-    ).toBe('App-CI');
+    ).toBeUndefined();
   });
 
   it('returns the only managed implicit scheme when no scheme file exists', () => {

--- a/test/apple/snapshots/snapshotpreviews-xcode-smoke.test.ts
+++ b/test/apple/snapshots/snapshotpreviews-xcode-smoke.test.ts
@@ -1,0 +1,249 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { PBXNativeTarget } from 'xcode';
+
+import { configureSnapshotPreviewsXcodeProject } from '../../../src/apple/snapshots/configure-snapshotpreviews-xcode-project';
+import { ensureSnapshotTestFile } from '../../../src/apple/snapshots/snapshot-test-file';
+import {
+  SNAPSHOTPREVIEWS_PACKAGE_URL,
+  SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT,
+  SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
+} from '../../../src/apple/snapshots/snapshotpreviews-package';
+import { XcodeProject } from '../../../src/apple/xcode-manager';
+import {
+  addHostedUnitTestTarget,
+  copySingleTargetProjectToTemp,
+} from './hosted-test-target-fixture';
+
+vi.mock('@clack/prompts', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+}));
+
+const projectObjectId = 'D4E604C52D50CEEC00CAB00F';
+const productsGroupId = 'D4E604CE2D50CEEC00CAB00F';
+
+const hostedTestTargetIds = {
+  targetId: 'AAAABBBBCCCCDDDDEEEE0001',
+  frameworksBuildPhaseId: 'AAAABBBBCCCCDDDDEEEE0002',
+  sourcesBuildPhaseId: 'AAAABBBBCCCCDDDDEEEE0003',
+  debugBuildConfigurationId: 'AAAABBBBCCCCDDDDEEEE0004',
+  releaseBuildConfigurationId: 'AAAABBBBCCCCDDDDEEEE0005',
+  buildConfigurationListId: 'AAAABBBBCCCCDDDDEEEE0006',
+  productReferenceId: 'AAAABBBBCCCCDDDDEEEE0007',
+};
+
+function getTargetByName(
+  xcodeProject: XcodeProject,
+  targetName: string,
+): PBXNativeTarget {
+  const target = Object.values(xcodeProject.objects.PBXNativeTarget ?? {}).find(
+    (candidate) => {
+      return typeof candidate !== 'string' && candidate.name === targetName;
+    },
+  ) as PBXNativeTarget | undefined;
+
+  if (!target) {
+    throw new Error(`Target not found: ${targetName}`);
+  }
+
+  return target;
+}
+
+function getProductDependencyIds(
+  xcodeProject: XcodeProject,
+  productName: string,
+): string[] {
+  return Object.entries(
+    xcodeProject.objects.XCSwiftPackageProductDependency ?? {},
+  ).reduce((ids, [id, productDependency]) => {
+    if (
+      id.endsWith('_comment') ||
+      typeof productDependency === 'string' ||
+      productDependency.productName !== productName
+    ) {
+      return ids;
+    }
+
+    return ids.concat(id);
+  }, new Array<string>());
+}
+
+function getProductDependency(
+  xcodeProject: XcodeProject,
+  productDependencyId: string,
+) {
+  const productDependency =
+    xcodeProject.objects.XCSwiftPackageProductDependency?.[productDependencyId];
+  if (!productDependency || typeof productDependency === 'string') {
+    throw new Error(`Product dependency not found: ${productDependencyId}`);
+  }
+
+  return productDependency;
+}
+
+function getFrameworkProductRefs(
+  xcodeProject: XcodeProject,
+  targetName: string,
+): string[] {
+  return (getTargetByName(xcodeProject, targetName).buildPhases ?? []).reduce(
+    (productRefs, buildPhaseReference) => {
+      const buildPhase =
+        xcodeProject.objects.PBXFrameworksBuildPhase?.[
+          buildPhaseReference.value
+        ];
+      if (!buildPhase || typeof buildPhase === 'string') {
+        return productRefs;
+      }
+
+      return productRefs.concat(
+        (buildPhase.files ?? []).flatMap((file) => {
+          const buildFile = xcodeProject.objects.PBXBuildFile?.[file.value];
+          return buildFile &&
+            typeof buildFile !== 'string' &&
+            typeof buildFile.productRef === 'string'
+            ? [buildFile.productRef]
+            : [];
+        }),
+      );
+    },
+    new Array<string>(),
+  );
+}
+
+function getSnapshotPreviewsPackageReferenceIds(
+  xcodeProject: XcodeProject,
+): string[] {
+  return Object.entries(
+    xcodeProject.objects.XCRemoteSwiftPackageReference ?? {},
+  ).reduce((ids, [id, packageReference]) => {
+    if (
+      id.endsWith('_comment') ||
+      typeof packageReference === 'string' ||
+      packageReference.repositoryURL !== `"${SNAPSHOTPREVIEWS_PACKAGE_URL}"`
+    ) {
+      return ids;
+    }
+
+    return ids.concat(id);
+  }, new Array<string>());
+}
+
+describe('SnapshotPreviews hosted XCTest Xcode project smoke coverage', () => {
+  it('mutates, reparses, and reruns without duplicating package or source membership', () => {
+    const pbxprojPath = copySingleTargetProjectToTemp(
+      'snapshotpreviews-xcode-smoke-',
+    );
+    const xcodeProject = new XcodeProject(pbxprojPath);
+    addHostedUnitTestTarget(xcodeProject, {
+      ids: hostedTestTargetIds,
+      includeSourcesBuildPhase: true,
+      projectObjectId,
+      productsGroupId,
+    });
+
+    const snapshotTestResult = ensureSnapshotTestFile({
+      xcodeProject,
+      hostedTestTargetName: 'ProjectTests',
+    });
+    const packageResult = configureSnapshotPreviewsXcodeProject({
+      xcodeProject,
+      hostedTestTargetName: 'ProjectTests',
+      previewTargetNames: ['Project'],
+    });
+    xcodeProject.write();
+
+    expect(snapshotTestResult.changed).toBe(true);
+    expect(snapshotTestResult.filePath).toBe(
+      path.join(
+        xcodeProject.baseDir,
+        'ProjectTests',
+        'ProjectTestsSnapshotTest.swift',
+      ),
+    );
+    expect(packageResult).toEqual({ changed: true, linked: true });
+
+    const firstSerializedProject = fs.readFileSync(pbxprojPath, 'utf8');
+    const reparsedProject = new XcodeProject(pbxprojPath);
+
+    expect(reparsedProject.getUnitTestTargetNames()).toContain('ProjectTests');
+    expect(
+      getSnapshotPreviewsPackageReferenceIds(reparsedProject),
+    ).toHaveLength(1);
+
+    const snapshottingTestsProductDependencyIds = getProductDependencyIds(
+      reparsedProject,
+      SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
+    );
+    const snapshotPreferencesProductDependencyIds = getProductDependencyIds(
+      reparsedProject,
+      SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT,
+    );
+    expect(snapshottingTestsProductDependencyIds).toHaveLength(1);
+    expect(snapshotPreferencesProductDependencyIds).toHaveLength(1);
+    expect(
+      getProductDependency(
+        reparsedProject,
+        snapshottingTestsProductDependencyIds[0],
+      ).package,
+    ).toBe(getSnapshotPreviewsPackageReferenceIds(reparsedProject)[0]);
+    expect(
+      getProductDependency(
+        reparsedProject,
+        snapshotPreferencesProductDependencyIds[0],
+      ).package,
+    ).toBe(getSnapshotPreviewsPackageReferenceIds(reparsedProject)[0]);
+    expect(getFrameworkProductRefs(reparsedProject, 'ProjectTests')).toEqual([
+      snapshottingTestsProductDependencyIds[0],
+    ]);
+    expect(getFrameworkProductRefs(reparsedProject, 'Project')).toEqual([
+      snapshotPreferencesProductDependencyIds[0],
+    ]);
+
+    expect(
+      getTargetByName(reparsedProject, 'ProjectTests')
+        .packageProductDependencies,
+    ).toEqual([
+      {
+        value: snapshottingTestsProductDependencyIds[0],
+        comment: SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
+      },
+    ]);
+    expect(
+      getTargetByName(reparsedProject, 'Project').packageProductDependencies,
+    ).toEqual([
+      {
+        value: snapshotPreferencesProductDependencyIds[0],
+        comment: SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT,
+      },
+    ]);
+    expect(
+      reparsedProject
+        .getSourceFilesForTarget('ProjectTests')
+        ?.filter((sourceFilePath) =>
+          sourceFilePath.endsWith(
+            'ProjectTests/ProjectTestsSnapshotTest.swift',
+          ),
+        ),
+    ).toHaveLength(1);
+
+    const secondSnapshotTestResult = ensureSnapshotTestFile({
+      xcodeProject: reparsedProject,
+      hostedTestTargetName: 'ProjectTests',
+    });
+    const secondPackageResult = configureSnapshotPreviewsXcodeProject({
+      xcodeProject: reparsedProject,
+      hostedTestTargetName: 'ProjectTests',
+      previewTargetNames: ['Project'],
+    });
+    reparsedProject.write();
+
+    expect(secondSnapshotTestResult.changed).toBe(false);
+    expect(secondPackageResult).toEqual({ changed: false, linked: true });
+    expect(fs.readFileSync(pbxprojPath, 'utf8')).toBe(firstSerializedProject);
+  });
+});

--- a/test/apple/snapshots/snapshots-cli-preflight.test.ts
+++ b/test/apple/snapshots/snapshots-cli-preflight.test.ts
@@ -83,6 +83,29 @@ describe('snapshots CLI preflight', () => {
     expect(mocks.executeSync).not.toHaveBeenCalled();
   });
 
+  it('does not prompt to install sentry-cli in non-interactive mode', async () => {
+    mocks.hasSentryCLI.mockReturnValue(false);
+
+    const projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'snapshot-cli-non-interactive-'),
+    );
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      nonInteractive: true,
+      verificationGuidance: getVerificationGuidance(projectDir),
+    });
+
+    expect(mocks.askToInstallSentryCLI).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('upload snapshots to Sentry'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('sentry-cli snapshots upload'),
+    );
+    expect(mocks.executeSync).not.toHaveBeenCalled();
+  });
+
   it('verifies snapshots upload support and prefers existing Fastlane guidance', async () => {
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-cli-'));
     const fastlaneDir = path.join(projectDir, 'fastlane');

--- a/test/apple/snapshots/snapshots-cli-preflight.test.ts
+++ b/test/apple/snapshots/snapshots-cli-preflight.test.ts
@@ -1,0 +1,210 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  askToInstallSentryCLI: vi.fn(),
+  executeSync: vi.fn(),
+  hasSentryCLI: vi.fn(),
+  info: vi.fn(),
+  installSentryCLI: vi.fn(),
+  setTag: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  default: {
+    log: {
+      info: mocks.info,
+      success: mocks.success,
+      warn: mocks.warn,
+    },
+  },
+}));
+
+vi.mock('@sentry/node', () => ({
+  setTag: mocks.setTag,
+}));
+
+vi.mock('../../../src/telemetry', () => ({
+  traceStep: async (_name: string, callback: () => Promise<boolean>) =>
+    await callback(),
+}));
+
+vi.mock('../../../src/utils/bash', () => ({
+  executeSync: mocks.executeSync,
+  hasSentryCLI: mocks.hasSentryCLI,
+  installSentryCLI: mocks.installSentryCLI,
+}));
+
+vi.mock('../../../src/utils/clack', () => ({
+  askToInstallSentryCLI: mocks.askToInstallSentryCLI,
+}));
+
+import {
+  checkInstalledCLISnapshots,
+  getSnapshotFastlaneGuidance,
+} from '../../../src/apple/snapshots/snapshots-cli-preflight';
+
+function getVerificationGuidance(projectDir: string) {
+  return {
+    appId: 'com.getsentry.App',
+    hostedTestTargetName: 'AppTests',
+    projectDir,
+    projectPath: path.join(projectDir, 'App.xcodeproj'),
+    schemeName: 'App',
+  };
+}
+
+describe('snapshots CLI preflight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers to install sentry-cli with snapshots-aware warning when missing', async () => {
+    mocks.hasSentryCLI.mockReturnValue(false);
+    mocks.askToInstallSentryCLI.mockResolvedValue(false);
+
+    const projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'snapshot-cli-missing-'),
+    );
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      verificationGuidance: getVerificationGuidance(projectDir),
+    });
+
+    expect(mocks.askToInstallSentryCLI).toHaveBeenCalledTimes(1);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('upload snapshots to Sentry'),
+    );
+    expect(mocks.executeSync).not.toHaveBeenCalled();
+  });
+
+  it('verifies snapshots upload support and prefers existing Fastlane guidance', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-cli-'));
+    const fastlaneDir = path.join(projectDir, 'fastlane');
+    fs.mkdirSync(fastlaneDir);
+    fs.writeFileSync(
+      path.join(fastlaneDir, 'Fastfile'),
+      'platform :ios do\n  lane :upload_sentry_snapshots do |options|\n    sentry_upload_snapshots(path: options[:path])\n  end\nend\n',
+    );
+    mocks.hasSentryCLI.mockReturnValue(true);
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      verificationGuidance: getVerificationGuidance(projectDir),
+    });
+
+    expect(mocks.executeSync).toHaveBeenCalledWith(
+      'sentry-cli snapshots upload --help',
+    );
+    expect(mocks.success).toHaveBeenCalledWith(
+      'sentry-cli snapshots upload is available.',
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('xcodebuild test'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('-project App.xcodeproj'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('-scheme App'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('-only-testing:AppTests/AppTestsSnapshotTest'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'bundle exec fastlane ios upload_sentry_snapshots',
+      ),
+    );
+  });
+
+  it('prints xcodebuild export and sentry-cli upload guidance', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-cli-'));
+    mocks.hasSentryCLI.mockReturnValue(true);
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      verificationGuidance: getVerificationGuidance(projectDir),
+    });
+
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('TEST_RUNNER_SNAPSHOTS_EXPORT_DIR'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('-only-testing:AppTests/AppTestsSnapshotTest'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('sentry-cli snapshots upload'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('--app-id com.getsentry.App'),
+    );
+  });
+
+  it('uses a scheme placeholder when no verification scheme was detected', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-cli-'));
+    mocks.hasSentryCLI.mockReturnValue(true);
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      verificationGuidance: {
+        ...getVerificationGuidance(projectDir),
+        schemeName: undefined,
+      },
+    });
+
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('-scheme <scheme>'),
+    );
+    expect(mocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("-scheme '<scheme>'"),
+    );
+  });
+
+  it('uses an explicit app id placeholder when the bundle identifier is unavailable', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-cli-'));
+    const verificationGuidance = {
+      ...getVerificationGuidance(projectDir),
+      appId: undefined,
+    };
+    mocks.hasSentryCLI.mockReturnValue(true);
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      verificationGuidance,
+    });
+
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('--app-id YOUR_APP_BUNDLE_ID'),
+    );
+    expect(mocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('com.example.MyApp'),
+    );
+    expect(mocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('<your-app-bundle-id>'),
+    );
+  });
+
+  it('detects existing Fastlane snapshots upload support', () => {
+    const projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'snapshot-fastlane-'),
+    );
+    const fastlaneDir = path.join(projectDir, 'fastlane');
+    fs.mkdirSync(fastlaneDir);
+    fs.writeFileSync(
+      path.join(fastlaneDir, 'Fastfile'),
+      'lane :upload_sentry_snapshots do\n  sentry_upload_snapshots(path: "snapshot-images")\nend\n',
+    );
+
+    expect(getSnapshotFastlaneGuidance(projectDir)).toEqual({
+      fastfilePath: path.join(fastlaneDir, 'Fastfile'),
+      hasUploadLane: true,
+      hasSentryUploadAction: true,
+    });
+  });
+});

--- a/test/apple/snapshots/source-file-insertion.test.ts
+++ b/test/apple/snapshots/source-file-insertion.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PBXSourcesBuildPhase } from 'xcode';
+
+import { XcodeProject } from '../../../src/apple/xcode-manager';
+import { copySingleTargetProjectToTemp } from './hosted-test-target-fixture';
+
+vi.mock('@clack/prompts', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+}));
+
+function sourceBuildPhaseFiles(xcodeProject: XcodeProject): unknown[] {
+  const phase = xcodeProject.objects.PBXSourcesBuildPhase?.[
+    'D4E604C92D50CEEC00CAB00F'
+  ] as PBXSourcesBuildPhase | undefined;
+  return phase?.files ?? [];
+}
+
+describe('XcodeProject Swift source-file insertion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds a Swift source file to a classic PBXSourcesBuildPhase once', () => {
+    const xcodeProject = new XcodeProject(
+      copySingleTargetProjectToTemp('snapshot-source-file-'),
+    );
+    const filePath = path.join(
+      xcodeProject.baseDir,
+      'ProjectTests',
+      'SnapshotTest.swift',
+    );
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'import SnapshottingTests\n', 'utf8');
+
+    const firstResult = xcodeProject.addSwiftSourceFileToTarget({
+      targetName: 'Project',
+      filePath,
+    });
+    const secondResult = xcodeProject.addSwiftSourceFileToTarget({
+      targetName: 'Project',
+      filePath,
+    });
+
+    expect(firstResult).toEqual({ changed: true, included: true });
+    expect(secondResult).toEqual({ changed: false, included: true });
+    expect(sourceBuildPhaseFiles(xcodeProject)).toHaveLength(1);
+    expect(
+      Object.values(xcodeProject.objects.PBXFileReference ?? {}).filter(
+        (fileReference) =>
+          typeof fileReference === 'object' &&
+          fileReference.path === 'ProjectTests/SnapshotTest.swift',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('uses synchronized root group inclusion when the file is inside a target synchronized folder', () => {
+    const xcodeProject = new XcodeProject(
+      copySingleTargetProjectToTemp('snapshot-source-file-'),
+    );
+    const filePath = path.join(
+      xcodeProject.baseDir,
+      'Sources',
+      'SnapshotTest.swift',
+    );
+    fs.writeFileSync(filePath, 'import SnapshottingTests\n', 'utf8');
+
+    const result = xcodeProject.addSwiftSourceFileToTarget({
+      targetName: 'Project',
+      filePath,
+    });
+
+    expect(result).toEqual({ changed: false, included: true });
+    expect(sourceBuildPhaseFiles(xcodeProject)).toEqual([]);
+  });
+});

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -8,9 +8,24 @@ import type {
   PBXShellScriptBuildPhase,
   XCBuildConfiguration,
 } from 'xcode';
+import {
+  configureSnapshotPreviewsXcodeProject,
+  snapshottingTestsProductSpec,
+} from '../../src/apple/snapshots/configure-snapshotpreviews-xcode-project';
+import {
+  SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+  sentrySwiftPackageProductSpec,
+} from '../../src/apple/sentry-swift-package';
 import { getRunScriptTemplate } from '../../src/apple/templates';
-import { XcodeProject } from '../../src/apple/xcode-manager';
+import {
+  SwiftPackageProductLinkOptions,
+  XcodeProject,
+} from '../../src/apple/xcode-manager';
 import type { SentryProjectData } from '../../src/utils/types';
+import {
+  addHostedUnitTestTarget,
+  type HostedTestTargetFixtureIds,
+} from './snapshots/hosted-test-target-fixture';
 
 vi.mock('node:fs', async () => ({
   __esModule: true,
@@ -63,6 +78,39 @@ const projectData: SentryProjectData = {
   },
   keys: [{ dsn: { public: 'https://sentry.io/1234567890' } }],
 };
+
+const appFrameworksBuildPhaseId = 'D4E604CA2D50CEEC00CAB00F';
+const sentrySwiftPackageProductLinkOptions: SwiftPackageProductLinkOptions = {
+  product: sentrySwiftPackageProductSpec,
+  existingFrameworkComment: SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+  successMessage: 'Added Sentry SPM dependency to your project',
+};
+const projectObjectId = 'D4E604C52D50CEEC00CAB00F';
+const productsGroupId = 'D4E604CE2D50CEEC00CAB00F';
+
+function objectKeysWithoutComments(object: unknown): string[] {
+  return Object.keys((object ?? {}) as Record<string, unknown>).filter(
+    (key) => {
+      return !key.endsWith('_comment');
+    },
+  );
+}
+
+function getTargetByName(
+  xcodeProject: XcodeProject,
+  targetName: string,
+): PBXNativeTarget {
+  const target = Object.values(xcodeProject.objects.PBXNativeTarget ?? {}).find(
+    (candidate) => {
+      return typeof candidate !== 'string' && candidate.name === targetName;
+    },
+  ) as PBXNativeTarget | undefined;
+  if (!target) {
+    throw new Error(`Target not found: ${targetName}`);
+  }
+
+  return target;
+}
 
 describe('XcodeManager', () => {
   beforeEach(() => {
@@ -150,6 +198,375 @@ describe('XcodeManager', () => {
       });
     });
 
+    describe('target type detection', () => {
+      it('lists application and unit-test targets by name', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          projectObjectId,
+          productsGroupId,
+        });
+
+        // -- Act & Assert --
+        expect(xcodeProject.getAllTargets()).toEqual(['Project']);
+        expect(xcodeProject.getUnitTestTargetNames()).toEqual(['ProjectTests']);
+      });
+
+      it('returns multiple unit-test targets by name', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectTests',
+          projectObjectId,
+          productsGroupId,
+        });
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectSnapshotTests',
+          projectObjectId,
+          productsGroupId,
+        });
+
+        // -- Act & Assert --
+        expect(xcodeProject.getUnitTestTargetNames()).toEqual([
+          'ProjectTests',
+          'ProjectSnapshotTests',
+        ]);
+      });
+
+      it('returns only unit-test targets hosted by the selected application target', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectTests',
+          projectObjectId,
+          productsGroupId,
+        });
+        addHostedUnitTestTarget(xcodeProject, {
+          hostAppName: 'OtherApp',
+          name: 'OtherAppTests',
+          projectObjectId,
+          productsGroupId,
+        });
+
+        // -- Act & Assert --
+        expect(
+          xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget(
+            'Project',
+          ),
+        ).toEqual(['ProjectTests']);
+      });
+
+      it('matches hosted unit-test targets by app product name', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectTests',
+          projectObjectId,
+          productsGroupId,
+          testHost:
+            '"$(BUILT_PRODUCTS_DIR)/SentryWizardSampleBlank.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SentryWizardSampleBlank"',
+        });
+
+        // -- Act & Assert --
+        expect(
+          xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget(
+            'Project',
+          ),
+        ).toEqual(['ProjectTests']);
+      });
+
+      it('returns no hosted unit-test targets for an unknown application target', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectTests',
+          projectObjectId,
+          productsGroupId,
+        });
+
+        // -- Act & Assert --
+        expect(
+          xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget(
+            'MissingApp',
+          ),
+        ).toEqual([]);
+      });
+    });
+
+    describe('ensureSwiftPackageProductLinked', () => {
+      let xcodeProject: XcodeProject;
+      let hostedTestTargetIds: HostedTestTargetFixtureIds;
+
+      beforeEach(() => {
+        xcodeProject = new XcodeProject(singleTargetProjectPath);
+        hostedTestTargetIds = addHostedUnitTestTarget(xcodeProject, {
+          projectObjectId,
+          productsGroupId,
+        });
+      });
+
+      it('links a Swift package product only to the selected target', () => {
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'ProjectTests',
+          snapshottingTestsProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: true, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ),
+        ).toHaveLength(1);
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toHaveLength(1);
+
+        const appTarget = getTargetByName(xcodeProject, 'Project');
+        const hostedTestTarget = getTargetByName(xcodeProject, 'ProjectTests');
+        expect(appTarget.packageProductDependencies).toEqual([]);
+        expect(hostedTestTarget.packageProductDependencies).toEqual([
+          expect.objectContaining({ comment: 'SnapshottingTests' }),
+        ]);
+
+        const appFrameworksBuildPhase =
+          xcodeProject.objects.PBXFrameworksBuildPhase?.[
+            appFrameworksBuildPhaseId
+          ];
+        const testFrameworksBuildPhase =
+          xcodeProject.objects.PBXFrameworksBuildPhase?.[
+            hostedTestTargetIds.frameworksBuildPhaseId
+          ];
+        expect(
+          typeof appFrameworksBuildPhase !== 'string'
+            ? appFrameworksBuildPhase?.files
+            : undefined,
+        ).toEqual([]);
+        expect(
+          typeof testFrameworksBuildPhase !== 'string'
+            ? testFrameworksBuildPhase?.files
+            : undefined,
+        ).toEqual([
+          expect.objectContaining({
+            comment: 'SnapshottingTests in Frameworks',
+          }),
+        ]);
+      });
+
+      it('is idempotent across repeated runs', () => {
+        // -- Act --
+        const firstResult = xcodeProject.ensureSwiftPackageProductLinked(
+          'ProjectTests',
+          snapshottingTestsProductSpec,
+        );
+        const secondResult = xcodeProject.ensureSwiftPackageProductLinked(
+          'ProjectTests',
+          snapshottingTestsProductSpec,
+        );
+
+        // -- Assert --
+        expect(firstResult).toEqual({ changed: true, linked: true });
+        expect(secondResult).toEqual({ changed: false, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ),
+        ).toHaveLength(1);
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toHaveLength(1);
+        expect(
+          objectKeysWithoutComments(xcodeProject.objects.PBXBuildFile),
+        ).toHaveLength(1);
+      });
+
+      it('reuses an existing package reference with the same repository URL and updates a lower minimum version', () => {
+        // -- Arrange --
+        xcodeProject.objects.XCRemoteSwiftPackageReference = {
+          EXISTINGPACKAGE000000000001: {
+            isa: 'XCRemoteSwiftPackageReference',
+            repositoryURL: `"${snapshottingTestsProductSpec.package.repositoryURL}/"`,
+            requirement: {
+              kind: 'upToNextMajorVersion',
+              minimumVersion: '0.8.0',
+            },
+          },
+          EXISTINGPACKAGE000000000001_comment:
+            'XCRemoteSwiftPackageReference "SnapshotPreviews"',
+        };
+
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'ProjectTests',
+          snapshottingTestsProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: true, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ),
+        ).toEqual(['EXISTINGPACKAGE000000000001']);
+        expect(
+          xcodeProject.objects.XCRemoteSwiftPackageReference?.[
+            'EXISTINGPACKAGE000000000001'
+          ],
+        ).toEqual(
+          expect.objectContaining({
+            requirement: snapshottingTestsProductSpec.package.requirement,
+          }),
+        );
+        expect(
+          xcodeProject.objects.XCSwiftPackageProductDependency?.[
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCSwiftPackageProductDependency,
+            )[0]
+          ],
+        ).toEqual(
+          expect.objectContaining({
+            package: 'EXISTINGPACKAGE000000000001',
+            productName: 'SnapshottingTests',
+          }),
+        );
+      });
+
+      it('does not partially mutate package state when the target has no Frameworks build phase', () => {
+        // -- Arrange --
+        const hostedTestTarget = getTargetByName(xcodeProject, 'ProjectTests');
+        hostedTestTarget.buildPhases = [];
+
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'ProjectTests',
+          snapshottingTestsProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: false, linked: false });
+        expect(
+          xcodeProject.objects.XCRemoteSwiftPackageReference,
+        ).toBeUndefined();
+        expect(
+          xcodeProject.objects.XCSwiftPackageProductDependency,
+        ).toBeUndefined();
+        expect(xcodeProject.objects.PBXBuildFile).toBeUndefined();
+        expect(hostedTestTarget.packageProductDependencies).toEqual([]);
+      });
+    });
+
+    describe('configureSnapshotPreviewsXcodeProject', () => {
+      it('links SnapshottingTests to the hosted test target and SnapshotPreferences only to selected preview targets', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          projectObjectId,
+          productsGroupId,
+        });
+
+        // -- Act --
+        const result = configureSnapshotPreviewsXcodeProject({
+          xcodeProject,
+          hostedTestTargetName: 'ProjectTests',
+          previewTargetNames: ['Project'],
+        });
+
+        // -- Assert --
+        expect(result).toEqual({ changed: true, linked: true });
+        const appTarget = getTargetByName(xcodeProject, 'Project');
+        const hostedTestTarget = getTargetByName(xcodeProject, 'ProjectTests');
+        expect(appTarget.packageProductDependencies).toEqual([
+          expect.objectContaining({ comment: 'SnapshotPreferences' }),
+        ]);
+        expect(hostedTestTarget.packageProductDependencies).toEqual([
+          expect.objectContaining({ comment: 'SnapshottingTests' }),
+        ]);
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toHaveLength(2);
+      });
+
+      it('does not link SnapshotPreferences when no preview targets are selected', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          projectObjectId,
+          productsGroupId,
+        });
+
+        // -- Act --
+        configureSnapshotPreviewsXcodeProject({
+          xcodeProject,
+          hostedTestTargetName: 'ProjectTests',
+        });
+
+        // -- Assert --
+        const appTarget = getTargetByName(xcodeProject, 'Project');
+        const hostedTestTarget = getTargetByName(xcodeProject, 'ProjectTests');
+        expect(appTarget.packageProductDependencies).toEqual([]);
+        expect(hostedTestTarget.packageProductDependencies).toEqual([
+          expect.objectContaining({ comment: 'SnapshottingTests' }),
+        ]);
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toHaveLength(1);
+      });
+
+      it('does not mutate package state when the hosted test target is missing', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+
+        // -- Act --
+        const result = configureSnapshotPreviewsXcodeProject({
+          xcodeProject,
+          hostedTestTargetName: 'MissingTests',
+        });
+
+        // -- Assert --
+        expect(result).toEqual({ changed: false, linked: false });
+        expect(
+          xcodeProject.objects.XCRemoteSwiftPackageReference,
+        ).toBeUndefined();
+        expect(
+          xcodeProject.objects.XCSwiftPackageProductDependency,
+        ).toBeUndefined();
+        expect(xcodeProject.objects.PBXBuildFile).toBeUndefined();
+      });
+
+      it('does not link SnapshotPreferences when the hosted test target is missing', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+
+        // -- Act --
+        const result = configureSnapshotPreviewsXcodeProject({
+          xcodeProject,
+          hostedTestTargetName: 'MissingTests',
+          previewTargetNames: ['Project'],
+        });
+
+        // -- Assert --
+        const appTarget = getTargetByName(xcodeProject, 'Project');
+        expect(result).toEqual({ changed: false, linked: false });
+        expect(appTarget.packageProductDependencies).toEqual([]);
+        expect(
+          xcodeProject.objects.XCRemoteSwiftPackageReference,
+        ).toBeUndefined();
+        expect(
+          xcodeProject.objects.XCSwiftPackageProductDependency,
+        ).toBeUndefined();
+        expect(xcodeProject.objects.PBXBuildFile).toBeUndefined();
+      });
+    });
+
     describe('updateXcodeProject', () => {
       let sourceProjectPath: string;
       let tempProjectPath: string;
@@ -219,7 +636,7 @@ describe('XcodeManager', () => {
               xcodeProject.updateXcodeProject(
                 projectData,
                 'Project',
-                false, // Ignore SPM reference
+                undefined, // Ignore SPM reference
                 variant.uploadSource,
               );
 
@@ -276,7 +693,7 @@ describe('XcodeManager', () => {
             xcodeProject.updateXcodeProject(
               projectData,
               'Project',
-              false, // Ignore SPM reference
+              undefined, // Ignore SPM reference
               false,
             );
 
@@ -297,7 +714,7 @@ describe('XcodeManager', () => {
               xcodeProject.updateXcodeProject(
                 projectData,
                 'Invalid Target Name',
-                false, // Ignore SPM reference
+                undefined, // Ignore SPM reference
                 uploadSource,
               );
 
@@ -316,7 +733,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Invalid Target Name',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -339,7 +756,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Invalid Target Name',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -363,7 +780,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Project',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -394,7 +811,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Project',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -439,55 +856,134 @@ describe('XcodeManager', () => {
       });
 
       describe('add SPM reference', () => {
-        const addSPMReference = true;
+        const swiftPackageProduct = sentrySwiftPackageProductLinkOptions;
 
-        describe('framework build phase already contains Sentry', () => {
-          it('should not update the Xcode project', () => {
-            // -- Arrange --
-            xcodeProject.objects.PBXFrameworksBuildPhase = {
-              'framework-id': {
-                isa: 'PBXFrameworksBuildPhase',
-                files: [
-                  {
-                    value: '123',
-                    comment: 'Sentry in Frameworks',
-                  },
-                ],
-              },
-            };
+        it('should treat an existing Sentry framework comment on the selected target as already installed', () => {
+          // -- Arrange --
+          const frameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              appFrameworksBuildPhaseId
+            ];
+          if (
+            !frameworksBuildPhase ||
+            typeof frameworksBuildPhase === 'string'
+          ) {
+            throw new Error('Frameworks build phase is undefined');
+          }
+          frameworksBuildPhase.files = [
+            {
+              value: '123',
+              comment: 'Sentry in Frameworks',
+            },
+          ];
 
-            // -- Act --
-            xcodeProject.updateXcodeProject(
-              projectData,
-              'Project',
-              addSPMReference,
-            );
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
 
-            // -- Assert --
-            const expectedXcodeProject = new XcodeProject(sourceProjectPath);
-            expectedXcodeProject.objects.PBXFrameworksBuildPhase = {
-              'framework-id': {
-                isa: 'PBXFrameworksBuildPhase',
-                files: [
-                  {
-                    value: '123',
-                    comment: 'Sentry in Frameworks',
-                  },
-                ],
-              },
-            };
-            expect(xcodeProject.objects.PBXFrameworksBuildPhase).toEqual(
-              expectedXcodeProject.objects.PBXFrameworksBuildPhase,
-            );
-            expect(xcodeProject.objects.XCRemoteSwiftPackageReference).toEqual(
-              expectedXcodeProject.objects.XCRemoteSwiftPackageReference,
-            );
-            expect(
-              xcodeProject.objects.XCSwiftPackageProductDependency,
-            ).toEqual(
-              expectedXcodeProject.objects.XCSwiftPackageProductDependency,
-            );
+          // -- Assert --
+          expect(frameworksBuildPhase.files).toEqual([
+            {
+              value: '123',
+              comment: 'Sentry in Frameworks',
+            },
+          ]);
+          expect(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ).toBeUndefined();
+          expect(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ).toBeUndefined();
+        });
+
+        it('should not treat a Sentry framework comment on another target as installed on the selected target', () => {
+          // -- Arrange --
+          const hostedTestTargetIds = addHostedUnitTestTarget(xcodeProject, {
+            projectObjectId,
+            productsGroupId,
           });
+          const testFrameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              hostedTestTargetIds.frameworksBuildPhaseId
+            ];
+          if (
+            !testFrameworksBuildPhase ||
+            typeof testFrameworksBuildPhase === 'string'
+          ) {
+            throw new Error('Frameworks build phase is undefined');
+          }
+          testFrameworksBuildPhase.files = [
+            {
+              value: '123',
+              comment: 'Sentry in Frameworks',
+            },
+          ];
+
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+
+          // -- Assert --
+          expect(
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCRemoteSwiftPackageReference,
+            ),
+          ).toHaveLength(1);
+          const appFrameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              appFrameworksBuildPhaseId
+            ];
+          expect(
+            typeof appFrameworksBuildPhase !== 'string'
+              ? appFrameworksBuildPhase?.files?.filter((file) => {
+                  return file.comment === 'Sentry in Frameworks';
+                })
+              : [],
+          ).toHaveLength(1);
+        });
+
+        it('should not duplicate the Sentry SPM dependency on repeated runs', () => {
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+
+          // -- Assert --
+          expect(
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCRemoteSwiftPackageReference,
+            ),
+          ).toHaveLength(1);
+          expect(
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCSwiftPackageProductDependency,
+            ),
+          ).toHaveLength(1);
+
+          const frameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              appFrameworksBuildPhaseId
+            ];
+          expect(
+            typeof frameworksBuildPhase !== 'string'
+              ? frameworksBuildPhase?.files?.filter((file) => {
+                  return file.comment === 'Sentry in Frameworks';
+                })
+              : [],
+          ).toHaveLength(1);
         });
 
         it('should add the SPM reference to the target', () => {
@@ -495,7 +991,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            addSPMReference,
+            swiftPackageProduct,
           );
 
           // -- Assert --
@@ -563,6 +1059,42 @@ describe('XcodeManager', () => {
           });
         });
 
+        it('should link Sentry only to the selected target', () => {
+          // -- Arrange --
+          const hostedTestTargetIds = addHostedUnitTestTarget(xcodeProject, {
+            projectObjectId,
+            productsGroupId,
+          });
+
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+
+          // -- Assert --
+          const appTarget = getTargetByName(xcodeProject, 'Project');
+          const hostedTestTarget = getTargetByName(
+            xcodeProject,
+            'ProjectTests',
+          );
+          expect(appTarget.packageProductDependencies).toEqual([
+            expect.objectContaining({ comment: 'Sentry' }),
+          ]);
+          expect(hostedTestTarget.packageProductDependencies).toEqual([]);
+
+          const testFrameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              hostedTestTargetIds.frameworksBuildPhaseId
+            ];
+          expect(
+            typeof testFrameworksBuildPhase !== 'string'
+              ? testFrameworksBuildPhase?.files
+              : undefined,
+          ).toEqual([]);
+        });
+
         it('should initialize packageProductDependencies if not present', () => {
           // -- Arrange --
           // Ensure the target exists but has no packageProductDependencies initially
@@ -579,7 +1111,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            addSPMReference,
+            swiftPackageProduct,
           );
 
           // -- Assert --

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -233,6 +233,31 @@ describe('XcodeManager', () => {
         ]);
       });
 
+      it('returns only unit-test targets with TEST_HOST configured', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectTests',
+          projectObjectId,
+          productsGroupId,
+        });
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'UnhostedProjectTests',
+          projectObjectId,
+          productsGroupId,
+          testHost: '""',
+        });
+
+        // -- Act & Assert --
+        expect(xcodeProject.getUnitTestTargetNames()).toEqual([
+          'ProjectTests',
+          'UnhostedProjectTests',
+        ]);
+        expect(xcodeProject.getHostedUnitTestTargetNames()).toEqual([
+          'ProjectTests',
+        ]);
+      });
+
       it('returns only unit-test targets hosted by the selected application target', () => {
         // -- Arrange --
         const xcodeProject = new XcodeProject(singleTargetProjectPath);

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getIntegrationDescription,
+  Integration,
+  mapIntegrationToPlatform,
+} from '../lib/Constants';
+
+describe('Constants', () => {
+  it('exposes Apple Snapshots as a selectable integration', () => {
+    expect(Object.keys(Integration)).toContain('appleSnapshots');
+    expect(getIntegrationDescription(Integration.appleSnapshots)).toBe(
+      'Apple Snapshots',
+    );
+    expect(mapIntegrationToPlatform(Integration.appleSnapshots)).toBe('iOS');
+  });
+});

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -107,6 +107,7 @@ function getBaseArgs(integration: RunArgs['integration']): RunArgs {
     skipConnect: false,
     debug: false,
     quiet: false,
+    nonInteractive: false,
     disableTelemetry: true,
   };
 }
@@ -117,19 +118,40 @@ describe('run', () => {
     wizardMocks.readEnvironment.mockReturnValue({});
   });
 
-  it('routes appleSnapshots to the Apple Snapshots wizard with the Xcode project directory', async () => {
+  it('routes appleSnapshots to the Apple Snapshots wizard with Apple target options', async () => {
     await run({
       ...getBaseArgs('appleSnapshots'),
+      appTarget: 'App',
+      hostedTestTarget: 'AppTests',
+      nonInteractive: true,
       xcodeProjectDir: '/tmp/MyApp',
     });
 
     expect(wizardMocks.runAppleSnapshotsWizard).toHaveBeenCalledWith(
       expect.objectContaining({
+        appTarget: 'App',
+        hostedTestTarget: 'AppTests',
+        nonInteractive: true,
         telemetryEnabled: false,
         projectDir: '/tmp/MyApp',
       }),
     );
     expect(wizardMocks.runAppleWizard).not.toHaveBeenCalled();
+  });
+
+  it('passes quiet through to the existing Cordova wizard', async () => {
+    await run({
+      ...getBaseArgs('cordova'),
+      quiet: true,
+    });
+
+    expect(wizardMocks.legacyRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integration: 'cordova',
+        quiet: true,
+      }),
+      expect.any(Object),
+    );
   });
 
   it('keeps ios routing on the existing Apple wizard', async () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const wizardMocks = vi.hoisted(() => ({
+  legacyRun: vi.fn(),
+  readEnvironment: vi.fn(() => ({})),
+  runAndroidWizard: vi.fn(),
+  runAngularWizard: vi.fn(),
+  runAppleSnapshotsWizard: vi.fn(),
+  runAppleWizard: vi.fn(),
+  runCloudflareWizard: vi.fn(),
+  runFlutterWizard: vi.fn(),
+  runNextjsWizard: vi.fn(),
+  runNuxtWizard: vi.fn(),
+  runReactNativeWizard: vi.fn(),
+  runReactRouterWizard: vi.fn(),
+  runRemixWizard: vi.fn(),
+  runSourcemapsWizard: vi.fn(),
+  runSvelteKitWizard: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  log: {
+    error: vi.fn(),
+  },
+  outro: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock('../lib/Helper/Env', () => ({
+  readEnvironment: wizardMocks.readEnvironment,
+}));
+
+vi.mock('../lib/Setup', () => ({
+  run: wizardMocks.legacyRun,
+}));
+
+vi.mock('../src/android/android-wizard', () => ({
+  runAndroidWizard: wizardMocks.runAndroidWizard,
+}));
+
+vi.mock('../src/angular/angular-wizard', () => ({
+  runAngularWizard: wizardMocks.runAngularWizard,
+}));
+
+vi.mock('../src/apple/apple-wizard', () => ({
+  runAppleWizard: wizardMocks.runAppleWizard,
+}));
+
+vi.mock('../src/apple/snapshots/apple-snapshots-wizard', () => ({
+  runAppleSnapshotsWizard: wizardMocks.runAppleSnapshotsWizard,
+}));
+
+vi.mock('../src/cloudflare/cloudflare-wizard', () => ({
+  runCloudflareWizard: wizardMocks.runCloudflareWizard,
+}));
+
+vi.mock('../src/flutter/flutter-wizard', () => ({
+  runFlutterWizard: wizardMocks.runFlutterWizard,
+}));
+
+vi.mock('../src/nextjs/nextjs-wizard', () => ({
+  runNextjsWizard: wizardMocks.runNextjsWizard,
+}));
+
+vi.mock('../src/nuxt/nuxt-wizard', () => ({
+  runNuxtWizard: wizardMocks.runNuxtWizard,
+}));
+
+vi.mock('../src/react-native/react-native-wizard', () => ({
+  runReactNativeWizard: wizardMocks.runReactNativeWizard,
+}));
+
+vi.mock('../src/react-router/react-router-wizard', () => ({
+  runReactRouterWizard: wizardMocks.runReactRouterWizard,
+}));
+
+vi.mock('../src/remix/remix-wizard', () => ({
+  runRemixWizard: wizardMocks.runRemixWizard,
+}));
+
+vi.mock('../src/sourcemaps/sourcemaps-wizard', () => ({
+  runSourcemapsWizard: wizardMocks.runSourcemapsWizard,
+}));
+
+vi.mock('../src/sveltekit/sveltekit-wizard', () => ({
+  runSvelteKitWizard: wizardMocks.runSvelteKitWizard,
+}));
+
+vi.mock('../src/utils/debug', () => ({
+  enableDebugLogs: vi.fn(),
+}));
+
+vi.mock('../src/utils/clack', () => ({
+  abortIfCancelled: async <T>(input: T | Promise<T>): Promise<T> => await input,
+}));
+
+import { run } from '../src/run';
+
+type RunArgs = Parameters<typeof run>[0];
+
+function getBaseArgs(integration: RunArgs['integration']): RunArgs {
+  return {
+    integration,
+    uninstall: false,
+    signup: false,
+    skipConnect: false,
+    debug: false,
+    quiet: false,
+    disableTelemetry: true,
+  };
+}
+
+describe('run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wizardMocks.readEnvironment.mockReturnValue({});
+  });
+
+  it('routes appleSnapshots to the Apple Snapshots wizard with the Xcode project directory', async () => {
+    await run({
+      ...getBaseArgs('appleSnapshots'),
+      xcodeProjectDir: '/tmp/MyApp',
+    });
+
+    expect(wizardMocks.runAppleSnapshotsWizard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        telemetryEnabled: false,
+        projectDir: '/tmp/MyApp',
+      }),
+    );
+    expect(wizardMocks.runAppleWizard).not.toHaveBeenCalled();
+  });
+
+  it('keeps ios routing on the existing Apple wizard', async () => {
+    await run({
+      ...getBaseArgs('ios'),
+      xcodeProjectDir: '/tmp/MyApp',
+    });
+
+    expect(wizardMocks.runAppleWizard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        telemetryEnabled: false,
+        projectDir: '/tmp/MyApp',
+      }),
+    );
+    expect(wizardMocks.runAppleSnapshotsWizard).not.toHaveBeenCalled();
+  });
+});

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -77,6 +77,19 @@ describe('getUncommittedOrUntrackedFiles', () => {
     expect(getUncommittedOrUntrackedFiles()).toEqual([]);
   });
 
+  it('forwards cwd if provided', () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      return '';
+    });
+
+    getUncommittedOrUntrackedFiles({ cwd: '/path/to/dir' });
+
+    expect(mockedExecSync).toHaveBeenCalledWith('git status --porcelain=v1', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      cwd: '/path/to/dir',
+    });
+  });
+
   it('returns an empty list if the git command fails', () => {
     mockedExecSync.mockImplementationOnce(() => {
       throw new Error('Command failed');


### PR DESCRIPTION
Adds a standalone **Apple Snapshots** wizard for configuring Sentry SnapshotPreviews in Apple/Xcode projects without running the normal iOS runtime SDK setup.

The new `appleSnapshots` integration is available from the wizard picker and via `--integration appleSnapshots`. It reuses the existing Xcode project discovery path, asks for the app target that hosts Swift previews, then selects a hosted XCTest target for running SnapshotPreviews. The wizard wires SnapshotPreviews into the project by linking `SnapshottingTests` to the hosted test target and `SnapshotPreferences` to the selected app target only when Swift previews are detected. It also creates or reuses a generated `SnapshotTest` subclass, ensures the file belongs to the selected XCTest target, and prints local export/upload guidance for `xcodebuild`, `sentry-cli snapshots upload`, and existing Fastlane snapshot upload lanes.

The Apple Snapshots behavior contract is:

- App target selection uses `--app-target` when provided; otherwise the wizard auto-selects only when there is a single app target, prompts when interactive, and fails in non-interactive mode with guidance to pass `--app-target`.
- Hosted XCTest target selection uses `--hosted-test-target` when provided and treats it as an explicit user or agent choice, as long as the target exists and has a non-empty `TEST_HOST`.
- Without `--hosted-test-target`, the wizard first narrows hosted XCTest targets to those whose `TEST_HOST` matches the selected app target's bundle/executable names.
- If app-specific hosted-test matching finds one target, the wizard uses it. If it finds multiple targets, the wizard prompts in interactive mode and fails in non-interactive mode with guidance to pass `--hosted-test-target`.
- If app-specific hosted-test matching is inconclusive but the project has exactly one hosted XCTest target, the wizard assumes the common case that this target belongs to the selected app. If there are multiple hosted XCTest targets, the wizard prompts in interactive mode and fails in non-interactive mode.
- Non-interactive mode must never wait on stdin. It either proceeds from explicit arguments/safe single-target assumptions or fails with manual setup instructions and the CLI flag needed to continue.
- Missing Swift previews are not fatal. Interactive mode asks whether to continue; non-interactive mode logs the limitation and continues, because agents may still want the project wiring and manual next steps.
- Snapshot scheme inference is used only to generate `xcodebuild test` guidance. If the correct scheme cannot be inferred safely, the wizard still completes and prints guidance without a scheme.
- The wizard does not configure Sentry auth, DSNs, runtime SDK initialization, dSYM upload scripts, Fastlane dSYM setup, MCP config, or CI workflow files.

This is separate from the existing `ios` wizard on purpose. Snapshot setup is related to Apple projects, but it should not silently configure normal runtime SDK behavior. Keeping this as its own wizard makes the user-visible behavior narrower: project wiring plus explicit next-step guidance for snapshot export/upload.

The existing `ios` wizard remains the normal Sentry Apple setup path. The Xcode refactor is intended to be shared infrastructure rather than a behavior change: project lookup is split from target selection, Sentry Swift package metadata moved into a package spec, and `XcodeProject` now has reusable helpers for hosted XCTest target detection, bundle ID lookup, Swift package product linking, synchronized-folder source membership, Swift source insertion, and source file resolution. Existing Sentry package/script setup still flows through `configureXcodeProject` and `updateXcodeProject`.

Suggested review focus:

- `.pbxproj` mutation correctness and idempotency, especially shared Swift package product linking
- hosted XCTest detection via `TEST_HOST` and app bundle/executable name matching
- the target-selection contract for single-target assumptions, explicit CLI choices, and non-interactive failures
- SnapshotPreviews package URL, minimum version, and product names
- generated snapshot test file placement/reuse for both classic source phases and synchronized folders
- scheme inference used only for generated `xcodebuild test` guidance
- ensuring the existing `ios` wizard did not pick up accidental runtime behavior changes

Risk is medium because the new wizard mutates Xcode project graphs and the package-linking helper is shared with existing Sentry Swift package setup. The new `appleSnapshots` flow is isolated from auth/runtime/dSYM/CI configuration, but unusual Xcode project structures, ambiguous schemes, or non-standard hosted test target settings are the areas most likely to need reviewer scrutiny.