### PR TITLE
feat(apple): Refactor Xcode project primitives for snapshots

### DIFF
--- a/src/apple/apple-wizard.ts
+++ b/src/apple/apple-wizard.ts
@@ -16,7 +16,7 @@ import { configurePackageManager } from './configure-package-manager';
 import { configureSentryCLI } from './configure-sentry-cli';
 import { configureXcodeProject } from './configure-xcode-project';
 import { injectCodeSnippet } from './inject-code-snippet';
-import { lookupXcodeProject } from './lookup-xcode-project';
+import { lookupXcodeProject, selectXcodeTarget } from './lookup-xcode-project';
 import { AppleWizardOptions } from './options';
 import { abortIfSpotlightNotSupported } from '../utils/abort-if-sportlight-not-supported';
 
@@ -57,9 +57,8 @@ async function runAppleWizardWithTelementry(
   // Step - Xcode Project Lookup
   // This step should be run before the Sentry Project and API Key step
   // because it can abort the wizard if no Xcode project is found.
-  const { xcProject, target } = await lookupXcodeProject({
-    projectDir,
-  });
+  const xcProject = await lookupXcodeProject({ projectDir });
+  const target = await selectXcodeTarget(xcProject);
 
   // Step - Sentry Project and API Key
   const projectData = await getOrAskForProjectData(options, 'apple-ios');

--- a/src/apple/check-installed-cli.ts
+++ b/src/apple/check-installed-cli.ts
@@ -6,14 +6,16 @@ import * as bash from '../utils/bash';
 import { askToInstallSentryCLI } from '../utils/clack';
 import { debug } from '../utils/debug';
 
-export async function checkInstalledCLI() {
+export async function checkInstalledCLI(
+  declineWarning = "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+): Promise<boolean> {
   debug(`Checking if sentry-cli is installed`);
   const hasCli = bash.hasSentryCLI();
   Sentry.setTag('has-cli', hasCli);
   if (hasCli) {
     // If the CLI is installed, we don't need to ask the user to install it and can exit early.
     debug(`sentry-cli is installed`);
-    return;
+    return true;
   }
 
   debug(`sentry-cli is not installed, asking user to install it`);
@@ -24,11 +26,11 @@ export async function checkInstalledCLI() {
     debug(`User agreed to install sentry-cli`);
     await bash.installSentryCLI();
     Sentry.setTag('CLI-Installed', true);
-  } else {
-    debug(`User declined to install sentry-cli`);
-    clack.log.warn(
-      "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
-    );
-    Sentry.setTag('CLI-Installed', false);
+    return true;
   }
+
+  debug(`User declined to install sentry-cli`);
+  clack.log.warn(declineWarning);
+  Sentry.setTag('CLI-Installed', false);
+  return false;
 }

--- a/src/apple/configure-xcode-project.ts
+++ b/src/apple/configure-xcode-project.ts
@@ -1,5 +1,9 @@
 import { traceStep } from '../telemetry';
 import { SentryProjectData } from '../utils/types';
+import {
+  SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+  sentrySwiftPackageProductSpec,
+} from './sentry-swift-package';
 import { XcodeProject } from './xcode-manager';
 
 export function configureXcodeProject({
@@ -14,6 +18,18 @@ export function configureXcodeProject({
   shouldUseSPM: boolean;
 }) {
   traceStep('Update Xcode project', () => {
-    xcProject.updateXcodeProject(project, target, shouldUseSPM, true);
+    xcProject.updateXcodeProject(
+      project,
+      target,
+      shouldUseSPM
+        ? {
+            product: sentrySwiftPackageProductSpec,
+            existingFrameworkComment:
+              SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+            successMessage: 'Added Sentry SPM dependency to your project',
+          }
+        : undefined,
+      true,
+    );
   });
 }

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -31,6 +31,8 @@ export async function lookupXcodeProject({
     )} candidates for Xcode project`,
   );
 
+  // In case there is only one Xcode project, we can use that one.
+  // Otherwise, we need to ask the user which one they want to use.
   let xcodeProjFile: string;
   if (xcodeProjFiles.length === 1) {
     debug(`Found exactly one Xcode project, using it`);

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -15,10 +15,7 @@ export async function lookupXcodeProject({
   projectDir,
 }: {
   projectDir: string;
-}): Promise<{
-  xcProject: XcodeProject;
-  target: string;
-}> {
+}): Promise<XcodeProject> {
   debug(`Looking for Xcode project in directory: ${chalk.cyan(projectDir)}`);
   const xcodeProjFiles = searchXcodeProjectAtPath(projectDir);
   if (xcodeProjFiles.length === 0) {
@@ -34,8 +31,6 @@ export async function lookupXcodeProject({
     )} candidates for Xcode project`,
   );
 
-  // In case there is only one Xcode project, we can use that one.
-  // Otherwise, we need to ask the user which one they want to use.
   let xcodeProjFile: string;
   if (xcodeProjFiles.length === 1) {
     debug(`Found exactly one Xcode project, using it`);
@@ -54,7 +49,6 @@ export async function lookupXcodeProject({
     ).value;
   }
 
-  // Load the pbxproj file
   const pathToPbxproj = path.join(projectDir, xcodeProjFile, 'project.pbxproj');
   debug(`Loading Xcode project pbxproj at path: ${chalk.cyan(pathToPbxproj)}`);
   if (!fs.existsSync(pathToPbxproj)) {
@@ -63,41 +57,49 @@ export async function lookupXcodeProject({
     return await abort();
   }
 
-  const xcProject = new XcodeProject(pathToPbxproj);
-  const availableTargets = xcProject.getAllTargets();
-  if (availableTargets.length == 0) {
-    clack.log.error(`No suitable Xcode target found in ${xcodeProjFile}`);
+  return new XcodeProject(pathToPbxproj);
+}
+
+export async function selectXcodeTarget(
+  xcProject: XcodeProject,
+  {
+    targetNames = xcProject.getAllTargets(),
+    noTargetMessage = `No suitable Xcode target found in ${path.basename(
+      xcProject.xcodeprojPath,
+    )}`,
+    promptMessage = 'Which target do you want to add Sentry to?',
+  }: {
+    targetNames?: string[];
+    noTargetMessage?: string;
+    promptMessage?: string;
+  } = {},
+): Promise<string> {
+  if (targetNames.length === 0) {
+    clack.log.error(noTargetMessage);
     Sentry.setTag('No-Target', true);
     return await abort();
   }
   debug(
     `Found ${chalk.cyan(
-      availableTargets.length.toString(),
+      targetNames.length.toString(),
     )} targets in Xcode project`,
   );
 
-  // Step - Lookup Xcode Target
   let target: string;
-  if (availableTargets.length == 1) {
+  if (targetNames.length === 1) {
     debug(`Found exactly one target, using it`);
     Sentry.setTag('multiple-targets', false);
-    target = availableTargets[0];
+    target = targetNames[0];
   } else {
     debug(`Found multiple targets, asking user to choose one`);
     Sentry.setTag('multiple-targets', true);
     target = (
       await traceStep('Choose target', () =>
-        askForItemSelection(
-          availableTargets,
-          'Which target do you want to add Sentry to?',
-        ),
+        askForItemSelection(targetNames, promptMessage),
       )
     ).value;
   }
   debug(`Selected target: ${chalk.cyan(target)}`);
 
-  return {
-    xcProject,
-    target,
-  };
+  return target;
 }

--- a/src/apple/sentry-swift-package.ts
+++ b/src/apple/sentry-swift-package.ts
@@ -10,7 +10,7 @@ export const sentrySwiftPackageSpec: SwiftPackageSpec = {
   repositoryURL: 'https://github.com/getsentry/sentry-cocoa/',
   requirement: {
     kind: 'upToNextMajorVersion',
-    minimumVersion: '8.0.0',
+    minimumVersion: '9.0.0',
   },
   commentName: 'sentry-cocoa',
 };

--- a/src/apple/sentry-swift-package.ts
+++ b/src/apple/sentry-swift-package.ts
@@ -1,0 +1,21 @@
+import type {
+  SwiftPackageProductSpec,
+  SwiftPackageSpec,
+} from './xcode-manager';
+
+export const SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT =
+  'Sentry in Frameworks';
+
+export const sentrySwiftPackageSpec: SwiftPackageSpec = {
+  repositoryURL: 'https://github.com/getsentry/sentry-cocoa/',
+  requirement: {
+    kind: 'upToNextMajorVersion',
+    minimumVersion: '8.0.0',
+  },
+  commentName: 'sentry-cocoa',
+};
+
+export const sentrySwiftPackageProductSpec: SwiftPackageProductSpec = {
+  package: sentrySwiftPackageSpec,
+  productName: 'Sentry',
+};

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -6,6 +6,7 @@
 import * as clack from '@clack/prompts';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { lt, valid } from 'semver';
 import { debug } from '../utils/debug';
 import type { SentryProjectData } from '../utils/types';
 import * as templates from './templates';
@@ -31,6 +32,106 @@ interface ProjectFile {
   key?: string;
   name: string;
   path: string;
+}
+
+export type SwiftPackageSpec = {
+  repositoryURL: string;
+  requirement: {
+    kind: 'upToNextMajorVersion';
+    minimumVersion: string;
+  };
+  commentName: string;
+};
+
+export type SwiftPackageProductSpec = {
+  package: SwiftPackageSpec;
+  productName: string;
+};
+
+function unquote(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/"/g, '') : '';
+}
+
+function stripAppExtension(value: string | undefined): string | undefined {
+  return value?.endsWith('.app') ? value.slice(0, -'.app'.length) : value;
+}
+
+function resolveBuildSettingValue(
+  value: unknown,
+  targetName: string,
+): string | undefined {
+  const resolvedValue = unquote(value)
+    .replace(/\$\(TARGET_NAME\)/g, targetName)
+    .replace(/\$\{TARGET_NAME\}/g, targetName)
+    .trim();
+
+  return resolvedValue && !resolvedValue.includes('$')
+    ? resolvedValue
+    : undefined;
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter(Boolean))] as string[];
+}
+
+function testHostReferencesApplication(
+  testHost: unknown,
+  appHostCandidates: ApplicationHostCandidates,
+): boolean {
+  const resolvedTestHost = unquote(testHost);
+  if (!resolvedTestHost) {
+    return false;
+  }
+
+  const referencesAppBundle = appHostCandidates.bundleNames.some((bundleName) =>
+    containsPathSegment(resolvedTestHost, `${bundleName}.app`),
+  );
+  if (!referencesAppBundle) {
+    return false;
+  }
+
+  return appHostCandidates.executableNames.some((executableName) =>
+    containsPathSegment(resolvedTestHost, executableName),
+  );
+}
+
+function containsPathSegment(value: string, segment: string): boolean {
+  return new RegExp(`(^|/)${escapeRegExp(segment)}(/|$)`).test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeSwiftPackageRepositoryURL(value: unknown): string {
+  return unquote(value).replace(/\/+$/, '');
+}
+
+function shouldUpdatePackageRequirement(
+  existingRequirement: unknown,
+  requestedRequirement: SwiftPackageSpec['requirement'],
+): boolean {
+  if (!existingRequirement || typeof existingRequirement !== 'object') {
+    return true;
+  }
+
+  const requirement = existingRequirement as Record<string, unknown>;
+  if (requirement.kind !== requestedRequirement.kind) {
+    return true;
+  }
+
+  const existingMinimumVersion = requirement.minimumVersion;
+  if (typeof existingMinimumVersion !== 'string') {
+    return true;
+  }
+
+  const existingVersion = valid(existingMinimumVersion);
+  const requestedVersion = valid(requestedRequirement.minimumVersion);
+  if (!existingVersion || !requestedVersion) {
+    return existingMinimumVersion !== requestedRequirement.minimumVersion;
+  }
+
+  return lt(existingVersion, requestedVersion);
 }
 
 function setDebugInformationFormatAndSandbox(
@@ -84,123 +185,16 @@ function setDebugInformationFormatAndSandbox(
   }
 }
 
-function addSentrySPM(proj: Project, targetName: string): void {
-  const xcObjects = proj.hash.project.objects;
+export type SwiftPackageProductLinkOptions = {
+  product: SwiftPackageProductSpec;
+  existingFrameworkComment?: string;
+  successMessage?: string;
+};
 
-  const sentryFrameworkUUID = proj.generateUuid();
-  const sentrySPMUUID = proj.generateUuid();
-
-  // Check whether xcObjects already have sentry framework
-  if (xcObjects.PBXFrameworksBuildPhase) {
-    for (const key in xcObjects.PBXFrameworksBuildPhase || {}) {
-      const frameworkBuildPhase = xcObjects.PBXFrameworksBuildPhase[key];
-      if (key.endsWith('_comment') || typeof frameworkBuildPhase === 'string') {
-        // Ignore comments
-        continue;
-      }
-      for (const framework of frameworkBuildPhase.files ?? []) {
-        // We identify the Sentry framework by the comment "Sentry in Frameworks",
-        // which is set by this manager in previous runs.
-        if (framework.comment === 'Sentry in Frameworks') {
-          return;
-        }
-      }
-    }
-  }
-
-  if (!xcObjects.PBXBuildFile) {
-    xcObjects.PBXBuildFile = {};
-  }
-  xcObjects.PBXBuildFile[sentryFrameworkUUID] = {
-    isa: 'PBXBuildFile',
-    productRef: sentrySPMUUID,
-    productRef_comment: 'Sentry',
-  };
-  xcObjects.PBXBuildFile[`${sentryFrameworkUUID}_comment`] =
-    'Sentry in Frameworks';
-
-  if (!xcObjects.PBXFrameworksBuildPhase) {
-    xcObjects.PBXFrameworksBuildPhase = {};
-  }
-  for (const key in xcObjects.PBXFrameworksBuildPhase) {
-    const value = xcObjects.PBXFrameworksBuildPhase[key];
-    if (key.endsWith('_comment') || typeof value === 'string') {
-      // Ignore comments
-      continue;
-    }
-
-    const frameworks = value.files ?? [];
-    frameworks.push({
-      value: sentryFrameworkUUID,
-      comment: 'Sentry in Frameworks',
-    });
-    value.files = frameworks;
-
-    xcObjects.PBXFrameworksBuildPhase[key] = value;
-  }
-
-  if (!xcObjects.PBXNativeTarget) {
-    xcObjects.PBXNativeTarget = {};
-  }
-  const targetKey = Object.keys(xcObjects.PBXNativeTarget || {}).filter(
-    (key) => {
-      const value = xcObjects.PBXNativeTarget?.[key];
-      return (
-        !key.endsWith('_comment') &&
-        typeof value !== 'string' &&
-        value?.name === targetName
-      );
-    },
-  )[0];
-  const target = xcObjects.PBXNativeTarget[targetKey] as PBXNativeTarget;
-
-  if (!target.packageProductDependencies) {
-    target.packageProductDependencies = [];
-  }
-  target.packageProductDependencies.push({
-    value: sentrySPMUUID,
-    comment: 'Sentry',
-  });
-
-  const sentrySwiftPackageUUID = proj.generateUuid();
-  const xcProject = proj.getFirstProject().firstProject;
-  if (!xcProject.packageReferences) {
-    xcProject.packageReferences = [];
-  }
-  xcProject.packageReferences.push({
-    value: sentrySwiftPackageUUID,
-    comment: 'XCRemoteSwiftPackageReference "sentry-cocoa"',
-  });
-
-  if (!xcObjects.XCRemoteSwiftPackageReference) {
-    xcObjects.XCRemoteSwiftPackageReference = {};
-  }
-
-  xcObjects.XCRemoteSwiftPackageReference[sentrySwiftPackageUUID] = {
-    isa: 'XCRemoteSwiftPackageReference',
-    repositoryURL: '"https://github.com/getsentry/sentry-cocoa/"',
-    requirement: {
-      kind: 'upToNextMajorVersion',
-      minimumVersion: '8.0.0',
-    },
-  };
-  xcObjects.XCRemoteSwiftPackageReference[`${sentrySwiftPackageUUID}_comment`] =
-    'XCRemoteSwiftPackageReference "sentry-cocoa"';
-
-  if (!xcObjects.XCSwiftPackageProductDependency) {
-    xcObjects.XCSwiftPackageProductDependency = {};
-  }
-  xcObjects.XCSwiftPackageProductDependency[sentrySPMUUID] = {
-    isa: 'XCSwiftPackageProductDependency',
-    package: sentrySwiftPackageUUID,
-    package_comment: 'XCRemoteSwiftPackageReference "sentry-cocoa"',
-    productName: 'Sentry',
-  };
-  xcObjects.XCSwiftPackageProductDependency[`${sentrySPMUUID}_comment`] =
-    'Sentry';
-
-  clack.log.step('Added Sentry SPM dependency to your project');
-}
+type ApplicationHostCandidates = {
+  bundleNames: string[];
+  executableNames: string[];
+};
 
 export class XcodeProject {
   /**
@@ -256,10 +250,142 @@ export class XcodeProject {
       });
   }
 
+  public getUnitTestTargetNames(): string[] {
+    const targets = this.objects.PBXNativeTarget ?? {};
+    return Object.keys(targets)
+      .filter((key) => {
+        const value = targets[key];
+        return (
+          !key.endsWith('_comment') &&
+          typeof value !== 'string' &&
+          unquote(value.productType) ===
+            'com.apple.product-type.bundle.unit-test'
+        );
+      })
+      .map((key) => {
+        return (targets[key] as PBXNativeTarget).name;
+      });
+  }
+
+  public getHostedUnitTestTargetNamesForApplicationTarget(
+    appTargetName: string,
+  ): string[] {
+    const appTarget = this.findNativeTargetByName(appTargetName);
+    if (!appTarget) {
+      return [];
+    }
+
+    const appHostCandidates = this.getApplicationHostCandidates(appTarget);
+    const targets = this.objects.PBXNativeTarget ?? {};
+    return Object.keys(targets)
+      .filter((key) => {
+        const value = targets[key];
+        return (
+          !key.endsWith('_comment') &&
+          typeof value !== 'string' &&
+          unquote(value.productType) ===
+            'com.apple.product-type.bundle.unit-test' &&
+          this.getTargetBuildSettings(value).some((buildSettings) =>
+            testHostReferencesApplication(
+              buildSettings.TEST_HOST,
+              appHostCandidates,
+            ),
+          )
+        );
+      })
+      .map((key) => {
+        return (targets[key] as PBXNativeTarget).name;
+      });
+  }
+
+  public getBundleIdentifierForTarget(targetName: string): string | undefined {
+    const target = this.findNativeTargetByName(targetName);
+    if (!target) {
+      return undefined;
+    }
+
+    return this.getTargetBuildSettings(target.obj)
+      .map((buildSettings) => {
+        return unquote(buildSettings.PRODUCT_BUNDLE_IDENTIFIER);
+      })
+      .find(Boolean);
+  }
+
+  /**
+   * Idempotently links a Swift package product to one target dependency list
+   * and Frameworks build phase. Returns whether the pbxproj graph changed and
+   * whether the product is linked after the operation.
+   */
+  public ensureSwiftPackageProductLinked(
+    targetName: string,
+    product: SwiftPackageProductSpec,
+  ): { changed: boolean; linked: boolean } {
+    const target = this.findNativeTargetByName(targetName);
+    if (!target) {
+      debug(`Target not found: ${targetName}`);
+      return { changed: false, linked: false };
+    }
+
+    const frameworksBuildPhase = this.findFrameworksBuildPhaseInTarget(
+      target.obj,
+    );
+    if (!frameworksBuildPhase) {
+      debug(`Frameworks build phase not found for target: ${targetName}`);
+      return { changed: false, linked: false };
+    }
+
+    let changed = false;
+
+    // Ensure the remote Swift package object exists.
+    const packageReference = this.ensureSwiftPackageReference(product.package);
+    changed = packageReference.changed || changed;
+
+    // Attach the Swift package object to the root Xcode project.
+    changed =
+      this.ensureProjectSwiftPackageReference(
+        packageReference.packageRefId,
+        product.package.commentName,
+      ) || changed;
+
+    // Ensure the package product dependency object exists.
+    const productDependency = this.ensureSwiftPackageProductDependency(
+      packageReference.packageRefId,
+      product,
+    );
+    changed = productDependency.changed || changed;
+
+    if (!target.obj.packageProductDependencies) {
+      target.obj.packageProductDependencies = [];
+    }
+
+    // Attach the package product dependency to the selected target.
+    if (
+      !target.obj.packageProductDependencies.some((dependency) => {
+        return dependency.value === productDependency.productDependencyId;
+      })
+    ) {
+      target.obj.packageProductDependencies.push({
+        value: productDependency.productDependencyId,
+        comment: product.productName,
+      });
+      changed = true;
+    }
+
+    // Link the package product in the target Frameworks build phase.
+    changed =
+      this.ensureFrameworksBuildFile(
+        frameworksBuildPhase,
+        productDependency.productDependencyId,
+        product,
+      ) || changed;
+
+    return { changed, linked: true };
+  }
+
   public updateXcodeProject(
     sentryProject: SentryProjectData,
     target: string,
-    addSPMReference: boolean,
+    swiftPackageProduct?: SwiftPackageProductLinkOptions,
     uploadSource = true,
   ): void {
     this.addUploadSymbolsScript({
@@ -270,11 +396,25 @@ export class XcodeProject {
     if (uploadSource) {
       setDebugInformationFormatAndSandbox(this.project, target);
     }
-    if (addSPMReference) {
-      addSentrySPM(this.project, target);
+    if (
+      swiftPackageProduct &&
+      !(
+        swiftPackageProduct.existingFrameworkComment &&
+        this.hasFrameworkBuildFileCommentInTarget(
+          target,
+          swiftPackageProduct.existingFrameworkComment,
+        )
+      )
+    ) {
+      const result = this.ensureSwiftPackageProductLinked(
+        target,
+        swiftPackageProduct.product,
+      );
+      if (result.changed && swiftPackageProduct.successMessage) {
+        clack.log.step(swiftPackageProduct.successMessage);
+      }
     }
-    const newContent = this.project.writeSync();
-    fs.writeFileSync(this.pbxprojPath, newContent);
+    this.write();
   }
 
   addUploadSymbolsScript({
@@ -389,6 +529,116 @@ export class XcodeProject {
     }
   }
 
+  public write(): void {
+    const newContent = this.project.writeSync();
+    fs.writeFileSync(this.pbxprojPath, newContent);
+  }
+
+  public getSynchronizedRootGroupPathsForTarget(targetName: string): string[] {
+    const nativeTarget = this.findNativeTargetByName(targetName);
+    if (!nativeTarget) {
+      return [];
+    }
+
+    return (nativeTarget.obj.fileSystemSynchronizedGroups ?? []).reduce(
+      (groupPaths, group) => {
+        const groupObj =
+          this.objects.PBXFileSystemSynchronizedRootGroup?.[group.value];
+        if (!groupObj || typeof groupObj !== 'object') {
+          return groupPaths;
+        }
+
+        const groupPath = this.resolveAbsolutePathOfSynchronizedRootGroup({
+          id: group.value,
+          obj: groupObj,
+        });
+        if (!groupPath) {
+          return groupPaths;
+        }
+
+        return groupPaths.concat(groupPath);
+      },
+      new Array<string>(),
+    );
+  }
+
+  /**
+   * Ensures a Swift file is compiled by a target, either through an Xcode
+   * synchronized root group or an explicit Sources build phase entry.
+   */
+  public addSwiftSourceFileToTarget(args: {
+    targetName: string;
+    filePath: string;
+  }): { changed: boolean; included: boolean } {
+    const nativeTarget = this.findNativeTargetByName(args.targetName);
+    const defaultResult = { changed: false, included: false };
+    if (!nativeTarget) {
+      debug(`Target not found: ${args.targetName}`);
+      return defaultResult;
+    }
+
+    const absoluteFilePath = args.filePath;
+    if (
+      this.isFileIncludedBySynchronizedRootGroup(nativeTarget, absoluteFilePath)
+    ) {
+      return {
+        changed: false,
+        included: true,
+      };
+    }
+
+    const sourceBuildPhase = this.findSourceBuildPhaseInTarget(
+      nativeTarget.obj,
+    );
+    if (!sourceBuildPhase) {
+      debug(`Sources build phase not found for target: ${args.targetName}`);
+      return defaultResult;
+    }
+
+    const fileReference = this.ensureSwiftFileReference(absoluteFilePath);
+    const sourceBuildPhaseFiles = sourceBuildPhase.obj.files ?? [];
+    const existingBuildFileReference = sourceBuildPhaseFiles.find((file) => {
+      const buildFile = this.objects.PBXBuildFile?.[file.value];
+      return (
+        buildFile &&
+        typeof buildFile !== 'string' &&
+        buildFile.fileRef === fileReference.fileReferenceId
+      );
+    });
+
+    if (existingBuildFileReference) {
+      return {
+        changed: fileReference.changed,
+        included: true,
+      };
+    }
+
+    if (!this.objects.PBXBuildFile) {
+      this.objects.PBXBuildFile = {};
+    }
+
+    const buildFileId = this.project.generateUuid();
+    const fileName = path.basename(absoluteFilePath);
+    this.objects.PBXBuildFile[buildFileId] = {
+      isa: 'PBXBuildFile',
+      fileRef: fileReference.fileReferenceId,
+      fileRef_comment: fileName,
+    };
+    this.objects.PBXBuildFile[
+      `${buildFileId}_comment`
+    ] = `${fileName} in Sources`;
+
+    sourceBuildPhase.obj.files = [
+      ...sourceBuildPhaseFiles,
+      {
+        value: buildFileId,
+        comment: `${fileName} in Sources`,
+      },
+    ];
+
+    return { changed: true, included: true };
+  }
+
   /**
    * Retrieves all source files associated with a specific target in the Xcode project.
    * This is used to find files where we can inject Sentry initialization code.
@@ -432,6 +682,409 @@ export class XcodeProject {
       `Found ${filesInSynchronizedRootGroups.length} files in synchronized root groups for target: ${targetName}`,
     );
     return [...filesInBuildPhase, ...filesInSynchronizedRootGroups];
+  }
+
+  private getTargetBuildSettings(
+    target: PBXNativeTarget,
+  ): Record<string, unknown>[] {
+    const buildConfigurationListId = target.buildConfigurationList;
+    if (!buildConfigurationListId) {
+      return [];
+    }
+
+    const configurationList = this.objects.XCConfigurationList?.[
+      buildConfigurationListId
+    ] as XCConfigurationList | undefined;
+    if (!configurationList || typeof configurationList === 'string') {
+      return [];
+    }
+
+    return (configurationList.buildConfigurations ?? []).reduce(
+      (buildSettings, buildConfiguration) => {
+        const configuration =
+          this.objects.XCBuildConfiguration?.[buildConfiguration.value];
+        if (!configuration || typeof configuration === 'string') {
+          return buildSettings;
+        }
+
+        return buildSettings.concat(configuration.buildSettings ?? {});
+      },
+      new Array<Record<string, unknown>>(),
+    );
+  }
+
+  private getApplicationHostCandidates(
+    target: XcodeProjectObjectWithId<PBXNativeTarget>,
+  ): ApplicationHostCandidates {
+    const buildSettings = this.getTargetBuildSettings(target.obj);
+    const productReferencePath = this.getProductReferencePath(target.obj);
+    const productReferenceName = stripAppExtension(productReferencePath);
+    const targetProductName = resolveBuildSettingValue(
+      target.obj.productName,
+      target.obj.name,
+    );
+    const buildSettingProductNames = buildSettings.flatMap((settings) => [
+      resolveBuildSettingValue(settings.PRODUCT_NAME, target.obj.name),
+      stripAppExtension(
+        resolveBuildSettingValue(settings.FULL_PRODUCT_NAME, target.obj.name),
+      ),
+      stripAppExtension(
+        resolveBuildSettingValue(settings.WRAPPER_NAME, target.obj.name),
+      ),
+    ]);
+    const buildSettingExecutableNames = buildSettings.map((settings) =>
+      resolveBuildSettingValue(settings.EXECUTABLE_NAME, target.obj.name),
+    );
+
+    return {
+      bundleNames: uniqueStrings([
+        target.obj.name,
+        targetProductName,
+        productReferenceName,
+        ...buildSettingProductNames,
+      ]),
+      executableNames: uniqueStrings([
+        target.obj.name,
+        targetProductName,
+        productReferenceName,
+        ...buildSettingExecutableNames,
+      ]),
+    };
+  }
+
+  private getProductReferencePath(target: PBXNativeTarget): string | undefined {
+    if (!target.productReference) {
+      return undefined;
+    }
+
+    const productReference =
+      this.objects.PBXFileReference?.[target.productReference];
+    if (!productReference || typeof productReference === 'string') {
+      return undefined;
+    }
+
+    return unquote(productReference.path);
+  }
+
+  private hasFrameworkBuildFileCommentInTarget(
+    targetName: string,
+    comment: string,
+  ): boolean {
+    const target = this.findNativeTargetByName(targetName);
+    if (!target) {
+      return false;
+    }
+
+    const frameworksBuildPhase = this.findFrameworksBuildPhaseInTarget(
+      target.obj,
+    );
+    return (frameworksBuildPhase?.files ?? []).some((framework) => {
+      return framework.comment === comment;
+    });
+  }
+
+  private ensureSwiftPackageReference(packageSpec: SwiftPackageSpec): {
+    packageRefId: string;
+    changed: boolean;
+  } {
+    if (!this.objects.XCRemoteSwiftPackageReference) {
+      this.objects.XCRemoteSwiftPackageReference = {};
+    }
+
+    const packageReferences = this.objects
+      .XCRemoteSwiftPackageReference as Record<string, unknown>;
+    const requestedRepositoryURL = normalizeSwiftPackageRepositoryURL(
+      packageSpec.repositoryURL,
+    );
+    const existingPackageReference = Object.entries(packageReferences).find(
+      ([id, value]) => {
+        if (id.endsWith('_comment') || typeof value !== 'object') {
+          return false;
+        }
+
+        const packageReference = value as Record<string, unknown>;
+        return (
+          normalizeSwiftPackageRepositoryURL(packageReference.repositoryURL) ===
+          requestedRepositoryURL
+        );
+      },
+    );
+
+    if (existingPackageReference) {
+      const packageReference = existingPackageReference[1] as Record<
+        string,
+        unknown
+      >;
+      if (
+        shouldUpdatePackageRequirement(
+          packageReference.requirement,
+          packageSpec.requirement,
+        )
+      ) {
+        packageReference.requirement = packageSpec.requirement;
+        return { packageRefId: existingPackageReference[0], changed: true };
+      }
+
+      return { packageRefId: existingPackageReference[0], changed: false };
+    }
+
+    const packageRefId = this.project.generateUuid();
+    packageReferences[packageRefId] = {
+      isa: 'XCRemoteSwiftPackageReference',
+      repositoryURL: `"${packageSpec.repositoryURL}"`,
+      requirement: packageSpec.requirement,
+    };
+    packageReferences[`${packageRefId}_comment`] =
+      this.swiftPackageReferenceComment(packageSpec.commentName);
+
+    return { packageRefId, changed: true };
+  }
+
+  private ensureProjectSwiftPackageReference(
+    packageRefId: string,
+    commentName: string,
+  ): boolean {
+    const xcodeProject = this.project.getFirstProject().firstProject as {
+      packageReferences?: { value: string; comment?: string }[];
+    };
+    if (!xcodeProject.packageReferences) {
+      xcodeProject.packageReferences = [];
+    }
+
+    if (
+      xcodeProject.packageReferences.some((packageReference) => {
+        return packageReference.value === packageRefId;
+      })
+    ) {
+      return false;
+    }
+
+    xcodeProject.packageReferences.push({
+      value: packageRefId,
+      comment: this.swiftPackageReferenceComment(commentName),
+    });
+    return true;
+  }
+
+  private ensureSwiftPackageProductDependency(
+    packageRefId: string,
+    product: SwiftPackageProductSpec,
+  ): { productDependencyId: string; changed: boolean } {
+    if (!this.objects.XCSwiftPackageProductDependency) {
+      this.objects.XCSwiftPackageProductDependency = {};
+    }
+
+    const productDependencies = this.objects
+      .XCSwiftPackageProductDependency as Record<string, unknown>;
+    const existingProductDependency = Object.entries(productDependencies).find(
+      ([id, value]) => {
+        if (id.endsWith('_comment') || typeof value !== 'object') {
+          return false;
+        }
+
+        const productDependency = value as Record<string, unknown>;
+        return (
+          productDependency.package === packageRefId &&
+          unquote(productDependency.productName) === product.productName
+        );
+      },
+    );
+
+    if (existingProductDependency) {
+      return {
+        productDependencyId: existingProductDependency[0],
+        changed: false,
+      };
+    }
+
+    const productDependencyId = this.project.generateUuid();
+    productDependencies[productDependencyId] = {
+      isa: 'XCSwiftPackageProductDependency',
+      package: packageRefId,
+      package_comment: this.swiftPackageReferenceComment(
+        product.package.commentName,
+      ),
+      productName: product.productName,
+    };
+    productDependencies[`${productDependencyId}_comment`] = product.productName;
+
+    return { productDependencyId, changed: true };
+  }
+
+  private ensureFrameworksBuildFile(
+    frameworksBuildPhase: {
+      files?: { value: string; comment?: string }[];
+    },
+    productDependencyId: string,
+    product: SwiftPackageProductSpec,
+  ): boolean {
+    if (!this.objects.PBXBuildFile) {
+      this.objects.PBXBuildFile = {};
+    }
+
+    const existingFrameworkEntry = (frameworksBuildPhase.files ?? []).find(
+      (framework) => {
+        const buildFile = this.objects.PBXBuildFile?.[framework.value];
+        return (
+          buildFile &&
+          typeof buildFile !== 'string' &&
+          buildFile.productRef === productDependencyId
+        );
+      },
+    );
+    if (existingFrameworkEntry) {
+      return false;
+    }
+
+    const buildFileId = this.project.generateUuid();
+    this.objects.PBXBuildFile[buildFileId] = {
+      isa: 'PBXBuildFile',
+      productRef: productDependencyId,
+      productRef_comment: product.productName,
+    };
+    this.objects.PBXBuildFile[
+      `${buildFileId}_comment`
+    ] = `${product.productName} in Frameworks`;
+
+    if (!frameworksBuildPhase.files) {
+      frameworksBuildPhase.files = [];
+    }
+    frameworksBuildPhase.files.push({
+      value: buildFileId,
+      comment: `${product.productName} in Frameworks`,
+    });
+
+    return true;
+  }
+
+  private findFrameworksBuildPhaseInTarget(target: PBXNativeTarget):
+    | {
+        files?: { value: string; comment?: string }[];
+      }
+    | undefined {
+    for (const buildPhaseReference of target.buildPhases ?? []) {
+      const buildPhase =
+        this.objects.PBXFrameworksBuildPhase?.[buildPhaseReference.value];
+      if (buildPhase && typeof buildPhase !== 'string') {
+        return buildPhase as { files?: { value: string; comment?: string }[] };
+      }
+    }
+
+    return undefined;
+  }
+
+  private swiftPackageReferenceComment(commentName: string): string {
+    return `XCRemoteSwiftPackageReference "${commentName}"`;
+  }
+
+  private isFileIncludedBySynchronizedRootGroup(
+    nativeTarget: XcodeProjectObjectWithId<PBXNativeTarget>,
+    absoluteFilePath: string,
+  ): boolean {
+    return this.findFilesInSynchronizedRootGroups(nativeTarget).some(
+      (filePath) => filePath === absoluteFilePath,
+    );
+  }
+
+  private ensureSwiftFileReference(absoluteFilePath: string): {
+    fileReferenceId: string;
+    changed: boolean;
+  } {
+    if (!this.objects.PBXFileReference) {
+      this.objects.PBXFileReference = {};
+    }
+
+    const existingFileReference = Object.entries(
+      this.objects.PBXFileReference,
+    ).find(([id, fileReference]) => {
+      if (id.endsWith('_comment') || typeof fileReference !== 'object') {
+        return false;
+      }
+
+      const resolvedFilePath = this.resolveAbsolutePathOfFileReference({
+        id,
+        obj: fileReference,
+      });
+      return resolvedFilePath === absoluteFilePath;
+    });
+
+    if (existingFileReference) {
+      return { fileReferenceId: existingFileReference[0], changed: false };
+    }
+
+    const fileReferenceId = this.project.generateUuid();
+    const fileName = path.basename(absoluteFilePath);
+    const relativePath = path.relative(this.baseDir, absoluteFilePath);
+    this.objects.PBXFileReference[fileReferenceId] = {
+      isa: 'PBXFileReference',
+      lastKnownFileType: 'sourcecode.swift',
+      path: relativePath,
+      sourceTree: 'SOURCE_ROOT',
+    };
+    this.objects.PBXFileReference[`${fileReferenceId}_comment`] = fileName;
+
+    this.addFileReferenceToBestGroup(
+      fileReferenceId,
+      fileName,
+      absoluteFilePath,
+    );
+
+    return { fileReferenceId, changed: true };
+  }
+
+  private addFileReferenceToBestGroup(
+    fileReferenceId: string,
+    fileName: string,
+    absoluteFilePath: string,
+  ): void {
+    const parentDirectory = path.dirname(absoluteFilePath);
+    const parentGroup =
+      this.groups.find((group) => {
+        const groupPath = this.resolveAbsolutePathOfGroup(group);
+        return groupPath === parentDirectory;
+      }) ?? this.mainGroup;
+
+    if (!parentGroup) {
+      return;
+    }
+
+    if (!parentGroup.obj.children) {
+      parentGroup.obj.children = [];
+    }
+
+    if (
+      parentGroup.obj.children.some((child) => child.value === fileReferenceId)
+    ) {
+      return;
+    }
+
+    parentGroup.obj.children.push({
+      value: fileReferenceId,
+      comment: fileName,
+    });
+  }
+
+  private get mainGroup(): XcodeProjectObjectWithId<PBXGroup> | undefined {
+    const project = Object.entries(this.objects.PBXProject ?? {}).find(
+      ([id, candidate]) => {
+        return !id.endsWith('_comment') && typeof candidate === 'object';
+      },
+    )?.[1];
+    if (!project || typeof project !== 'object') {
+      return undefined;
+    }
+
+    const mainGroupId = (project as { mainGroup?: string }).mainGroup;
+    if (!mainGroupId) {
+      return undefined;
+    }
+
+    const mainGroup = this.objects.PBXGroup?.[mainGroupId];
+    if (!mainGroup || typeof mainGroup !== 'object') {
+      return undefined;
+    }
+
+    return { id: mainGroupId, obj: mainGroup };
   }
 
   // ================================ TARGET HELPERS ================================

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -48,6 +48,9 @@ export type SwiftPackageProductSpec = {
   productName: string;
 };
 
+const XCODE_APPLICATION_PRODUCT_TYPE = 'com.apple.product-type.application';
+const XCODE_UNIT_TEST_PRODUCT_TYPE = 'com.apple.product-type.bundle.unit-test';
+
 function unquote(value: unknown): string {
   return typeof value === 'string' ? value.replace(/"/g, '') : '';
 }
@@ -242,7 +245,7 @@ export class XcodeProject {
         return (
           !key.endsWith('_comment') &&
           typeof value !== 'string' &&
-          value.productType.startsWith('"com.apple.product-type.application')
+          unquote(value.productType).startsWith(XCODE_APPLICATION_PRODUCT_TYPE)
         );
       })
       .map((key) => {
@@ -258,8 +261,7 @@ export class XcodeProject {
         return (
           !key.endsWith('_comment') &&
           typeof value !== 'string' &&
-          unquote(value.productType) ===
-            'com.apple.product-type.bundle.unit-test'
+          unquote(value.productType) === XCODE_UNIT_TEST_PRODUCT_TYPE
         );
       })
       .map((key) => {
@@ -283,8 +285,7 @@ export class XcodeProject {
         return (
           !key.endsWith('_comment') &&
           typeof value !== 'string' &&
-          unquote(value.productType) ===
-            'com.apple.product-type.bundle.unit-test' &&
+          unquote(value.productType) === XCODE_UNIT_TEST_PRODUCT_TYPE &&
           this.getTargetBuildSettings(value).some((buildSettings) =>
             testHostReferencesApplication(
               buildSettings.TEST_HOST,

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -228,7 +228,9 @@ export async function confirmContinueIfNoOrDirtyGitRepo(options: {
       return;
     }
 
-    const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles();
+    const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles({
+      cwd: options.cwd,
+    });
     if (
       uncommittedOrUntrackedFiles.length &&
       options.ignoreGitChanges !== true

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -20,12 +20,15 @@ export function isInGitRepo(opts: { cwd: string | undefined }) {
   }
 }
 
-export function getUncommittedOrUntrackedFiles(): string[] {
+export function getUncommittedOrUntrackedFiles(opts?: {
+  cwd: string | undefined;
+}): string[] {
   try {
     const gitStatus = childProcess
       .execSync('git status --porcelain=v1', {
         // we only care about stdout
         stdio: ['ignore', 'pipe', 'ignore'],
+        cwd: opts?.cwd,
       })
       .toString();
 

--- a/test/apple/lookup-xcode-project.test.ts
+++ b/test/apple/lookup-xcode-project.test.ts
@@ -1,0 +1,198 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockXcodeProject = {
+  projectPath: string;
+  xcodeprojPath: string;
+  getAllTargets: () => string[];
+};
+
+const mocks = vi.hoisted(() => {
+  const targetsByProjectPath = new Map<string, string[]>();
+
+  return {
+    abort: vi.fn(() => {
+      throw new Error('abort');
+    }),
+    askForItemSelection: vi.fn(),
+    clackError: vi.fn(),
+    debug: vi.fn(),
+    searchXcodeProjectAtPath: vi.fn(),
+    setTag: vi.fn(),
+    targetsByProjectPath,
+    traceStep: vi.fn(
+      async <T>(_name: string, callback: () => Promise<T> | T): Promise<T> =>
+        await callback(),
+    ),
+    XcodeProject: vi.fn(function (this: MockXcodeProject, projectPath: string) {
+      this.projectPath = projectPath;
+      this.xcodeprojPath = path.dirname(projectPath);
+      this.getAllTargets = () => targetsByProjectPath.get(projectPath) ?? [];
+    }),
+  };
+});
+
+vi.mock('@clack/prompts', () => ({
+  default: {
+    log: {
+      error: mocks.clackError,
+    },
+  },
+}));
+
+vi.mock('@sentry/node', () => ({
+  setTag: mocks.setTag,
+}));
+
+vi.mock('../../src/apple/search-xcode-project-at-path', () => ({
+  searchXcodeProjectAtPath: mocks.searchXcodeProjectAtPath,
+}));
+
+vi.mock('../../src/apple/xcode-manager', () => ({
+  XcodeProject: mocks.XcodeProject,
+}));
+
+vi.mock('../../src/telemetry', () => ({
+  traceStep: mocks.traceStep,
+}));
+
+vi.mock('../../src/utils/clack', () => ({
+  abort: mocks.abort,
+  askForItemSelection: mocks.askForItemSelection,
+}));
+
+vi.mock('../../src/utils/debug', () => ({
+  debug: mocks.debug,
+}));
+
+import {
+  lookupXcodeProject,
+  selectXcodeTarget,
+} from '../../src/apple/lookup-xcode-project';
+
+function createProject(projectDir: string, projectName: string): string {
+  const projectPath = path.join(projectDir, projectName);
+  fs.mkdirSync(projectPath, { recursive: true });
+  const pbxprojPath = path.join(projectPath, 'project.pbxproj');
+  fs.writeFileSync(pbxprojPath, 'mock pbxproj');
+
+  return pbxprojPath;
+}
+
+function createMockXcodeProject(
+  pbxprojPath: string,
+): Parameters<typeof selectXcodeTarget>[0] {
+  const XcodeProjectConstructor = mocks.XcodeProject as unknown as {
+    new (projectPath: string): MockXcodeProject;
+  };
+
+  return new XcodeProjectConstructor(pbxprojPath) as unknown as Parameters<
+    typeof selectXcodeTarget
+  >[0];
+}
+
+describe('lookup-xcode-project', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'lookup-xcode-project-'),
+    );
+    vi.clearAllMocks();
+    mocks.targetsByProjectPath.clear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { force: true, recursive: true });
+  });
+
+  describe('lookupXcodeProject', () => {
+    it('returns an Xcode project without selecting a target', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.searchXcodeProjectAtPath.mockReturnValue(['App.xcodeproj']);
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App']);
+
+      const result = await lookupXcodeProject({ projectDir });
+
+      expect(mocks.searchXcodeProjectAtPath).toHaveBeenCalledWith(projectDir);
+      expect(mocks.XcodeProject).toHaveBeenCalledWith(pbxprojPath);
+      expect(result).toEqual(
+        expect.objectContaining({ projectPath: pbxprojPath }),
+      );
+      expect(mocks.askForItemSelection).not.toHaveBeenCalledWith(
+        ['App'],
+        'Which target do you want to add Sentry to?',
+      );
+    });
+
+    it('prompts when multiple Xcode projects are found', async () => {
+      createProject(projectDir, 'First.xcodeproj');
+      const selectedPbxprojPath = createProject(projectDir, 'Second.xcodeproj');
+      mocks.searchXcodeProjectAtPath.mockReturnValue([
+        'First.xcodeproj',
+        'Second.xcodeproj',
+      ]);
+      mocks.askForItemSelection.mockResolvedValue({
+        value: 'Second.xcodeproj',
+      });
+
+      const result = await lookupXcodeProject({ projectDir });
+
+      expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+        ['First.xcodeproj', 'Second.xcodeproj'],
+        'Which project do you want to add Sentry to?',
+      );
+      expect(result).toEqual(
+        expect.objectContaining({ projectPath: selectedPbxprojPath }),
+      );
+    });
+  });
+
+  describe('selectXcodeTarget', () => {
+    it('returns the only target without prompting', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App']);
+      const xcProject = createMockXcodeProject(pbxprojPath);
+
+      const result = await selectXcodeTarget(xcProject);
+
+      expect(result).toBe('App');
+      expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    });
+
+    it('prompts when multiple targets are available', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App', 'Widget']);
+      mocks.askForItemSelection.mockResolvedValue({ value: 'Widget' });
+      const xcProject = createMockXcodeProject(pbxprojPath);
+
+      const result = await selectXcodeTarget(xcProject);
+
+      expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+        ['App', 'Widget'],
+        'Which target do you want to add Sentry to?',
+      );
+      expect(result).toBe('Widget');
+    });
+
+    it('selects from custom target candidates', async () => {
+      const pbxprojPath = createProject(projectDir, 'App.xcodeproj');
+      mocks.targetsByProjectPath.set(pbxprojPath, ['App']);
+      mocks.askForItemSelection.mockResolvedValue({ value: 'AppUITests' });
+      const xcProject = createMockXcodeProject(pbxprojPath);
+
+      const result = await selectXcodeTarget(xcProject, {
+        targetNames: ['AppTests', 'AppUITests'],
+        promptMessage: 'Which test target should render SnapshotPreviews?',
+      });
+
+      expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+        ['AppTests', 'AppUITests'],
+        'Which test target should render SnapshotPreviews?',
+      );
+      expect(result).toBe('AppUITests');
+    });
+  });
+});

--- a/test/apple/snapshots/hosted-test-target-fixture.ts
+++ b/test/apple/snapshots/hosted-test-target-fixture.ts
@@ -1,0 +1,229 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  PBXFileReference,
+  PBXNativeTarget,
+  PBXSourcesBuildPhase,
+  XCBuildConfiguration,
+  XCConfigurationList,
+} from 'xcode';
+
+import type { XcodeProject } from '../../../src/apple/xcode-manager';
+
+export type HostedTestTargetFixtureIds = {
+  targetId: string;
+  frameworksBuildPhaseId: string;
+  sourcesBuildPhaseId?: string;
+  debugBuildConfigurationId: string;
+  releaseBuildConfigurationId: string;
+  buildConfigurationListId: string;
+  productReferenceId: string;
+};
+
+const fixtureProjectPath = path.resolve(
+  __dirname,
+  '../../../fixtures/test-applications/apple/spm-swiftui-single-target/Project.xcodeproj/project.pbxproj',
+);
+
+type HostedTestTargetFixtureOptions = {
+  name?: string;
+  hostAppName?: string;
+  testHost?: string;
+  bundleLoader?: string;
+  ids?: HostedTestTargetFixtureIds;
+  includeSourcesBuildPhase?: boolean;
+  projectObjectId: string;
+  productsGroupId: string;
+};
+
+export function copySingleTargetProjectToTemp(prefix: string): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const xcodeprojDir = path.join(tempDir, 'Project.xcodeproj');
+  fs.mkdirSync(xcodeprojDir, { recursive: true });
+  fs.mkdirSync(path.join(tempDir, 'Sources'), { recursive: true });
+  fs.copyFileSync(
+    fixtureProjectPath,
+    path.join(xcodeprojDir, 'project.pbxproj'),
+  );
+  return path.join(xcodeprojDir, 'project.pbxproj');
+}
+
+export function addHostedUnitTestTarget(
+  xcodeProject: XcodeProject,
+  options: HostedTestTargetFixtureOptions,
+): HostedTestTargetFixtureIds {
+  const name = options.name ?? 'ProjectTests';
+  const ids = options.ids ?? hostedTestTargetFixtureIds(name);
+  const hostAppName = options.hostAppName ?? 'Project';
+  const buildSettings = hostedUnitTestBuildSettings({
+    bundleLoader: options.bundleLoader,
+    hostAppName,
+    name,
+    testHost: options.testHost,
+  });
+
+  xcodeProject.objects.PBXFileReference = {
+    ...(xcodeProject.objects.PBXFileReference ?? {}),
+    [ids.productReferenceId]: {
+      isa: 'PBXFileReference',
+      explicitFileType: 'wrapper.cfbundle',
+      includeInIndex: 0,
+      path: `${name}.xctest`,
+      sourceTree: 'BUILT_PRODUCTS_DIR',
+    } as unknown as PBXFileReference,
+    [`${ids.productReferenceId}_comment`]: `${name}.xctest`,
+  };
+
+  xcodeProject.objects.PBXFrameworksBuildPhase = {
+    ...(xcodeProject.objects.PBXFrameworksBuildPhase ?? {}),
+    [ids.frameworksBuildPhaseId]: {
+      isa: 'PBXFrameworksBuildPhase',
+      buildActionMask: 2147483647,
+      files: [],
+      runOnlyForDeploymentPostprocessing: 0,
+    },
+    [`${ids.frameworksBuildPhaseId}_comment`]: 'Frameworks',
+  };
+
+  const buildPhases = [
+    ...(options.includeSourcesBuildPhase && ids.sourcesBuildPhaseId
+      ? [
+          {
+            value: ids.sourcesBuildPhaseId,
+            comment: 'Sources',
+          },
+        ]
+      : []),
+    {
+      value: ids.frameworksBuildPhaseId,
+      comment: 'Frameworks',
+    },
+  ];
+
+  if (options.includeSourcesBuildPhase && ids.sourcesBuildPhaseId) {
+    xcodeProject.objects.PBXSourcesBuildPhase = {
+      ...(xcodeProject.objects.PBXSourcesBuildPhase ?? {}),
+      [ids.sourcesBuildPhaseId]: {
+        isa: 'PBXSourcesBuildPhase',
+        buildActionMask: 2147483647,
+        files: [],
+        runOnlyForDeploymentPostprocessing: 0,
+      } as PBXSourcesBuildPhase,
+      [`${ids.sourcesBuildPhaseId}_comment`]: 'Sources',
+    };
+  }
+
+  xcodeProject.objects.PBXNativeTarget = {
+    ...(xcodeProject.objects.PBXNativeTarget ?? {}),
+    [ids.targetId]: {
+      isa: 'PBXNativeTarget',
+      buildConfigurationList: ids.buildConfigurationListId,
+      buildPhases,
+      buildRules: [],
+      dependencies: [],
+      name,
+      packageProductDependencies: [],
+      productName: name,
+      productReference: ids.productReferenceId,
+      productType: '"com.apple.product-type.bundle.unit-test"',
+    } as PBXNativeTarget,
+    [`${ids.targetId}_comment`]: name,
+  };
+
+  xcodeProject.objects.XCBuildConfiguration = {
+    ...(xcodeProject.objects.XCBuildConfiguration ?? {}),
+    [ids.debugBuildConfigurationId]: {
+      isa: 'XCBuildConfiguration',
+      buildSettings,
+      name: 'Debug',
+    } as XCBuildConfiguration,
+    [`${ids.debugBuildConfigurationId}_comment`]: 'Debug',
+    [ids.releaseBuildConfigurationId]: {
+      isa: 'XCBuildConfiguration',
+      buildSettings,
+      name: 'Release',
+    } as XCBuildConfiguration,
+    [`${ids.releaseBuildConfigurationId}_comment`]: 'Release',
+  };
+
+  xcodeProject.objects.XCConfigurationList = {
+    ...(xcodeProject.objects.XCConfigurationList ?? {}),
+    [ids.buildConfigurationListId]: {
+      isa: 'XCConfigurationList',
+      buildConfigurations: [
+        {
+          value: ids.debugBuildConfigurationId,
+          comment: 'Debug',
+        },
+        {
+          value: ids.releaseBuildConfigurationId,
+          comment: 'Release',
+        },
+      ],
+      defaultConfigurationIsVisible: 0,
+      defaultConfigurationName: 'Release',
+    } as XCConfigurationList,
+    [`${ids.buildConfigurationListId}_comment`]: `Build configuration list for PBXNativeTarget "${name}"`,
+  };
+
+  const project = xcodeProject.objects.PBXProject?.[options.projectObjectId];
+  if (project && typeof project !== 'string') {
+    project.targets = [
+      ...(project.targets ?? []),
+      {
+        value: ids.targetId,
+        comment: name,
+      },
+    ];
+  }
+
+  const productsGroup =
+    xcodeProject.objects.PBXGroup?.[options.productsGroupId];
+  if (productsGroup && typeof productsGroup !== 'string') {
+    productsGroup.children = [
+      ...(productsGroup.children ?? []),
+      {
+        value: ids.productReferenceId,
+        comment: `${name}.xctest`,
+      },
+    ];
+  }
+
+  return ids;
+}
+
+export function hostedTestTargetFixtureIds(
+  name: string,
+): HostedTestTargetFixtureIds {
+  const idPrefix = name.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+  return {
+    targetId: `${idPrefix}000000000000000001`,
+    frameworksBuildPhaseId: `${idPrefix}000000000000000002`,
+    debugBuildConfigurationId: `${idPrefix}000000000000000003`,
+    releaseBuildConfigurationId: `${idPrefix}000000000000000004`,
+    buildConfigurationListId: `${idPrefix}000000000000000005`,
+    productReferenceId: `${idPrefix}000000000000000006`,
+  };
+}
+
+function hostedUnitTestBuildSettings({
+  bundleLoader,
+  hostAppName,
+  name,
+  testHost,
+}: {
+  bundleLoader?: string;
+  hostAppName: string;
+  name: string;
+  testHost?: string;
+}): Record<string, string> {
+  return {
+    BUNDLE_LOADER: bundleLoader ?? '"$(TEST_HOST)"',
+    PRODUCT_BUNDLE_IDENTIFIER: `com.getsentry.${name}`,
+    PRODUCT_NAME: '"$(TARGET_NAME)"',
+    TEST_HOST:
+      testHost ??
+      `"$(BUILT_PRODUCTS_DIR)/${hostAppName}.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/${hostAppName}"`,
+  };
+}

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -687,8 +687,6 @@ describe('XcodeManager', () => {
       });
 
       describe('add SPM reference', () => {
-        const swiftPackageProduct = sentrySwiftPackageProductLinkOptions;
-
         it('should treat an existing Sentry framework comment on the selected target as already installed', () => {
           // -- Arrange --
           const frameworksBuildPhase =
@@ -712,7 +710,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
 
           // -- Assert --
@@ -757,7 +755,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
 
           // -- Assert --
@@ -784,12 +782,12 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
 
           // -- Assert --
@@ -822,7 +820,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
 
           // -- Assert --
@@ -901,7 +899,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
 
           // -- Assert --
@@ -942,7 +940,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            swiftPackageProduct,
+            sentrySwiftPackageProductLinkOptions,
           );
 
           // -- Assert --

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -862,7 +862,7 @@ describe('XcodeManager', () => {
             repositoryURL: '"https://github.com/getsentry/sentry-cocoa/"',
             requirement: {
               kind: 'upToNextMajorVersion',
-              minimumVersion: '8.0.0',
+              minimumVersion: '9.0.0',
             },
           });
           expect(remoteSwiftPackageReferences?.[rspRefKeys[1]]).toBe(

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -8,9 +8,18 @@ import type {
   PBXShellScriptBuildPhase,
   XCBuildConfiguration,
 } from 'xcode';
+import {
+  SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+  sentrySwiftPackageProductSpec,
+} from '../../src/apple/sentry-swift-package';
 import { getRunScriptTemplate } from '../../src/apple/templates';
-import { XcodeProject } from '../../src/apple/xcode-manager';
+import {
+  SwiftPackageProductLinkOptions,
+  type SwiftPackageProductSpec,
+  XcodeProject,
+} from '../../src/apple/xcode-manager';
 import type { SentryProjectData } from '../../src/utils/types';
+import { addHostedUnitTestTarget } from './snapshots/hosted-test-target-fixture';
 
 vi.mock('node:fs', async () => ({
   __esModule: true,
@@ -63,6 +72,50 @@ const projectData: SentryProjectData = {
   },
   keys: [{ dsn: { public: 'https://sentry.io/1234567890' } }],
 };
+
+const appFrameworksBuildPhaseId = 'D4E604CA2D50CEEC00CAB00F';
+const sentrySwiftPackageProductLinkOptions: SwiftPackageProductLinkOptions = {
+  product: sentrySwiftPackageProductSpec,
+  existingFrameworkComment: SENTRY_SPM_ALREADY_LINKED_FRAMEWORK_COMMENT,
+  successMessage: 'Added Sentry SPM dependency to your project',
+};
+const projectObjectId = 'D4E604C52D50CEEC00CAB00F';
+const productsGroupId = 'D4E604CE2D50CEEC00CAB00F';
+const genericSwiftPackageProductSpec: SwiftPackageProductSpec = {
+  package: {
+    repositoryURL: 'https://github.com/example/example-package/',
+    requirement: {
+      kind: 'upToNextMajorVersion',
+      minimumVersion: '1.2.3',
+    },
+    commentName: 'ExamplePackage',
+  },
+  productName: 'ExampleProduct',
+};
+
+function objectKeysWithoutComments(object: unknown): string[] {
+  return Object.keys((object ?? {}) as Record<string, unknown>).filter(
+    (key) => {
+      return !key.endsWith('_comment');
+    },
+  );
+}
+
+function getTargetByName(
+  xcodeProject: XcodeProject,
+  targetName: string,
+): PBXNativeTarget {
+  const target = Object.values(xcodeProject.objects.PBXNativeTarget ?? {}).find(
+    (candidate) => {
+      return typeof candidate !== 'string' && candidate.name === targetName;
+    },
+  ) as PBXNativeTarget | undefined;
+  if (!target) {
+    throw new Error(`Target not found: ${targetName}`);
+  }
+
+  return target;
+}
 
 describe('XcodeManager', () => {
   beforeEach(() => {
@@ -150,6 +203,201 @@ describe('XcodeManager', () => {
       });
     });
 
+    describe('ensureSwiftPackageProductLinked', () => {
+      let xcodeProject: XcodeProject;
+
+      beforeEach(() => {
+        xcodeProject = new XcodeProject(singleTargetProjectPath);
+      });
+
+      it('links a Swift package product to the selected target', () => {
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'Project',
+          genericSwiftPackageProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: true, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ),
+        ).toHaveLength(1);
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toHaveLength(1);
+
+        const target = getTargetByName(xcodeProject, 'Project');
+        expect(target.packageProductDependencies).toEqual([
+          expect.objectContaining({ comment: 'ExampleProduct' }),
+        ]);
+
+        const frameworksBuildPhase =
+          xcodeProject.objects.PBXFrameworksBuildPhase?.[
+            appFrameworksBuildPhaseId
+          ];
+        expect(
+          typeof frameworksBuildPhase !== 'string'
+            ? frameworksBuildPhase?.files
+            : undefined,
+        ).toEqual([
+          expect.objectContaining({
+            comment: 'ExampleProduct in Frameworks',
+          }),
+        ]);
+      });
+
+      it('is idempotent across repeated runs', () => {
+        // -- Act --
+        const firstResult = xcodeProject.ensureSwiftPackageProductLinked(
+          'Project',
+          genericSwiftPackageProductSpec,
+        );
+        const secondResult = xcodeProject.ensureSwiftPackageProductLinked(
+          'Project',
+          genericSwiftPackageProductSpec,
+        );
+
+        // -- Assert --
+        expect(firstResult).toEqual({ changed: true, linked: true });
+        expect(secondResult).toEqual({ changed: false, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ),
+        ).toHaveLength(1);
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toHaveLength(1);
+        expect(
+          objectKeysWithoutComments(xcodeProject.objects.PBXBuildFile),
+        ).toHaveLength(1);
+      });
+
+      it('reuses an existing product dependency with a quoted product name', () => {
+        // -- Arrange --
+        const packageRefId = 'EXISTINGPACKAGE000000000001';
+        const productDependencyId = 'EXISTINGPRODUCT000000000001';
+        xcodeProject.objects.XCRemoteSwiftPackageReference = {
+          [packageRefId]: {
+            isa: 'XCRemoteSwiftPackageReference',
+            repositoryURL: `"${genericSwiftPackageProductSpec.package.repositoryURL}"`,
+            requirement: genericSwiftPackageProductSpec.package.requirement,
+          },
+          [`${packageRefId}_comment`]:
+            'XCRemoteSwiftPackageReference "ExamplePackage"',
+        };
+        xcodeProject.objects.XCSwiftPackageProductDependency = {
+          [productDependencyId]: {
+            isa: 'XCSwiftPackageProductDependency',
+            package: packageRefId,
+            productName: '"ExampleProduct"',
+          },
+          [`${productDependencyId}_comment`]: 'ExampleProduct',
+        };
+
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'Project',
+          genericSwiftPackageProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: true, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ),
+        ).toEqual([productDependencyId]);
+        expect(getTargetByName(xcodeProject, 'Project')).toEqual(
+          expect.objectContaining({
+            packageProductDependencies: [
+              expect.objectContaining({ value: productDependencyId }),
+            ],
+          }),
+        );
+      });
+
+      it('reuses an existing package reference with the same repository URL and updates a lower minimum version', () => {
+        // -- Arrange --
+        xcodeProject.objects.XCRemoteSwiftPackageReference = {
+          EXISTINGPACKAGE000000000001: {
+            isa: 'XCRemoteSwiftPackageReference',
+            repositoryURL: `"${genericSwiftPackageProductSpec.package.repositoryURL}/"`,
+            requirement: {
+              kind: 'upToNextMajorVersion',
+              minimumVersion: '1.0.0',
+            },
+          },
+          EXISTINGPACKAGE000000000001_comment:
+            'XCRemoteSwiftPackageReference "ExamplePackage"',
+        };
+
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'Project',
+          genericSwiftPackageProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: true, linked: true });
+        expect(
+          objectKeysWithoutComments(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ),
+        ).toEqual(['EXISTINGPACKAGE000000000001']);
+        expect(
+          xcodeProject.objects.XCRemoteSwiftPackageReference?.[
+            'EXISTINGPACKAGE000000000001'
+          ],
+        ).toEqual(
+          expect.objectContaining({
+            requirement: genericSwiftPackageProductSpec.package.requirement,
+          }),
+        );
+        expect(
+          xcodeProject.objects.XCSwiftPackageProductDependency?.[
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCSwiftPackageProductDependency,
+            )[0]
+          ],
+        ).toEqual(
+          expect.objectContaining({
+            package: 'EXISTINGPACKAGE000000000001',
+            productName: 'ExampleProduct',
+          }),
+        );
+      });
+
+      it('does not partially mutate package state when the target has no Frameworks build phase', () => {
+        // -- Arrange --
+        const target = getTargetByName(xcodeProject, 'Project');
+        target.buildPhases = [];
+
+        // -- Act --
+        const result = xcodeProject.ensureSwiftPackageProductLinked(
+          'Project',
+          genericSwiftPackageProductSpec,
+        );
+
+        // -- Assert --
+        expect(result).toEqual({ changed: false, linked: false });
+        expect(
+          xcodeProject.objects.XCRemoteSwiftPackageReference,
+        ).toBeUndefined();
+        expect(
+          xcodeProject.objects.XCSwiftPackageProductDependency,
+        ).toBeUndefined();
+        expect(xcodeProject.objects.PBXBuildFile).toBeUndefined();
+        expect(target.packageProductDependencies).toEqual([]);
+      });
+    });
+
     describe('updateXcodeProject', () => {
       let sourceProjectPath: string;
       let tempProjectPath: string;
@@ -219,7 +467,7 @@ describe('XcodeManager', () => {
               xcodeProject.updateXcodeProject(
                 projectData,
                 'Project',
-                false, // Ignore SPM reference
+                undefined, // Ignore SPM reference
                 variant.uploadSource,
               );
 
@@ -276,7 +524,7 @@ describe('XcodeManager', () => {
             xcodeProject.updateXcodeProject(
               projectData,
               'Project',
-              false, // Ignore SPM reference
+              undefined, // Ignore SPM reference
               false,
             );
 
@@ -297,7 +545,7 @@ describe('XcodeManager', () => {
               xcodeProject.updateXcodeProject(
                 projectData,
                 'Invalid Target Name',
-                false, // Ignore SPM reference
+                undefined, // Ignore SPM reference
                 uploadSource,
               );
 
@@ -316,7 +564,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Invalid Target Name',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -339,7 +587,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Invalid Target Name',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -363,7 +611,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Project',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -394,7 +642,7 @@ describe('XcodeManager', () => {
                 xcodeProject.updateXcodeProject(
                   projectData,
                   'Project',
-                  false, // Ignore SPM reference
+                  undefined, // Ignore SPM reference
                   uploadSource,
                 );
 
@@ -439,55 +687,134 @@ describe('XcodeManager', () => {
       });
 
       describe('add SPM reference', () => {
-        const addSPMReference = true;
+        const swiftPackageProduct = sentrySwiftPackageProductLinkOptions;
 
-        describe('framework build phase already contains Sentry', () => {
-          it('should not update the Xcode project', () => {
-            // -- Arrange --
-            xcodeProject.objects.PBXFrameworksBuildPhase = {
-              'framework-id': {
-                isa: 'PBXFrameworksBuildPhase',
-                files: [
-                  {
-                    value: '123',
-                    comment: 'Sentry in Frameworks',
-                  },
-                ],
-              },
-            };
+        it('should treat an existing Sentry framework comment on the selected target as already installed', () => {
+          // -- Arrange --
+          const frameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              appFrameworksBuildPhaseId
+            ];
+          if (
+            !frameworksBuildPhase ||
+            typeof frameworksBuildPhase === 'string'
+          ) {
+            throw new Error('Frameworks build phase is undefined');
+          }
+          frameworksBuildPhase.files = [
+            {
+              value: '123',
+              comment: 'Sentry in Frameworks',
+            },
+          ];
 
-            // -- Act --
-            xcodeProject.updateXcodeProject(
-              projectData,
-              'Project',
-              addSPMReference,
-            );
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
 
-            // -- Assert --
-            const expectedXcodeProject = new XcodeProject(sourceProjectPath);
-            expectedXcodeProject.objects.PBXFrameworksBuildPhase = {
-              'framework-id': {
-                isa: 'PBXFrameworksBuildPhase',
-                files: [
-                  {
-                    value: '123',
-                    comment: 'Sentry in Frameworks',
-                  },
-                ],
-              },
-            };
-            expect(xcodeProject.objects.PBXFrameworksBuildPhase).toEqual(
-              expectedXcodeProject.objects.PBXFrameworksBuildPhase,
-            );
-            expect(xcodeProject.objects.XCRemoteSwiftPackageReference).toEqual(
-              expectedXcodeProject.objects.XCRemoteSwiftPackageReference,
-            );
-            expect(
-              xcodeProject.objects.XCSwiftPackageProductDependency,
-            ).toEqual(
-              expectedXcodeProject.objects.XCSwiftPackageProductDependency,
-            );
+          // -- Assert --
+          expect(frameworksBuildPhase.files).toEqual([
+            {
+              value: '123',
+              comment: 'Sentry in Frameworks',
+            },
+          ]);
+          expect(
+            xcodeProject.objects.XCRemoteSwiftPackageReference,
+          ).toBeUndefined();
+          expect(
+            xcodeProject.objects.XCSwiftPackageProductDependency,
+          ).toBeUndefined();
+        });
+
+        it('should not treat a Sentry framework comment on another target as installed on the selected target', () => {
+          // -- Arrange --
+          const hostedTestTargetIds = addHostedUnitTestTarget(xcodeProject, {
+            projectObjectId,
+            productsGroupId,
           });
+          const testFrameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              hostedTestTargetIds.frameworksBuildPhaseId
+            ];
+          if (
+            !testFrameworksBuildPhase ||
+            typeof testFrameworksBuildPhase === 'string'
+          ) {
+            throw new Error('Frameworks build phase is undefined');
+          }
+          testFrameworksBuildPhase.files = [
+            {
+              value: '123',
+              comment: 'Sentry in Frameworks',
+            },
+          ];
+
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+
+          // -- Assert --
+          expect(
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCRemoteSwiftPackageReference,
+            ),
+          ).toHaveLength(1);
+          const appFrameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              appFrameworksBuildPhaseId
+            ];
+          expect(
+            typeof appFrameworksBuildPhase !== 'string'
+              ? appFrameworksBuildPhase?.files?.filter((file) => {
+                  return file.comment === 'Sentry in Frameworks';
+                })
+              : [],
+          ).toHaveLength(1);
+        });
+
+        it('should not duplicate the Sentry SPM dependency on repeated runs', () => {
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+
+          // -- Assert --
+          expect(
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCRemoteSwiftPackageReference,
+            ),
+          ).toHaveLength(1);
+          expect(
+            objectKeysWithoutComments(
+              xcodeProject.objects.XCSwiftPackageProductDependency,
+            ),
+          ).toHaveLength(1);
+
+          const frameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              appFrameworksBuildPhaseId
+            ];
+          expect(
+            typeof frameworksBuildPhase !== 'string'
+              ? frameworksBuildPhase?.files?.filter((file) => {
+                  return file.comment === 'Sentry in Frameworks';
+                })
+              : [],
+          ).toHaveLength(1);
         });
 
         it('should add the SPM reference to the target', () => {
@@ -495,7 +822,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            addSPMReference,
+            swiftPackageProduct,
           );
 
           // -- Assert --
@@ -563,6 +890,42 @@ describe('XcodeManager', () => {
           });
         });
 
+        it('should link Sentry only to the selected target', () => {
+          // -- Arrange --
+          const hostedTestTargetIds = addHostedUnitTestTarget(xcodeProject, {
+            projectObjectId,
+            productsGroupId,
+          });
+
+          // -- Act --
+          xcodeProject.updateXcodeProject(
+            projectData,
+            'Project',
+            swiftPackageProduct,
+          );
+
+          // -- Assert --
+          const appTarget = getTargetByName(xcodeProject, 'Project');
+          const hostedTestTarget = getTargetByName(
+            xcodeProject,
+            'ProjectTests',
+          );
+          expect(appTarget.packageProductDependencies).toEqual([
+            expect.objectContaining({ comment: 'Sentry' }),
+          ]);
+          expect(hostedTestTarget.packageProductDependencies).toEqual([]);
+
+          const testFrameworksBuildPhase =
+            xcodeProject.objects.PBXFrameworksBuildPhase?.[
+              hostedTestTargetIds.frameworksBuildPhaseId
+            ];
+          expect(
+            typeof testFrameworksBuildPhase !== 'string'
+              ? testFrameworksBuildPhase?.files
+              : undefined,
+          ).toEqual([]);
+        });
+
         it('should initialize packageProductDependencies if not present', () => {
           // -- Arrange --
           // Ensure the target exists but has no packageProductDependencies initially
@@ -579,7 +942,7 @@ describe('XcodeManager', () => {
           xcodeProject.updateXcodeProject(
             projectData,
             'Project',
-            addSPMReference,
+            swiftPackageProduct,
           );
 
           // -- Assert --

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -77,6 +77,19 @@ describe('getUncommittedOrUntrackedFiles', () => {
     expect(getUncommittedOrUntrackedFiles()).toEqual([]);
   });
 
+  it('forwards cwd if provided', () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      return '';
+    });
+
+    getUncommittedOrUntrackedFiles({ cwd: '/path/to/dir' });
+
+    expect(mockedExecSync).toHaveBeenCalledWith('git status --porcelain=v1', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      cwd: '/path/to/dir',
+    });
+  });
+
   it('returns an empty list if the git command fails', () => {
     mockedExecSync.mockImplementationOnce(() => {
       throw new Error('Command failed');


### PR DESCRIPTION
## Stack

This is **1/3** in the Apple Snapshots stack replacing the original unified PR #1293.

- 1/3: #1295 — Xcode project primitives (this PR)
- 2/3: #1296 — Interactive Apple Snapshots wizard
- 3/3: #1297 — Non-interactive Apple Snapshots mode

The top of the stack is intended to be an exact, lossless re-expression of #1293.

## Summary

This PR refactors the existing Apple/Xcode project infrastructure needed by the Apple Snapshots wizard, without exposing the new `appleSnapshots` wizard yet.

The goal is to make the shared Xcode helpers reviewable independently before adding the user-facing SnapshotPreviews flow. Existing Sentry Apple setup remains routed through the current `ios` wizard; this layer should be shared infrastructure, not a new runtime setup behavior.

## What changed

- Split Xcode project lookup/selection helpers so target discovery can be reused by the snapshots flow.
- Move Sentry Swift package metadata into a reusable package spec.
- Extend `XcodeProject` with reusable helpers for:
  - hosted XCTest target detection via `TEST_HOST`
  - app bundle ID / executable lookup
  - Swift package product linking
  - source file resolution
  - Swift source insertion
  - synchronized-folder source membership support
- Preserve existing `configureXcodeProject` / `updateXcodeProject` behavior for the normal Apple SDK setup path.
- Add focused tests for the refactored project lookup, Xcode mutation, and git helper behavior.

## What this PR intentionally does not do

- Does not add the `appleSnapshots` integration option.
- Does not add the Apple Snapshots wizard entrypoint.
- Does not configure SnapshotPreviews yet.
- Does not configure Sentry auth, DSNs, runtime SDK initialization, dSYM upload scripts, Fastlane setup, MCP config, or CI workflow files.

Those pieces land in the upstack PRs.

## Suggested review focus

- `.pbxproj` mutation correctness and idempotency.
- Shared Swift package product linking behavior.
- Hosted XCTest target detection via `TEST_HOST`.
- Ensuring existing `ios` wizard behavior did not accidentally change.
- Whether the helper boundaries are general enough for both normal Apple SDK setup and SnapshotPreviews setup.

## Risk

Medium. This refactors shared Apple/Xcode project mutation code used by existing setup paths. The risk is primarily around unusual Xcode project graphs, package product linking, target discovery, and source membership handling.

## Validation

Before submitting the stack:

- `yarn test` passed: 947 passed, 4 skipped
- `yarn build` passed
- Final stack tree matched original PR #1293 exactly
- `gt submit --stack --dry-run` passed

Co-Authored-By: GPT-5 Codex <noreply@openai.com>
