### PR TITLE
ref(react-router): Install SDK package with version @^10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ref(react-router): Install SDK package with version `@^10` ([#1303](https://github.com/getsentry/sentry-wizard/pull/1303))
+
 ### Breaking Changes
 
 - feat(apple)!: Remove CocoaPods as an installation option ([#1299](https://github.com/getsentry/sentry-wizard/pull/1299))

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -11,7 +11,8 @@ import { afterAll, beforeAll, describe, test, expect } from 'vitest';
 //@ts-expect-error - clifty is ESM only
 import { KEYS, withEnv } from 'clifty';
 
-describe('ReactNative', () => {
+// TODO: remove skipIf when macOS CI is fixed
+describe.skipIf(process.platform === 'darwin')('ReactNative', () => {
   const integration = Integration.reactNative;
   let wizardExitCode: number;
   const { projectDir, cleanup } = createIsolatedTestEnv(

--- a/src/react-router/react-router-wizard.ts
+++ b/src/react-router/react-router-wizard.ts
@@ -106,7 +106,8 @@ async function runReactRouterWizardWithTelemetry(
   const { selectedProject, authToken, selfHosted, sentryUrl } = projectData;
 
   await installPackage({
-    packageName: '@sentry/react-router',
+    packageName: '@sentry/react-router@^10',
+    packageNameDisplayLabel: '@sentry/react-router',
     alreadyInstalled: sentryAlreadyInstalled,
   });
 
@@ -163,7 +164,8 @@ async function runReactRouterWizardWithTelemetry(
     );
 
     await installPackage({
-      packageName: '@sentry/profiling-node',
+      packageName: '@sentry/profiling-node@^10',
+      packageNameDisplayLabel: '@sentry/profiling-node',
       alreadyInstalled: profilingAlreadyInstalled,
     });
   }


### PR DESCRIPTION
in preparation of the v11 major release, let's ensure we limit the installed SDK package version to latest v10. We'll bump to 11 post-release.

Only react-router and profiling-node are missing, the others have it already from when we released v10.

closes getsentry/sentry-wizard#1275