### PR TITLE
fix(react-native): Add `use_modular_headers!` to iOS Podfile for Swift RNSentry pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(react-native): Add `use_modular_headers!` to the iOS `Podfile` so `pod install` succeeds with the Swift-based RNSentry pod
 - feat(react-native): Prompt for Logs first in the feature selection flow ([#1308](https://github.com/getsentry/sentry-wizard/pull/1308))
 - fix(react-native): Use User Feedback Widget terminology in the setup flow
 - ref(react-router): Install SDK package with version `@^10` ([#1303](https://github.com/getsentry/sentry-wizard/pull/1303))

--- a/e2e-tests/tests/react-native.test.ts
+++ b/e2e-tests/tests/react-native.test.ts
@@ -11,8 +11,7 @@ import { afterAll, beforeAll, describe, test, expect } from 'vitest';
 //@ts-expect-error - clifty is ESM only
 import { KEYS, withEnv } from 'clifty';
 
-// TODO: remove skipIf when macOS CI is fixed
-describe.skipIf(process.platform === 'darwin')('ReactNative', () => {
+describe('ReactNative', () => {
   const integration = Integration.reactNative;
   let wizardExitCode: number;
   const { projectDir, cleanup } = createIsolatedTestEnv(
@@ -145,6 +144,10 @@ defaults.project=${TEST_ARGS.PROJECT_SLUG}
 
 defaults.url=https://sentry.io/`,
     );
+  });
+
+  test('ios/Podfile is updated with use_modular_headers!', () => {
+    checkFileContents(`${projectDir}/ios/Podfile`, `use_modular_headers!`);
   });
 
   test('build.gradle is updated correctly', () => {

--- a/src/react-native/cocoapod.ts
+++ b/src/react-native/cocoapod.ts
@@ -10,6 +10,68 @@ export function usesCocoaPod(projPath: string): boolean {
   return fs.existsSync(path.join(projPath, 'Podfile'));
 }
 
+/**
+ * Ensures `use_modular_headers!` is present in the Podfile.
+ *
+ * As of `@sentry/react-native` 8.19.0 the `RNSentry` pod ships Swift code (the
+ * `RNSentryInternal` bridge over `SentrySDK.internal`, part of the migration to
+ * the prebuilt `Sentry.xcframework`). CocoaPods refuses to integrate a Swift pod
+ * that depends on a non-modular Objective-C pod (e.g. `React-hermes` on React
+ * Native versions that don't modularize it by default) unless the Podfile opts
+ * into module maps. Without it, `pod install` fails with:
+ *
+ *   [!] The following Swift pods cannot yet be integrated as static libraries:
+ *   The Swift pod `RNSentry` depends upon `React-hermes`, which does not define
+ *   modules. [...] you may set `use_modular_headers!` globally in your Podfile
+ *
+ * The SDK's own docs instruct users to add this line manually; we do it for them.
+ *
+ * @returns `true` if the Podfile already had (or now has) `use_modular_headers!`,
+ *   `false` if there is no Podfile to patch.
+ */
+export function addModularHeaders(projPath: string): boolean {
+  const podfile = path.join(projPath, 'Podfile');
+
+  if (!fs.existsSync(podfile)) {
+    return false;
+  }
+
+  const podContent = fs.readFileSync(podfile, 'utf8');
+
+  if (/^\s*use_modular_headers!/m.test(podContent)) {
+    // Already opted into modular headers, nothing to do.
+    return true;
+  }
+
+  // Insert above the first `target '...' do` block, matching the placement the
+  // SDK docs recommend. The `^\s*` anchor avoids matching commented-out targets.
+  const targetMatch = /^([ \t]*)target\s+['"][^'"]+['"]\s+do/m.exec(podContent);
+
+  let newFileContent: string;
+  if (targetMatch) {
+    const insertIndex = targetMatch.index;
+    newFileContent =
+      podContent.slice(0, insertIndex) +
+      'use_modular_headers!\n\n' +
+      podContent.slice(insertIndex);
+  } else {
+    // No target block found, append to the end as a safe fallback.
+    const separator =
+      podContent.endsWith('\n') || podContent.length === 0 ? '' : '\n';
+    newFileContent = `${podContent}${separator}use_modular_headers!\n`;
+  }
+
+  fs.writeFileSync(podfile, newFileContent, 'utf8');
+
+  clack.log.step(
+    `Added ${chalk.cyan('use_modular_headers!')} to the iOS ${chalk.cyan(
+      'Podfile',
+    )} (required by the Sentry React Native SDK).`,
+  );
+
+  return true;
+}
+
 export async function addCocoaPods(projPath: string): Promise<boolean> {
   const podfile = path.join(projPath, 'Podfile');
 

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 
 import * as Sentry from '@sentry/node';
 import { platform } from 'os';
-import { podInstall } from './cocoapod';
+import { addModularHeaders, podInstall, usesCocoaPod } from './cocoapod';
 import { traceStep, withTelemetry } from '../telemetry';
 import { offerProjectScopedMcpConfig } from '../utils/clack/mcp-config';
 import {
@@ -348,6 +348,13 @@ async function patchXcodeFiles(config: RNCliSetupConfigContent) {
     filename: 'ios/sentry.properties',
     gitignore: false,
   });
+
+  // The RNSentry pod is a Swift pod and requires `use_modular_headers!` in the
+  // Podfile to integrate as a static library. Patch it before `pod install` so
+  // the install succeeds now and any later manual `pod install` keeps working.
+  if (usesCocoaPod('ios')) {
+    traceStep('add-modular-headers', () => addModularHeaders('ios'));
+  }
 
   if (platform() === 'darwin' && (await confirmPodInstall())) {
     await traceStep('pod-install', () => podInstall('ios'));

--- a/test/react-native/cocoapod.test.ts
+++ b/test/react-native/cocoapod.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   addCocoaPods,
+  addModularHeaders,
   podInstall,
   usesCocoaPod,
 } from '../../src/react-native/cocoapod';
@@ -214,6 +215,108 @@ describe('cocoapod', () => {
             `pod "OtherPod"\npod 'Sentry'\n`,
           );
         });
+      });
+    });
+  });
+
+  describe('addModularHeaders', () => {
+    describe('Podfile does not exist', () => {
+      it('should return false and not create a Podfile', () => {
+        // -- Arrange --
+        const projPath = fs.mkdtempSync(path.join(os.tmpdir(), 'project'));
+
+        // -- Act --
+        const result = addModularHeaders(projPath);
+
+        // -- Assert --
+        expect(result).toBe(false);
+        expect(fs.existsSync(path.join(projPath, 'Podfile'))).toBe(false);
+      });
+    });
+
+    describe('Podfile already includes use_modular_headers!', () => {
+      const variations = [
+        { case: 'simple', content: 'use_modular_headers!\n' },
+        { case: 'leading-space', content: '  use_modular_headers!\n' },
+        {
+          case: 'within-target',
+          content: `target 'App' do\n  use_modular_headers!\nend\n`,
+        },
+      ];
+      for (const variation of variations) {
+        it(`should not change the Podfile for ${variation.case}`, () => {
+          // -- Arrange --
+          const projPath = fs.mkdtempSync(path.join(os.tmpdir(), 'project'));
+          const podfile = path.join(projPath, 'Podfile');
+          fs.writeFileSync(podfile, variation.content, 'utf8');
+
+          // -- Act --
+          const result = addModularHeaders(projPath);
+
+          // -- Assert --
+          expect(result).toBe(true);
+          expect(fs.readFileSync(podfile, 'utf8')).toBe(variation.content);
+        });
+      }
+    });
+
+    describe('Podfile includes a target block', () => {
+      it('should insert use_modular_headers! above the target block', () => {
+        // -- Arrange --
+        const projPath = fs.mkdtempSync(path.join(os.tmpdir(), 'project'));
+        const podfile = path.join(projPath, 'Podfile');
+        fs.writeFileSync(
+          podfile,
+          `platform :ios, min_ios_version_supported\n\ntarget 'App' do\n  use_react_native!\nend\n`,
+          'utf8',
+        );
+
+        // -- Act --
+        const result = addModularHeaders(projPath);
+
+        // -- Assert --
+        expect(result).toBe(true);
+        expect(fs.readFileSync(podfile, 'utf8')).toBe(
+          `platform :ios, min_ios_version_supported\n\nuse_modular_headers!\n\ntarget 'App' do\n  use_react_native!\nend\n`,
+        );
+      });
+
+      it('should ignore commented-out target blocks', () => {
+        // -- Arrange --
+        const projPath = fs.mkdtempSync(path.join(os.tmpdir(), 'project'));
+        const podfile = path.join(projPath, 'Podfile');
+        fs.writeFileSync(
+          podfile,
+          `# target 'Commented' do\ntarget 'App' do\nend\n`,
+          'utf8',
+        );
+
+        // -- Act --
+        const result = addModularHeaders(projPath);
+
+        // -- Assert --
+        expect(result).toBe(true);
+        expect(fs.readFileSync(podfile, 'utf8')).toBe(
+          `# target 'Commented' do\nuse_modular_headers!\n\ntarget 'App' do\nend\n`,
+        );
+      });
+    });
+
+    describe('Podfile has no target block', () => {
+      it('should append use_modular_headers! to the end', () => {
+        // -- Arrange --
+        const projPath = fs.mkdtempSync(path.join(os.tmpdir(), 'project'));
+        const podfile = path.join(projPath, 'Podfile');
+        fs.writeFileSync(podfile, `platform :ios, '15.1'`, 'utf8');
+
+        // -- Act --
+        const result = addModularHeaders(projPath);
+
+        // -- Assert --
+        expect(result).toBe(true);
+        expect(fs.readFileSync(podfile, 'utf8')).toBe(
+          `platform :ios, '15.1'\nuse_modular_headers!\n`,
+        );
       });
     });
   });


### PR DESCRIPTION
## Summary

Re-enables the React Native e2e test on macOS (skipped in #1303) by fixing the underlying `pod install` failure.

**Root cause:** As of `@sentry/react-native` 8.19.0, the `RNSentry` pod ships Swift code (the `RNSentryInternal` bridge over `SentrySDK.internal`, part of the migration to the prebuilt `Sentry.xcframework` — see sentry-react-native [#6413](https://github.com/getsentry/sentry-react-native/pull/6413) / [#6495](https://github.com/getsentry/sentry-react-native/pull/6495)). CocoaPods refuses to integrate a Swift pod that depends on a non-modular Objective-C pod (e.g. `React-hermes` on RN versions that don't modularize it by default) unless the Podfile opts into module maps. So `pod install` fails with:

```
[!] The following Swift pods cannot yet be integrated as static libraries:
The Swift pod `RNSentry` depends upon `React-hermes`, which does not define
modules. [...] you may set `use_modular_headers!` globally in your Podfile
```

The error was masked in CI because `pod install --silent` only surfaces curl progress, not the CocoaPods error (which is why #1305's `--verbose` repro was on the right track). This affected real RN users too — the SDK CHANGELOG instructs them to add `use_modular_headers!` by hand — so the wizard now does it for them.

## Changes

- `src/react-native/cocoapod.ts`: new idempotent `addModularHeaders()` that inserts `use_modular_headers!` above the first `target` block in `ios/Podfile` (no-op if already present, ignores commented-out targets, logged transparently).
- `src/react-native/react-native-wizard.ts`: patch the Podfile before `pod install` whenever the project uses CocoaPods, so the wizard's install and any later manual `pod install` both work.
- `e2e-tests/tests/react-native.test.ts`: remove `describe.skipIf(darwin)` and assert the Podfile gets `use_modular_headers!`. Fixture Podfile stays vanilla so the test exercises the wizard adding it.
- `test/react-native/cocoapod.test.ts`: 7 new unit tests for `addModularHeaders`.
- `CHANGELOG.md`: entry under Unreleased.

## Testing

- Reproduced the exact `pod install` failure with `@sentry/react-native` 8.19.0 on the RN 0.78 test app (exit 1); confirmed `use_modular_headers!` fixes it (exit 0).
- **Full RN e2e test passes on macOS** (11/11) — the wizard logs adding the line, then `Pods installed.` succeeds.
- `test/react-native/` unit tests: 140/140. `yarn build` and `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)