### PR TITLE
feat(apple): Add non-interactive Apple Snapshots mode

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -96,8 +96,7 @@ const argv = yargs(hideBin(process.argv), process.cwd())
     },
     'non-interactive': {
       default: false,
-      describe:
-        'Run in non-interactive mode, useful for agentic setup',
+      describe: 'Run in non-interactive mode, useful for agentic setup',
       type: 'boolean',
     },
     i: {
@@ -169,14 +168,12 @@ const argv = yargs(hideBin(process.argv), process.cwd())
     'xcode-project-dir': xcodeProjectDirOption,
     'app-target': {
       default: undefined,
-      describe:
-        'Xcode application target that hosts Swift previews.',
+      describe: 'Xcode application target that hosts Swift previews.',
       type: 'string',
     },
     'hosted-test-target': {
       default: undefined,
-      describe:
-        'Hosted XCTest target to configure.',
+      describe: 'Hosted XCTest target to configure.',
       type: 'string',
     },
     ...PRESELECTED_PROJECT_OPTIONS,

--- a/bin.ts
+++ b/bin.ts
@@ -94,6 +94,12 @@ const argv = yargs(hideBin(process.argv), process.cwd())
         'Do not fallback to prompting user asking questions\nenv: SENTRY_WIZARD_QUIET',
       type: 'boolean',
     },
+    'non-interactive': {
+      default: false,
+      describe:
+        'Run in non-interactive mode, useful for agentic setup',
+      type: 'boolean',
+    },
     i: {
       alias: 'integration',
       choices: Object.keys(Integration),
@@ -161,6 +167,18 @@ const argv = yargs(hideBin(process.argv), process.cwd())
       type: 'boolean',
     },
     'xcode-project-dir': xcodeProjectDirOption,
+    'app-target': {
+      default: undefined,
+      describe:
+        'Xcode application target that hosts Swift previews.',
+      type: 'string',
+    },
+    'hosted-test-target': {
+      default: undefined,
+      describe:
+        'Hosted XCTest target to configure.',
+      type: 'string',
+    },
     ...PRESELECTED_PROJECT_OPTIONS,
   })
   // This prevents `yargs` from trying to read the local package.json

--- a/e2e-tests/tests/help-message.test.ts
+++ b/e2e-tests/tests/help-message.test.ts
@@ -27,6 +27,8 @@ describe('--help command', () => {
                                                             [boolean] [default: false]
             --quiet               Do not fallback to prompting user asking questions
                                   env: SENTRY_WIZARD_QUIET  [boolean] [default: false]
+            --non-interactive     Run in non-interactive mode, useful for agentic
+                                  setup                     [boolean] [default: false]
         -i, --integration         Choose the integration to setup
                                   env: SENTRY_WIZARD_INTEGRATION
                [choices: "reactNative", "flutter", "ios", "appleSnapshots", "android",
@@ -54,6 +56,9 @@ describe('--help command', () => {
             --spotlight           Enable Spotlight for local development. This does
                                   not require a Sentry account or project.
                                                             [boolean] [default: false]
+            --app-target          Xcode application target that hosts Swift previews.
+                                                                              [string]
+            --hosted-test-target  Hosted XCTest target to configure.          [string]
             --version             Show version number                        [boolean]
       "
     `);

--- a/src/apple/check-installed-cli.ts
+++ b/src/apple/check-installed-cli.ts
@@ -8,7 +8,7 @@ import { debug } from '../utils/debug';
 
 export async function checkInstalledCLI(
   declineWarning = "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
-  nonInteractive?: boolean,
+  nonInteractive = false,
 ): Promise<boolean> {
   debug(`Checking if sentry-cli is installed`);
   const hasCli = bash.hasSentryCLI();

--- a/src/apple/check-installed-cli.ts
+++ b/src/apple/check-installed-cli.ts
@@ -8,6 +8,7 @@ import { debug } from '../utils/debug';
 
 export async function checkInstalledCLI(
   declineWarning = "Without sentry-cli, you won't be able to upload debug symbols to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+  nonInteractive?: boolean,
 ): Promise<boolean> {
   debug(`Checking if sentry-cli is installed`);
   const hasCli = bash.hasSentryCLI();
@@ -16,6 +17,13 @@ export async function checkInstalledCLI(
     // If the CLI is installed, we don't need to ask the user to install it and can exit early.
     debug(`sentry-cli is installed`);
     return true;
+  }
+
+  if (nonInteractive) {
+    debug(`sentry-cli is not installed; skipping install prompt`);
+    clack.log.warn(declineWarning);
+    Sentry.setTag('CLI-Installed', false);
+    return false;
   }
 
   debug(`sentry-cli is not installed, asking user to install it`);

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -13,7 +13,7 @@ import { XcodeProject } from './xcode-manager';
 
 export async function lookupXcodeProject({
   projectDir,
-  nonInteractive,
+  nonInteractive = false,
 }: {
   projectDir: string;
   nonInteractive?: boolean;

--- a/src/apple/lookup-xcode-project.ts
+++ b/src/apple/lookup-xcode-project.ts
@@ -13,8 +13,10 @@ import { XcodeProject } from './xcode-manager';
 
 export async function lookupXcodeProject({
   projectDir,
+  nonInteractive,
 }: {
   projectDir: string;
+  nonInteractive?: boolean;
 }): Promise<XcodeProject> {
   debug(`Looking for Xcode project in directory: ${chalk.cyan(projectDir)}`);
   const xcodeProjFiles = searchXcodeProjectAtPath(projectDir);
@@ -41,6 +43,18 @@ export async function lookupXcodeProject({
   } else {
     debug(`Found multiple Xcode projects, asking user to choose one`);
     Sentry.setTag('multiple-projects', true);
+
+    if (nonInteractive) {
+      clack.log.error(
+        [
+          'Multiple Xcode projects found in non-interactive mode.',
+          `Available projects: ${xcodeProjFiles.join(', ')}.`,
+          'Run from a directory with a single .xcodeproj or pass --xcode-project-dir with a narrower project directory.',
+        ].join(' '),
+      );
+      return await abort();
+    }
+
     xcodeProjFile = (
       await traceStep('Choose Xcode project', () =>
         askForItemSelection(

--- a/src/apple/options.ts
+++ b/src/apple/options.ts
@@ -7,5 +7,5 @@ export interface AppleWizardOptions extends WizardOptions {
 export interface AppleSnapshotsWizardOptions extends AppleWizardOptions {
   appTarget?: string;
   hostedTestTarget?: string;
-  nonInteractive?: boolean;
+  nonInteractive: boolean;
 }

--- a/src/apple/options.ts
+++ b/src/apple/options.ts
@@ -3,3 +3,9 @@ import { WizardOptions } from '../utils/types';
 export interface AppleWizardOptions extends WizardOptions {
   projectDir: string | undefined;
 }
+
+export interface AppleSnapshotsWizardOptions extends AppleWizardOptions {
+  appTarget?: string;
+  hostedTestTarget?: string;
+  nonInteractive?: boolean;
+}

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -6,14 +6,22 @@ import clack from '@clack/prompts';
 
 import { withTelemetry } from '../../telemetry';
 import {
+  abort,
+  abortIfCancelled,
+  askForItemSelection,
   confirmContinueIfNoOrDirtyGitRepo,
   printWelcome,
 } from '../../utils/clack';
 import { lookupXcodeProject, selectXcodeTarget } from '../lookup-xcode-project';
-import type { AppleWizardOptions } from '../options';
+import type { AppleSnapshotsWizardOptions } from '../options';
+import type { XcodeProject } from '../xcode-manager';
 import { checkInstalledCLISnapshots } from './snapshots-cli-preflight';
 import { configureSnapshotPreviewsXcodeProject } from './configure-snapshotpreviews-xcode-project';
-import { ensureSnapshotTestFile } from './snapshot-test-file';
+import {
+  ensureSnapshotTestFile,
+  snapshotTestClassName,
+  snapshotTestTemplate,
+} from './snapshot-test-file';
 import { resolveSnapshotVerificationSchemeName } from './snapshot-verification-scheme';
 import {
   SNAPSHOTPREVIEWS_MINIMUM_VERSION,
@@ -23,7 +31,7 @@ import {
 } from './snapshotpreviews-package';
 
 export async function runAppleSnapshotsWizard(
-  options: AppleWizardOptions,
+  options: AppleSnapshotsWizardOptions,
 ): Promise<void> {
   return withTelemetry(
     {
@@ -36,7 +44,7 @@ export async function runAppleSnapshotsWizard(
 }
 
 async function runAppleSnapshotsWizardWithTelemetry(
-  options: AppleWizardOptions,
+  options: AppleSnapshotsWizardOptions,
 ): Promise<void> {
   const projectDir = options.projectDir ?? process.cwd();
 
@@ -48,6 +56,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
   await confirmContinueIfNoOrDirtyGitRepo({
     ignoreGitChanges: options.ignoreGitChanges,
     cwd: projectDir,
+    nonInteractive: options.nonInteractive,
   });
 
   clack.log.info(
@@ -60,23 +69,24 @@ async function runAppleSnapshotsWizardWithTelemetry(
     ].join(' '),
   );
 
-  const xcProject = await lookupXcodeProject({ projectDir });
-
-  const appTargetName = await selectXcodeTarget(xcProject, {
-    noTargetMessage: 'No application target found.',
-    promptMessage: 'Which app target should SnapshotPreviews use?',
+  const xcProject = await lookupXcodeProject({
+    projectDir,
+    nonInteractive: options.nonInteractive,
   });
 
-  const hostedTestTargetNames =
-    xcProject.getHostedUnitTestTargetNamesForApplicationTarget(appTargetName);
-  const hostedTestTargetName = await selectXcodeTarget(xcProject, {
-    targetNames: hostedTestTargetNames,
-    noTargetMessage: [
-      `No hosted unit-test target was found for ${appTargetName}.`,
-      'Please configure a unit-test target with TEST_HOST pointing at that app target, then run the wizard again.',
-    ].join(' '),
-    promptMessage: 'Which test target should render SnapshotPreviews?',
-  });
+  const appTargetName = await resolveAppTargetName(xcProject, options);
+  if (!appTargetName) {
+    return await abort('Apple Snapshots setup did not complete.');
+  }
+
+  const hostedTestTargetName = await resolveHostedTestTargetName(
+    xcProject,
+    appTargetName,
+    options,
+  );
+  if (!hostedTestTargetName) {
+    return await abort('Apple Snapshots setup did not complete.');
+  }
 
   const previewTargetNames = [appTargetName];
 
@@ -146,6 +156,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
 
   await checkInstalledCLISnapshots({
     projectDir,
+    nonInteractive: options.nonInteractive,
     verificationGuidance: {
       appId: xcProject.getBundleIdentifierForTarget(appTargetName),
       hostedTestTargetName,
@@ -159,7 +170,169 @@ async function runAppleSnapshotsWizardWithTelemetry(
     },
   });
 
-  clack.outro(
-    'Apple Snapshots setup complete. No Sentry auth, DSN, runtime SDK, dSYM, or CI workflow files were configured.',
+  clack.outro('Apple Snapshots setup complete.');
+}
+
+async function resolveAppTargetName(
+  xcodeProject: XcodeProject,
+  options: AppleSnapshotsWizardOptions,
+): Promise<string | undefined> {
+  const appTargetNames = xcodeProject.getAllTargets();
+  if (options.appTarget) {
+    if (appTargetNames.includes(options.appTarget)) {
+      return options.appTarget;
+    }
+
+    clack.log.error(
+      `Xcode app target ${
+        options.appTarget
+      } was not found. Available app targets: ${formatList(appTargetNames)}.`,
+    );
+    return undefined;
+  }
+
+  if (options.nonInteractive && appTargetNames.length !== 1) {
+    clack.log.error(
+      [
+        'Could not automatically select an Xcode app target in non-interactive mode.',
+        `Available app targets: ${formatList(appTargetNames)}.`,
+        'Pass --app-target <target-name> to select the app target that SnapshotPreviews should use.',
+      ].join(' '),
+    );
+    return undefined;
+  }
+
+  return await selectXcodeTarget(xcodeProject, {
+    targetNames: appTargetNames,
+    noTargetMessage: 'No application target found.',
+    promptMessage: 'Which app target should SnapshotPreviews use?',
+  });
+}
+
+async function resolveHostedTestTargetName(
+  xcodeProject: XcodeProject,
+  appTargetName: string,
+  options: AppleSnapshotsWizardOptions,
+): Promise<string | undefined> {
+  const hostedTestTargetNames = xcodeProject.getHostedUnitTestTargetNames();
+  if (options.hostedTestTarget) {
+    if (hostedTestTargetNames.includes(options.hostedTestTarget)) {
+      return options.hostedTestTarget;
+    }
+
+    clack.log.error(
+      [
+        `Hosted XCTest target ${options.hostedTestTarget} was not found or does not define TEST_HOST.`,
+        `Available hosted XCTest targets: ${formatList(
+          hostedTestTargetNames,
+        )}.`,
+      ].join(' '),
+    );
+    return undefined;
+  }
+
+  const inferredHostedTestTargetNames =
+    xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget(
+      appTargetName,
+    );
+  if (inferredHostedTestTargetNames.length > 0) {
+    return await selectHostedTestTargetName({
+      appTargetName,
+      hostedTestTargetNames: inferredHostedTestTargetNames,
+      nonInteractive: options.nonInteractive,
+      promptMessage: 'Which test target should render SnapshotPreviews?',
+    });
+  }
+
+  if (hostedTestTargetNames.length === 0) {
+    clack.log.error(
+      [
+        `No hosted XCTest target was found for ${appTargetName}.`,
+        manualAppleSnapshotsSetupInstructions({ appTargetName }),
+      ].join('\n'),
+    );
+    return undefined;
+  }
+
+  clack.log.warn(
+    [
+      `Could not automatically match a hosted XCTest target to ${appTargetName}.`,
+      'This can happen when TEST_HOST uses Xcode build-setting macros for the app bundle or executable name.',
+    ].join(' '),
   );
+
+  return await selectHostedTestTargetName({
+    appTargetName,
+    hostedTestTargetNames,
+    nonInteractive: options.nonInteractive,
+    promptMessage: 'Which hosted XCTest target should render SnapshotPreviews?',
+  });
+}
+
+async function selectHostedTestTargetName({
+  appTargetName,
+  hostedTestTargetNames,
+  nonInteractive,
+  promptMessage,
+}: {
+  appTargetName: string;
+  hostedTestTargetNames: string[];
+  nonInteractive: boolean | undefined;
+  promptMessage: string;
+}): Promise<string | undefined> {
+  if (hostedTestTargetNames.length === 1) {
+    return hostedTestTargetNames[0];
+  }
+
+  if (nonInteractive) {
+    clack.log.error(
+      [
+        `Could not automatically select the hosted XCTest target for ${appTargetName} in non-interactive mode.`,
+        `Available hosted XCTest targets: ${formatList(
+          hostedTestTargetNames,
+        )}.`,
+        'Pass --hosted-test-target <target-name> to select the target explicitly.',
+        manualAppleSnapshotsSetupInstructions({
+          appTargetName,
+          hostedTestTargetName: hostedTestTargetNames[0],
+        }),
+      ].join('\n'),
+    );
+    return undefined;
+  }
+
+  const selection = await abortIfCancelled(
+    askForItemSelection(hostedTestTargetNames, promptMessage),
+  );
+  return selection.value;
+}
+
+function manualAppleSnapshotsSetupInstructions({
+  appTargetName,
+  hostedTestTargetName,
+}: {
+  appTargetName: string;
+  hostedTestTargetName?: string;
+}): string {
+  const exampleHostedTestTargetName = hostedTestTargetName ?? 'AppTests';
+  const sourceFileInstruction = hostedTestTargetName
+    ? '3. Add this XCTest source file to the hosted XCTest target:'
+    : `3. Add this XCTest source file to the hosted XCTest target. This example assumes the hosted XCTest target is named ${exampleHostedTestTargetName}:`;
+
+  return [
+    'Manual setup:',
+    `1. Add the ${SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT} package product to the hosted XCTest target for ${appTargetName}.`,
+    `2. Add the ${SNAPSHOTPREVIEWS_PREFERENCES_PRODUCT} package product to ${appTargetName} if its Swift previews use SnapshotPreviews modifiers.`,
+    sourceFileInstruction,
+    '```swift',
+    snapshotTestTemplate(
+      snapshotTestClassName(exampleHostedTestTargetName),
+    ).trimEnd(),
+    '```',
+    '4. Run the hosted XCTest target with xcodebuild.',
+  ].join('\n');
+}
+
+function formatList(values: string[]): string {
+  return values.length > 0 ? values.join(', ') : 'none';
 }

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -282,7 +282,7 @@ async function selectHostedTestTargetName({
 }: {
   appTargetName: string;
   hostedTestTargetNames: string[];
-  nonInteractive: boolean | undefined;
+  nonInteractive: boolean;
   promptMessage: string;
 }): Promise<string | undefined> {
   if (hostedTestTargetNames.length === 1) {

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -191,6 +191,11 @@ async function resolveAppTargetName(
     return undefined;
   }
 
+  if (appTargetNames.length === 0) {
+    clack.log.error('No application target found.');
+    return undefined;
+  }
+
   if (options.nonInteractive && appTargetNames.length !== 1) {
     clack.log.error(
       [

--- a/src/apple/snapshots/apple-snapshots-wizard.ts
+++ b/src/apple/snapshots/apple-snapshots-wizard.ts
@@ -30,6 +30,9 @@ import {
   SNAPSHOTPREVIEWS_SNAPSHOT_TESTS_PRODUCT,
 } from './snapshotpreviews-package';
 
+const APPLE_SNAPSHOTS_SETUP_DID_NOT_COMPLETE =
+  'Apple Snapshots setup did not complete.';
+
 export async function runAppleSnapshotsWizard(
   options: AppleSnapshotsWizardOptions,
 ): Promise<void> {
@@ -76,7 +79,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
 
   const appTargetName = await resolveAppTargetName(xcProject, options);
   if (!appTargetName) {
-    return await abort('Apple Snapshots setup did not complete.');
+    return await abort(APPLE_SNAPSHOTS_SETUP_DID_NOT_COMPLETE);
   }
 
   const hostedTestTargetName = await resolveHostedTestTargetName(
@@ -85,7 +88,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
     options,
   );
   if (!hostedTestTargetName) {
-    return await abort('Apple Snapshots setup did not complete.');
+    return await abort(APPLE_SNAPSHOTS_SETUP_DID_NOT_COMPLETE);
   }
 
   const previewTargetNames = [appTargetName];
@@ -119,7 +122,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
     clack.log.error(
       'SnapshotPreviews package products could not be linked to the selected targets. Please check the Xcode project target build phases and try again.',
     );
-    clack.outro('Apple Snapshots setup did not complete.');
+    await abort(APPLE_SNAPSHOTS_SETUP_DID_NOT_COMPLETE);
     return;
   }
 
@@ -143,7 +146,7 @@ async function runAppleSnapshotsWizardWithTelemetry(
     clack.log.error(
       'SnapshotPreviews test file could not be added to the selected XCTest target. Please check the target Sources build phase and try again.',
     );
-    clack.outro('Apple Snapshots setup did not complete.');
+    await abort(APPLE_SNAPSHOTS_SETUP_DID_NOT_COMPLETE);
     return;
   }
 

--- a/src/apple/snapshots/snapshots-cli-preflight.ts
+++ b/src/apple/snapshots/snapshots-cli-preflight.ts
@@ -23,7 +23,7 @@ export async function checkInstalledCLISnapshots({
   verificationGuidance,
 }: {
   projectDir: string;
-  nonInteractive: boolean | undefined;
+  nonInteractive: boolean;
   verificationGuidance: SnapshotVerificationGuidance;
 }): Promise<void> {
   const hasCli = await checkInstalledCLI(

--- a/src/apple/snapshots/snapshots-cli-preflight.ts
+++ b/src/apple/snapshots/snapshots-cli-preflight.ts
@@ -23,7 +23,7 @@ export async function checkInstalledCLISnapshots({
   verificationGuidance,
 }: {
   projectDir: string;
-  nonInteractive?: boolean;
+  nonInteractive: boolean | undefined;
   verificationGuidance: SnapshotVerificationGuidance;
 }): Promise<void> {
   const hasCli = await checkInstalledCLI(

--- a/src/apple/snapshots/snapshots-cli-preflight.ts
+++ b/src/apple/snapshots/snapshots-cli-preflight.ts
@@ -19,13 +19,16 @@ type SnapshotVerificationGuidance = {
 
 export async function checkInstalledCLISnapshots({
   projectDir,
+  nonInteractive,
   verificationGuidance,
 }: {
   projectDir: string;
+  nonInteractive?: boolean;
   verificationGuidance: SnapshotVerificationGuidance;
 }): Promise<void> {
   const hasCli = await checkInstalledCLI(
     "Without sentry-cli, you won't be able to upload snapshots to Sentry. You can install it later by following the instructions at https://docs.sentry.io/cli/",
+    nonInteractive,
   );
 
   if (hasCli) {

--- a/src/apple/xcode-manager.ts
+++ b/src/apple/xcode-manager.ts
@@ -258,10 +258,23 @@ export class XcodeProject {
     return Object.keys(targets)
       .filter((key) => {
         const value = targets[key];
+        return this.isUnitTestTargetEntry(key, value);
+      })
+      .map((key) => {
+        return (targets[key] as PBXNativeTarget).name;
+      });
+  }
+
+  public getHostedUnitTestTargetNames(): string[] {
+    const targets = this.objects.PBXNativeTarget ?? {};
+    return Object.keys(targets)
+      .filter((key) => {
+        const value = targets[key];
         return (
-          !key.endsWith('_comment') &&
-          typeof value !== 'string' &&
-          unquote(value.productType) === XCODE_UNIT_TEST_PRODUCT_TYPE
+          this.isUnitTestTargetEntry(key, value) &&
+          this.getTargetBuildSettings(value).some((buildSettings) =>
+            Boolean(unquote(buildSettings.TEST_HOST).trim()),
+          )
         );
       })
       .map((key) => {
@@ -683,6 +696,18 @@ export class XcodeProject {
       `Found ${filesInSynchronizedRootGroups.length} files in synchronized root groups for target: ${targetName}`,
     );
     return [...filesInBuildPhase, ...filesInSynchronizedRootGroups];
+  }
+
+  private isUnitTestTargetEntry(
+    key: string,
+    value: PBXNativeTarget | string | undefined,
+  ): value is PBXNativeTarget {
+    return (
+      !key.endsWith('_comment') &&
+      typeof value !== 'string' &&
+      value !== undefined &&
+      unquote(value.productType) === XCODE_UNIT_TEST_PRODUCT_TYPE
+    );
   }
 
   private getTargetBuildSettings(

--- a/src/run.ts
+++ b/src/run.ts
@@ -47,7 +47,7 @@ type Args = {
   skipConnect: boolean;
   debug: boolean;
   quiet: boolean;
-  nonInteractive: boolean;
+  nonInteractive?: boolean;
   disableTelemetry: boolean;
   spotlight?: boolean;
   promoCode?: string;
@@ -186,7 +186,7 @@ export async function run(argv: Args) {
         projectDir: finalArgs.xcodeProjectDir,
         appTarget: finalArgs.appTarget,
         hostedTestTarget: finalArgs.hostedTestTarget,
-        nonInteractive: finalArgs.nonInteractive,
+        nonInteractive: finalArgs.nonInteractive ?? false,
       });
       break;
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -47,6 +47,7 @@ type Args = {
   skipConnect: boolean;
   debug: boolean;
   quiet: boolean;
+  nonInteractive: boolean;
   disableTelemetry: boolean;
   spotlight?: boolean;
   promoCode?: string;
@@ -70,6 +71,8 @@ type Args = {
   comingFrom?: string;
   ignoreGitChanges?: boolean;
   xcodeProjectDir?: string;
+  appTarget?: string;
+  hostedTestTarget?: string;
 };
 
 function preSelectedProjectArgsToObject(
@@ -181,6 +184,9 @@ export async function run(argv: Args) {
       await runAppleSnapshotsWizard({
         ...wizardOptions,
         projectDir: finalArgs.xcodeProjectDir,
+        appTarget: finalArgs.appTarget,
+        hostedTestTarget: finalArgs.hostedTestTarget,
+        nonInteractive: finalArgs.nonInteractive,
       });
       break;
 
@@ -225,6 +231,7 @@ export async function run(argv: Args) {
       void legacyRun(
         {
           ...argv,
+          quiet: finalArgs.quiet,
           url: argv.url ?? '',
           integration: Integration.cordova,
           platform: argv.platform ?? [],
@@ -238,6 +245,7 @@ export async function run(argv: Args) {
       void legacyRun(
         {
           ...argv,
+          quiet: finalArgs.quiet,
           url: argv.url ?? '',
           integration: Integration.electron,
           platform: argv.platform ?? [],

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -204,6 +204,7 @@ You can turn this off at any time by running ${chalk.cyanBright(
 export async function confirmContinueIfNoOrDirtyGitRepo(options: {
   ignoreGitChanges: boolean | undefined;
   cwd: string | undefined;
+  nonInteractive?: boolean;
 }): Promise<void> {
   return traceStep('check-git-status', async () => {
     if (
@@ -212,6 +213,14 @@ export async function confirmContinueIfNoOrDirtyGitRepo(options: {
       }) &&
       options.ignoreGitChanges !== true
     ) {
+      if (options.nonInteractive) {
+        clack.log.error(
+          'Project is not inside a git repository in non-interactive mode. Run from a git repository or pass --ignore-git-changes to skip this safety check.',
+        );
+        Sentry.setTag('continue-without-git', false);
+        await abort();
+      }
+
       const continueWithoutGit = await abortIfCancelled(
         clack.confirm({
           message:
@@ -242,6 +251,15 @@ ${uncommittedOrUntrackedFiles.join('\n')}
 
 The wizard will create and update files.`,
       );
+
+      if (options.nonInteractive) {
+        clack.log.error(
+          'Project has uncommitted or untracked files in non-interactive mode. Commit or stash your changes, or pass --ignore-git-changes to skip this safety check.',
+        );
+        Sentry.setTag('continue-with-dirty-repo', false);
+        await abort();
+      }
+
       const continueWithDirtyRepo = await abortIfCancelled(
         clack.confirm({
           message: 'Do you want to continue anyway?',

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -201,7 +201,11 @@ You can turn this off at any time by running ${chalk.cyanBright(
  * @param options.ignoreGitChanges If true, the wizard will not check if the project is a git repository.
  * @param options.cwd The directory of the project. If undefined, the current process working directory will be used.
  */
-export async function confirmContinueIfNoOrDirtyGitRepo(options: {
+export async function confirmContinueIfNoOrDirtyGitRepo({
+  ignoreGitChanges,
+  cwd,
+  nonInteractive = false,
+}: {
   ignoreGitChanges: boolean | undefined;
   cwd: string | undefined;
   nonInteractive?: boolean;
@@ -209,11 +213,11 @@ export async function confirmContinueIfNoOrDirtyGitRepo(options: {
   return traceStep('check-git-status', async () => {
     if (
       !isInGitRepo({
-        cwd: options.cwd,
+        cwd: cwd,
       }) &&
-      options.ignoreGitChanges !== true
+      ignoreGitChanges !== true
     ) {
-      if (options.nonInteractive) {
+      if (nonInteractive) {
         clack.log.error(
           'Project is not inside a git repository in non-interactive mode. Run from a git repository or pass --ignore-git-changes to skip this safety check.',
         );
@@ -238,12 +242,9 @@ export async function confirmContinueIfNoOrDirtyGitRepo(options: {
     }
 
     const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles({
-      cwd: options.cwd,
+      cwd: cwd,
     });
-    if (
-      uncommittedOrUntrackedFiles.length &&
-      options.ignoreGitChanges !== true
-    ) {
+    if (uncommittedOrUntrackedFiles.length && ignoreGitChanges !== true) {
       clack.log.warn(
         `You have uncommitted or untracked files in your repo:
 
@@ -252,7 +253,7 @@ ${uncommittedOrUntrackedFiles.join('\n')}
 The wizard will create and update files.`,
       );
 
-      if (options.nonInteractive) {
+      if (nonInteractive) {
         clack.log.error(
           'Project has uncommitted or untracked files in non-interactive mode. Commit or stash your changes, or pass --ignore-git-changes to skip this safety check.',
         );

--- a/test/apple/lookup-xcode-project.test.ts
+++ b/test/apple/lookup-xcode-project.test.ts
@@ -148,6 +148,24 @@ describe('lookup-xcode-project', () => {
         expect.objectContaining({ projectPath: selectedPbxprojPath }),
       );
     });
+
+    it('fails instead of prompting when multiple Xcode projects are found in non-interactive mode', async () => {
+      createProject(projectDir, 'First.xcodeproj');
+      createProject(projectDir, 'Second.xcodeproj');
+      mocks.searchXcodeProjectAtPath.mockReturnValue([
+        'First.xcodeproj',
+        'Second.xcodeproj',
+      ]);
+
+      await expect(
+        lookupXcodeProject({ projectDir, nonInteractive: true }),
+      ).rejects.toThrow('abort');
+
+      expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+      expect(mocks.clackError).toHaveBeenCalledWith(
+        expect.stringContaining('Multiple Xcode projects found'),
+      );
+    });
   });
 
   describe('selectXcodeTarget', () => {

--- a/test/apple/snapshots/apple-snapshots-wizard.test.ts
+++ b/test/apple/snapshots/apple-snapshots-wizard.test.ts
@@ -163,6 +163,7 @@ describe('runAppleSnapshotsWizard', () => {
       projectDir: tempDir,
       promoCode: 'CAM',
       ignoreGitChanges: true,
+      nonInteractive: false,
     });
 
     expect(mocks.askForItemSelection).toHaveBeenCalledWith(
@@ -205,6 +206,7 @@ describe('runAppleSnapshotsWizard', () => {
       projectDir: tempDir,
       promoCode: 'CAM',
       ignoreGitChanges: true,
+      nonInteractive: false,
     });
 
     expect(
@@ -249,6 +251,7 @@ describe('runAppleSnapshotsWizard', () => {
       projectDir: tempDir,
       promoCode: 'CAM',
       ignoreGitChanges: true,
+      nonInteractive: false,
     });
 
     expect(mocks.confirm).not.toHaveBeenCalled();
@@ -288,6 +291,7 @@ describe('runAppleSnapshotsWizard', () => {
       projectDir: tempDir,
       promoCode: 'CAM',
       ignoreGitChanges: true,
+      nonInteractive: false,
     });
 
     expect(mocks.warn).toHaveBeenCalledWith(
@@ -407,6 +411,7 @@ describe('runAppleSnapshotsWizard', () => {
       projectDir: tempDir,
       promoCode: 'CAM',
       ignoreGitChanges: true,
+      nonInteractive: false,
     });
 
     expect(mocks.warn).toHaveBeenCalledWith(
@@ -523,6 +528,7 @@ describe('runAppleSnapshotsWizard', () => {
       projectDir: tempDir,
       promoCode: 'CAM',
       ignoreGitChanges: true,
+      nonInteractive: false,
     });
 
     expect(mocks.withTelemetry).toHaveBeenCalledWith(
@@ -536,11 +542,11 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.confirmContinueIfNoOrDirtyGitRepo).toHaveBeenCalledWith({
       ignoreGitChanges: true,
       cwd: tempDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
     });
     expect(mocks.lookupXcodeProject).toHaveBeenCalledWith({
       projectDir: tempDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
     });
     expect(mocks.confirm).not.toHaveBeenCalled();
     expect(mocks.info).toHaveBeenCalledWith(
@@ -561,7 +567,7 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.write).toHaveBeenCalledTimes(1);
     expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledWith({
       projectDir: tempDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance: {
         appId: 'com.getsentry.App',
         hostedTestTargetName: 'AppTests',

--- a/test/apple/snapshots/apple-snapshots-wizard.test.ts
+++ b/test/apple/snapshots/apple-snapshots-wizard.test.ts
@@ -4,12 +4,14 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  abort: vi.fn(),
   askForItemSelection: vi.fn(),
   checkInstalledCLISnapshots: vi.fn(),
   confirm: vi.fn(),
   confirmContinueIfNoOrDirtyGitRepo: vi.fn(),
   configureSnapshotPreviewsXcodeProject: vi.fn(),
   ensureSnapshotTestFile: vi.fn(),
+  error: vi.fn(),
   info: vi.fn(),
   lookupXcodeProject: vi.fn(),
   outro: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock('@clack/prompts', () => ({
   default: {
     confirm: mocks.confirm,
     log: {
+      error: mocks.error,
       info: mocks.info,
       success: mocks.success,
       warn: mocks.warn,
@@ -41,6 +44,7 @@ vi.mock('../../../src/telemetry', () => ({
 }));
 
 vi.mock('../../../src/utils/clack', () => ({
+  abort: mocks.abort,
   abortIfCancelled: async <T>(value: T | Promise<T>) => await value,
   askForItemSelection: mocks.askForItemSelection,
   confirmContinueIfNoOrDirtyGitRepo: mocks.confirmContinueIfNoOrDirtyGitRepo,
@@ -75,6 +79,17 @@ vi.mock('../../../src/apple/lookup-xcode-project', () => ({
 
 vi.mock('../../../src/apple/snapshots/snapshot-test-file', () => ({
   ensureSnapshotTestFile: mocks.ensureSnapshotTestFile,
+  snapshotTestClassName: (hostedTestTargetName: string): string =>
+    `${hostedTestTargetName}SnapshotTest`,
+  snapshotTestTemplate: (className: string): string => `import SnapshottingTests
+
+final class ${className}: SnapshotTest {
+  override class func snapshotPreviews() -> [String]? { nil }
+  override class func excludedSnapshotPreviews() -> [String]? { nil }
+  override class func snapshotPreviewModules() -> [String]? { nil }
+  override class func excludedSnapshotPreviewModules() -> [String]? { nil }
+}
+`,
 }));
 
 vi.mock(
@@ -113,6 +128,7 @@ describe('runAppleSnapshotsWizard', () => {
     mocks.resolveSnapshotVerificationSchemeName.mockReturnValue('AppScheme');
     mocks.askForItemSelection.mockResolvedValue({ value: 'App' });
     mocks.confirm.mockResolvedValue(false);
+    mocks.abort.mockRejectedValue(new Error('aborted'));
   });
 
   it('links SnapshotPreferences only to the selected app target', async () => {
@@ -132,6 +148,7 @@ describe('runAppleSnapshotsWizard', () => {
         targetName === 'App' ? [selectedPreviewFile] : [otherPreviewFile],
       ),
       getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),
@@ -170,6 +187,10 @@ describe('runAppleSnapshotsWizard', () => {
       getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
       getSourceFilesForTarget: vi.fn(() => [previewFile]),
       getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
         'AppSnapshotTests',
@@ -213,6 +234,7 @@ describe('runAppleSnapshotsWizard', () => {
         targetName === 'App' ? [selectedFile] : [otherPreviewFile],
       ),
       getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),
@@ -251,6 +273,7 @@ describe('runAppleSnapshotsWizard', () => {
       getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
       getSourceFilesForTarget: vi.fn(() => [previewFile]),
       getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),
@@ -273,6 +296,209 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledTimes(1);
   });
 
+  it('links SnapshotPreferences in non-interactive mode without scanning for Swift previews', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const selectedFile = path.join(tempDir, 'SelectedView.swift');
+    fs.writeFileSync(selectedFile, 'struct SelectedView {}', 'utf8');
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [selectedFile]),
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
+        'AppTests',
+      ]),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+      nonInteractive: true,
+    });
+
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(xcodeProject.getSourceFilesForTarget).not.toHaveBeenCalled();
+    expect(mocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('Continuing without Swift previews'),
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('uses explicit app and hosted XCTest targets without prompting', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const previewFile = path.join(tempDir, 'ContentView.swift');
+    fs.writeFileSync(previewFile, '#Preview { ContentView() }', 'utf8');
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [previewFile]),
+      getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => []),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      appTarget: 'App',
+      hostedTestTarget: 'AppTests',
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+      nonInteractive: true,
+    });
+
+    expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    expect(mocks.confirmContinueIfNoOrDirtyGitRepo).toHaveBeenCalledWith({
+      ignoreGitChanges: true,
+      cwd: tempDir,
+      nonInteractive: true,
+    });
+    expect(mocks.lookupXcodeProject).toHaveBeenCalledWith({
+      projectDir: tempDir,
+      nonInteractive: true,
+    });
+    expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledWith(
+      expect.objectContaining({ nonInteractive: true }),
+    );
+    expect(
+      xcodeProject.getHostedUnitTestTargetNamesForApplicationTarget,
+    ).not.toHaveBeenCalled();
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('falls back to prompting among hosted XCTest targets when app-specific matching is inconclusive', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const previewFile = path.join(tempDir, 'ContentView.swift');
+    fs.writeFileSync(previewFile, '#Preview { ContentView() }', 'utf8');
+    mocks.askForItemSelection.mockResolvedValue({
+      value: 'AppSnapshotTests',
+    });
+    const xcodeProject = {
+      getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
+      getSourceFilesForTarget: vi.fn(() => [previewFile]),
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => []),
+      write: mocks.write,
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await runAppleSnapshotsWizard({
+      telemetryEnabled: true,
+      projectDir: tempDir,
+      promoCode: 'CAM',
+      ignoreGitChanges: true,
+    });
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not automatically match'),
+    );
+    expect(mocks.askForItemSelection).toHaveBeenCalledWith(
+      ['AppTests', 'AppSnapshotTests'],
+      'Which hosted XCTest target should render SnapshotPreviews?',
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).toHaveBeenCalledWith({
+      xcodeProject,
+      hostedTestTargetName: 'AppSnapshotTests',
+      previewTargetNames: ['App'],
+    });
+  });
+
+  it('aborts when app target selection is ambiguous in non-interactive mode', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const xcodeProject = {
+      getAllTargets: vi.fn(() => ['App', 'OtherApp']),
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await expect(
+      runAppleSnapshotsWizard({
+        telemetryEnabled: true,
+        projectDir: tempDir,
+        promoCode: 'CAM',
+        ignoreGitChanges: true,
+        nonInteractive: true,
+      }),
+    ).rejects.toThrow('aborted');
+
+    expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Pass --app-target <target-name>'),
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).not.toHaveBeenCalled();
+    expect(mocks.abort).toHaveBeenCalledWith(
+      'Apple Snapshots setup did not complete.',
+    );
+    expect(mocks.outro).not.toHaveBeenCalledWith(
+      'Apple Snapshots setup did not complete.',
+    );
+  });
+
+  it('aborts with manual instructions instead of prompting when hosted XCTest fallback is ambiguous in non-interactive mode', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
+    const xcodeProject = {
+      getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => [
+        'AppTests',
+        'AppSnapshotTests',
+      ]),
+      getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => []),
+      xcodeprojPath: path.join(tempDir, 'App.xcodeproj'),
+    };
+    mocks.lookupXcodeProject.mockResolvedValue(xcodeProject);
+
+    await expect(
+      runAppleSnapshotsWizard({
+        telemetryEnabled: true,
+        projectDir: tempDir,
+        promoCode: 'CAM',
+        ignoreGitChanges: true,
+        nonInteractive: true,
+      }),
+    ).rejects.toThrow('aborted');
+
+    expect(mocks.askForItemSelection).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Pass --hosted-test-target <target-name>'),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('Manual setup:'),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('import SnapshottingTests'),
+    );
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('final class AppTestsSnapshotTest'),
+    );
+    expect(mocks.configureSnapshotPreviewsXcodeProject).not.toHaveBeenCalled();
+    expect(mocks.abort).toHaveBeenCalledWith(
+      'Apple Snapshots setup did not complete.',
+    );
+    expect(mocks.outro).not.toHaveBeenCalledWith(
+      'Apple Snapshots setup did not complete.',
+    );
+  });
+
   it('wires the Apple Snapshots flow without Sentry auth/runtime/CI mutation', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshots-wizard-'));
     const previewFile = path.join(tempDir, 'ContentView.swift');
@@ -282,6 +508,7 @@ describe('runAppleSnapshotsWizard', () => {
       getBundleIdentifierForTarget: vi.fn(() => 'com.getsentry.App'),
       getSourceFilesForTarget: vi.fn(() => [previewFile]),
       getAllTargets: vi.fn(() => ['App']),
+      getHostedUnitTestTargetNames: vi.fn(() => ['AppTests']),
       getHostedUnitTestTargetNamesForApplicationTarget: vi.fn(() => [
         'AppTests',
       ]),
@@ -309,9 +536,11 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.confirmContinueIfNoOrDirtyGitRepo).toHaveBeenCalledWith({
       ignoreGitChanges: true,
       cwd: tempDir,
+      nonInteractive: undefined,
     });
     expect(mocks.lookupXcodeProject).toHaveBeenCalledWith({
       projectDir: tempDir,
+      nonInteractive: undefined,
     });
     expect(mocks.confirm).not.toHaveBeenCalled();
     expect(mocks.info).toHaveBeenCalledWith(
@@ -332,6 +561,7 @@ describe('runAppleSnapshotsWizard', () => {
     expect(mocks.write).toHaveBeenCalledTimes(1);
     expect(mocks.checkInstalledCLISnapshots).toHaveBeenCalledWith({
       projectDir: tempDir,
+      nonInteractive: undefined,
       verificationGuidance: {
         appId: 'com.getsentry.App',
         hostedTestTargetName: 'AppTests',
@@ -342,9 +572,7 @@ describe('runAppleSnapshotsWizard', () => {
       },
     });
     expect(mocks.outro).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'No Sentry auth, DSN, runtime SDK, dSYM, or CI workflow files',
-      ),
+      expect.stringContaining('Apple Snapshots setup complete.'),
     );
   });
 });

--- a/test/apple/snapshots/snapshots-cli-preflight.test.ts
+++ b/test/apple/snapshots/snapshots-cli-preflight.test.ts
@@ -74,7 +74,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance: getVerificationGuidance(projectDir),
     });
 
@@ -120,7 +120,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance: getVerificationGuidance(projectDir),
     });
 
@@ -155,7 +155,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance: getVerificationGuidance(projectDir),
     });
 
@@ -179,7 +179,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance: {
         ...getVerificationGuidance(projectDir),
         snapshotTestClassName: 'CustomSnapshots',
@@ -200,7 +200,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance: {
         ...getVerificationGuidance(projectDir),
         schemeName: undefined,
@@ -225,7 +225,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
-      nonInteractive: undefined,
+      nonInteractive: false,
       verificationGuidance,
     });
 

--- a/test/apple/snapshots/snapshots-cli-preflight.test.ts
+++ b/test/apple/snapshots/snapshots-cli-preflight.test.ts
@@ -84,6 +84,29 @@ describe('snapshots CLI preflight', () => {
     expect(mocks.executeSync).not.toHaveBeenCalled();
   });
 
+  it('does not prompt to install sentry-cli in non-interactive mode', async () => {
+    mocks.hasSentryCLI.mockReturnValue(false);
+
+    const projectDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'snapshot-cli-non-interactive-'),
+    );
+
+    await checkInstalledCLISnapshots({
+      projectDir,
+      nonInteractive: true,
+      verificationGuidance: getVerificationGuidance(projectDir),
+    });
+
+    expect(mocks.askToInstallSentryCLI).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining('upload snapshots to Sentry'),
+    );
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('sentry-cli snapshots upload'),
+    );
+    expect(mocks.executeSync).not.toHaveBeenCalled();
+  });
+
   it('verifies snapshots upload support and prefers existing Fastlane guidance', async () => {
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-cli-'));
     const fastlaneDir = path.join(projectDir, 'fastlane');

--- a/test/apple/snapshots/snapshots-cli-preflight.test.ts
+++ b/test/apple/snapshots/snapshots-cli-preflight.test.ts
@@ -74,6 +74,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
+      nonInteractive: undefined,
       verificationGuidance: getVerificationGuidance(projectDir),
     });
 
@@ -119,6 +120,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
+      nonInteractive: undefined,
       verificationGuidance: getVerificationGuidance(projectDir),
     });
 
@@ -153,6 +155,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
+      nonInteractive: undefined,
       verificationGuidance: getVerificationGuidance(projectDir),
     });
 
@@ -176,6 +179,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
+      nonInteractive: undefined,
       verificationGuidance: {
         ...getVerificationGuidance(projectDir),
         snapshotTestClassName: 'CustomSnapshots',
@@ -196,6 +200,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
+      nonInteractive: undefined,
       verificationGuidance: {
         ...getVerificationGuidance(projectDir),
         schemeName: undefined,
@@ -220,6 +225,7 @@ describe('snapshots CLI preflight', () => {
 
     await checkInstalledCLISnapshots({
       projectDir,
+      nonInteractive: undefined,
       verificationGuidance,
     });
 

--- a/test/apple/xcode-manager.test.ts
+++ b/test/apple/xcode-manager.test.ts
@@ -233,6 +233,31 @@ describe('XcodeManager', () => {
         ]);
       });
 
+      it('returns only unit-test targets with TEST_HOST configured', () => {
+        // -- Arrange --
+        const xcodeProject = new XcodeProject(singleTargetProjectPath);
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'ProjectTests',
+          projectObjectId,
+          productsGroupId,
+        });
+        addHostedUnitTestTarget(xcodeProject, {
+          name: 'UnhostedProjectTests',
+          projectObjectId,
+          productsGroupId,
+          testHost: '""',
+        });
+
+        // -- Act & Assert --
+        expect(xcodeProject.getUnitTestTargetNames()).toEqual([
+          'ProjectTests',
+          'UnhostedProjectTests',
+        ]);
+        expect(xcodeProject.getHostedUnitTestTargetNames()).toEqual([
+          'ProjectTests',
+        ]);
+      });
+
       it('returns only unit-test targets hosted by the selected application target', () => {
         // -- Arrange --
         const xcodeProject = new XcodeProject(singleTargetProjectPath);

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -107,6 +107,7 @@ function getBaseArgs(integration: RunArgs['integration']): RunArgs {
     skipConnect: false,
     debug: false,
     quiet: false,
+    nonInteractive: false,
     disableTelemetry: true,
   };
 }
@@ -117,19 +118,40 @@ describe('run', () => {
     wizardMocks.readEnvironment.mockReturnValue({});
   });
 
-  it('routes appleSnapshots to the Apple Snapshots wizard with the Xcode project directory', async () => {
+  it('routes appleSnapshots to the Apple Snapshots wizard with Apple target options', async () => {
     await run({
       ...getBaseArgs('appleSnapshots'),
+      appTarget: 'App',
+      hostedTestTarget: 'AppTests',
+      nonInteractive: true,
       xcodeProjectDir: '/tmp/MyApp',
     });
 
     expect(wizardMocks.runAppleSnapshotsWizard).toHaveBeenCalledWith(
       expect.objectContaining({
+        appTarget: 'App',
+        hostedTestTarget: 'AppTests',
+        nonInteractive: true,
         telemetryEnabled: false,
         projectDir: '/tmp/MyApp',
       }),
     );
     expect(wizardMocks.runAppleWizard).not.toHaveBeenCalled();
+  });
+
+  it('passes quiet through to the existing Cordova wizard', async () => {
+    await run({
+      ...getBaseArgs('cordova'),
+      quiet: true,
+    });
+
+    expect(wizardMocks.legacyRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integration: 'cordova',
+        quiet: true,
+      }),
+      expect.any(Object),
+    );
   });
 
   it('keeps ios routing on the existing Apple wizard', async () => {

--- a/test/utils/clack/index.test.ts
+++ b/test/utils/clack/index.test.ts
@@ -2,6 +2,7 @@ import {
   abort,
   askForToolConfigPath,
   askForWizardLogin,
+  confirmContinueIfNoOrDirtyGitRepo,
   createNewConfigFile,
   getPackageManager,
   installPackage,
@@ -11,6 +12,7 @@ import * as fs from 'node:fs';
 import * as ChildProcess from 'node:child_process';
 import type { PackageManager } from '../../../src/utils/package-manager';
 import * as PackageManagerUtils from '../../../src/utils/package-manager';
+import * as GitUtils from '../../../src/utils/git';
 
 import {
   NPM,
@@ -64,6 +66,11 @@ const clackMock = clack as Mocked<typeof clack>;
 
 vi.mock('axios');
 const mockedAxios = axios as Mocked<typeof axios>;
+
+vi.mock('../../../src/utils/git', () => ({
+  isInGitRepo: vi.fn(),
+  getUncommittedOrUntrackedFiles: vi.fn(),
+}));
 
 vi.mock('opn', () => ({
   default: vi.fn(() => Promise.resolve({ on: vi.fn() })),
@@ -499,6 +506,146 @@ describe('getPackageManager', () => {
 
       expect(packageManager1).toBe(PNPM);
       expect(packageManager2).toBe(PNPM);
+    });
+  });
+});
+
+describe('confirmContinueIfNoOrDirtyGitRepo', () => {
+  // process.exit is mocked to throw so that abort() halts execution the same
+  // way it would terminate the process in production, instead of falling
+  // through to the interactive prompt.
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Drain any leftover `mockReturnValueOnce` values queued by earlier
+    // suites; `clearAllMocks` clears call history but not the once-queue.
+    clackMock.confirm.mockReset();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as typeof process.exit);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  describe('non-interactive mode', () => {
+    it('aborts without prompting when the project is not a git repository', async () => {
+      (GitUtils.isInGitRepo as Mock).mockReturnValue(false);
+
+      await expect(
+        confirmContinueIfNoOrDirtyGitRepo({
+          ignoreGitChanges: undefined,
+          cwd: undefined,
+          nonInteractive: true,
+        }),
+      ).rejects.toThrow('exit');
+
+      expect(clack.log.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'not inside a git repository in non-interactive mode',
+        ),
+      );
+      expect(Sentry.setTag).toHaveBeenCalledWith('continue-without-git', false);
+      expect(clack.confirm).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalled();
+    });
+
+    it('aborts without prompting when the repository has uncommitted or untracked files', async () => {
+      (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
+      (GitUtils.getUncommittedOrUntrackedFiles as Mock).mockReturnValue([
+        '- src/index.ts',
+      ]);
+
+      await expect(
+        confirmContinueIfNoOrDirtyGitRepo({
+          ignoreGitChanges: false,
+          cwd: undefined,
+          nonInteractive: true,
+        }),
+      ).rejects.toThrow('exit');
+
+      expect(clack.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('uncommitted or untracked files'),
+      );
+      expect(clack.log.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'uncommitted or untracked files in non-interactive mode',
+        ),
+      );
+      expect(Sentry.setTag).toHaveBeenCalledWith(
+        'continue-with-dirty-repo',
+        false,
+      );
+      expect(clack.confirm).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('interactive mode (default)', () => {
+    it('prompts to continue when the project is not a git repository', async () => {
+      (GitUtils.isInGitRepo as Mock).mockReturnValue(false);
+      mockUserResponse(clack.confirm as Mock, true);
+
+      await confirmContinueIfNoOrDirtyGitRepo({
+        ignoreGitChanges: undefined,
+        cwd: undefined,
+      });
+
+      expect(clack.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.stringContaining('not inside a git repository'),
+        }),
+      );
+      expect(clack.log.error).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(Sentry.setTag).toHaveBeenCalledWith('continue-without-git', true);
+    });
+
+    it('prompts to continue when the repository has uncommitted or untracked files', async () => {
+      (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
+      (GitUtils.getUncommittedOrUntrackedFiles as Mock).mockReturnValue([
+        '- src/index.ts',
+      ]);
+      mockUserResponse(clack.confirm as Mock, true);
+
+      await confirmContinueIfNoOrDirtyGitRepo({
+        ignoreGitChanges: false,
+        cwd: undefined,
+        nonInteractive: false,
+      });
+
+      expect(clack.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('uncommitted or untracked files'),
+      );
+      expect(clack.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.stringContaining('continue anyway'),
+        }),
+      );
+      expect(clack.log.error).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(Sentry.setTag).toHaveBeenCalledWith(
+        'continue-with-dirty-repo',
+        true,
+      );
+    });
+
+    it('does not prompt or abort for a clean git repository', async () => {
+      (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
+      (GitUtils.getUncommittedOrUntrackedFiles as Mock).mockReturnValue([]);
+
+      await confirmContinueIfNoOrDirtyGitRepo({
+        ignoreGitChanges: undefined,
+        cwd: undefined,
+      });
+
+      expect(clack.confirm).not.toHaveBeenCalled();
+      expect(clack.log.warn).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Stack

This is **3/3** in the Apple Snapshots stack replacing the original unified PR #1293.

- 1/3: #1295 — Xcode project primitives
- 2/3: #1296 — Interactive Apple Snapshots wizard
- 3/3: #1297 — Non-interactive Apple Snapshots mode (this PR)

This is the top of the stack. The final tree of this stack was verified to exactly match original PR #1293.

## Summary

Adds unattended/agent-friendly execution for the Apple Snapshots wizard introduced in #1296.

The main goal is that non-interactive mode never waits on stdin. It either proceeds from explicit arguments and safe single-target assumptions, or it fails with actionable manual setup instructions and the CLI flag needed to continue.

## What changed

- Adds Apple Snapshots CLI options:
  - `--non-interactive`
  - `--app-target`
  - `--hosted-test-target`
- Threads non-interactive behavior through:
  - CLI/run routing
  - project lookup
  - git safety checks
  - preview/missing-preview confirmation
  - sentry-cli preflight
  - hosted XCTest target selection
- Adds app-target and hosted-test-target resolution behavior for unattended runs.
- Adds prompt suppression paths so agentic setup cannot hang on stdin.
- Updates help output for the new flags.
- Adds tests for non-interactive success/failure paths, explicit target handling, and prompt-free behavior.

## Behavior contract in this layer

- App target selection uses `--app-target` when provided.
- Without `--app-target`, the wizard auto-selects only when there is a single app target.
- If the app target cannot be resolved safely in non-interactive mode, the wizard fails with guidance to pass `--app-target`.
- Hosted XCTest target selection uses `--hosted-test-target` when provided, as long as the target exists and has a non-empty `TEST_HOST`.
- Without `--hosted-test-target`, the wizard first narrows hosted XCTest targets to those whose `TEST_HOST` matches the selected app target's bundle/executable names.
- If app-specific hosted-test matching finds one target, the wizard uses it.
- If app-specific hosted-test matching finds multiple targets, non-interactive mode fails with guidance to pass `--hosted-test-target`.
- If app-specific hosted-test matching is inconclusive but the project has exactly one hosted XCTest target, the wizard assumes the common case that this target belongs to the selected app.
- If there are multiple hosted XCTest targets and no safe match, non-interactive mode fails with guidance.
- Missing Swift previews are not fatal. Non-interactive mode logs the limitation and continues because agents may still want the project wiring and manual next steps.
- Non-interactive mode must never wait on stdin.

## What this PR intentionally does not do

- Does not configure Sentry auth, DSNs, runtime SDK initialization, dSYM upload scripts, Fastlane dSYM setup, MCP config, or CI workflow files.
- Does not change the existing `ios` wizard into a SnapshotPreviews setup path.
- Does not make unsafe guesses when target resolution is ambiguous.

## Suggested review focus

- The target-selection contract for explicit CLI choices, single-target assumptions, and non-interactive failures.
- Hosted XCTest detection via `TEST_HOST` and app bundle/executable name matching.
- Confirming all non-interactive paths avoid stdin prompts.
- Error messages/manual setup guidance for ambiguous target/project structures.
- Help output and CLI option behavior.

## Risk

Medium. This layer controls unattended behavior and is the most important one for agentic setup safety. The main risk is choosing the wrong app/test target in unusual projects or leaving a prompt path reachable in non-interactive mode.

## Validation

Before submitting the stack:

- `yarn test` passed: 947 passed, 4 skipped
- `yarn build` passed
- Final stack tree matched original PR #1293 exactly
- `gt submit --stack --dry-run` passed

Co-Authored-By: GPT-5 Codex <noreply@openai.com>
