### PR TITLE
fix(sveltekit): support Cloudflare server setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(sveltekit): Configure Cloudflare adapters with the worker-compatible server initialization
 - fix(react-native): Add `use_modular_headers!` to the iOS `Podfile` so `pod install` succeeds with the Swift-based RNSentry pod
 - feat(react-native): Prompt for Logs first in the feature selection flow ([#1308](https://github.com/getsentry/sentry-wizard/pull/1308))
 - fix(react-native): Use User Feedback Widget terminology in the setup flow

--- a/src/sveltekit/sdk-setup/setup.ts
+++ b/src/sveltekit/sdk-setup/setup.ts
@@ -28,6 +28,7 @@ import x = recast.types;
 import t = x.namedTypes;
 import {
   enableTracingAndInstrumentation,
+  isCloudflareAdapter,
   type PartialBackwardsForwardsCompatibleSvelteConfig,
 } from './svelte-config';
 import { ProjectInfo } from './types';
@@ -65,6 +66,7 @@ export async function createOrMergeSvelteKitFiles(
   ] as const);
 
   const { clientHooksPath, serverHooksPath } = getHooksConfigDirs(svelteConfig);
+  const usesCloudflareAdapter = isCloudflareAdapter(svelteConfig);
 
   // full file paths with correct file ending (or undefined if not found)
   const originalClientHooksFile = findFile(clientHooksPath);
@@ -85,34 +87,36 @@ export async function createOrMergeSvelteKitFiles(
       selectedFeatures.performance,
     );
 
-    try {
-      if (!originalInstrumentationServerFile) {
-        await createNewInstrumentationServerFile(dsn, selectedFeatures);
-      } else {
-        await mergeInstrumentationServerFile(
-          originalInstrumentationServerFile,
-          dsn,
-          selectedFeatures,
+    if (!usesCloudflareAdapter) {
+      try {
+        if (!originalInstrumentationServerFile) {
+          await createNewInstrumentationServerFile(dsn, selectedFeatures);
+        } else {
+          await mergeInstrumentationServerFile(
+            originalInstrumentationServerFile,
+            dsn,
+            selectedFeatures,
+          );
+        }
+      } catch (e) {
+        clack.log.warn(
+          `Failed to automatically set up ${chalk.cyan(
+            `instrumentation.server.${
+              fileEnding ?? isUsingTypeScript() ? 'ts' : 'js'
+            }`,
+          )}.`,
         );
-      }
-    } catch (e) {
-      clack.log.warn(
-        `Failed to automatically set up ${chalk.cyan(
-          `instrumentation.server.${
+        debug(e);
+
+        await showCopyPasteInstructions({
+          codeSnippet: getInstrumentationServerTemplate(dsn, selectedFeatures),
+          filename: `instrumentation.server.${
             fileEnding ?? isUsingTypeScript() ? 'ts' : 'js'
           }`,
-        )}.`,
-      );
-      debug(e);
+        });
 
-      await showCopyPasteInstructions({
-        codeSnippet: getInstrumentationServerTemplate(dsn, selectedFeatures),
-        filename: `instrumentation.server.${
-          fileEnding ?? isUsingTypeScript() ? 'ts' : 'js'
-        }`,
-      });
-
-      Sentry.setTag('created-instrumentation-server', 'fail');
+        Sentry.setTag('created-instrumentation-server', 'fail');
+      }
     }
   }
 
@@ -128,14 +132,16 @@ export async function createOrMergeSvelteKitFiles(
       dsn,
       selectedFeatures,
       !setupForSvelteKitTracing,
+      usesCloudflareAdapter,
     );
   } else {
-    await mergeHooksFile(
+    await _mergeHooksFile(
       originalServerHooksFile,
       'server',
       dsn,
       selectedFeatures,
       !setupForSvelteKitTracing,
+      usesCloudflareAdapter,
     );
   }
 
@@ -152,7 +158,7 @@ export async function createOrMergeSvelteKitFiles(
       true,
     );
   } else {
-    await mergeHooksFile(
+    await _mergeHooksFile(
       originalClientHooksFile,
       'client',
       dsn,
@@ -208,11 +214,17 @@ async function createNewHooksFile(
     logs: boolean;
   },
   setupForSvelteKitTracing: boolean,
+  isCloudflare = false,
 ): Promise<void> {
   const filledTemplate =
     hooktype === 'client'
       ? getClientHooksTemplate(dsn, selectedFeatures)
-      : getServerHooksTemplate(dsn, selectedFeatures, setupForSvelteKitTracing);
+      : getServerHooksTemplate(
+          dsn,
+          selectedFeatures,
+          setupForSvelteKitTracing,
+          isCloudflare,
+        );
 
   await fs.promises.mkdir(path.dirname(hooksFileDest), { recursive: true });
   await fs.promises.writeFile(hooksFileDest, filledTemplate);
@@ -263,8 +275,10 @@ async function createNewInstrumentationServerFile(
  *
  * Additionally in  Server hook:
  * - add handle hook handler
+ *
+ * Exported only for testing.
  */
-async function mergeHooksFile(
+export async function _mergeHooksFile(
   hooksFile: string,
   hookType: 'client' | 'server',
   dsn: string,
@@ -274,6 +288,7 @@ async function mergeHooksFile(
     logs: boolean;
   },
   includeSentryInit: boolean,
+  isCloudflare = false,
 ): Promise<void> {
   const originalHooksMod = await loadFile(hooksFile);
 
@@ -304,7 +319,7 @@ Skipping adding Sentry functionality to.`,
     file,
   );
 
-  if (hookType === 'client' || includeSentryInit) {
+  if (hookType === 'client' || (includeSentryInit && !isCloudflare)) {
     await modifyAndRecordFail(
       () => {
         if (hookType === 'client') {
@@ -326,7 +341,11 @@ Skipping adding Sentry functionality to.`,
 
   if (hookType === 'server') {
     await modifyAndRecordFail(
-      () => wrapHandle(originalHooksMod),
+      () =>
+        wrapHandle(
+          originalHooksMod,
+          isCloudflare ? { dsn, selectedFeatures } : undefined,
+        ),
       'wrap-handle',
       'server-hooks',
     );
@@ -428,6 +447,16 @@ const DATA_COLLECTION_HINT = [
   '    },',
 ].join('\n');
 
+function addDataCollectionHint(generatedInitCode: string): string {
+  const lineEnding = generatedInitCode.includes('\r\n') ? '\r\n' : '\n';
+  const normalizedHint = DATA_COLLECTION_HINT.replace(/\n/g, lineEnding);
+
+  return generatedInitCode.replace(
+    /\r?\n\}\)$/,
+    `,${normalizedHint}${lineEnding}})`,
+  );
+}
+
 export function insertClientInitCall(
   dsn: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -473,10 +502,7 @@ export function insertClientInitCall(
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const generatedInitCode = generateCode(initCall).code;
-  const initCodeWithHint = generatedInitCode.replace(
-    /\n\}\)$/,
-    `,${DATA_COLLECTION_HINT}\n})`,
-  );
+  const initCodeWithHint = addDataCollectionHint(generatedInitCode);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const initCallWithComment = builders.raw(
@@ -506,6 +532,33 @@ function insertServerInitCall(
     logs: boolean;
   },
 ): void {
+  const initCodeWithHint = getServerInitCall(
+    'Sentry.init',
+    dsn,
+    selectedFeatures,
+  );
+
+  const originalModAST = originalMod.$ast as Program;
+
+  const initCallInsertionIndex = getInitCallInsertionIndex(originalModAST);
+
+  originalModAST.body.splice(
+    initCallInsertionIndex,
+    0,
+    // @ts-expect-error - string works here because the AST is proxified by magicast
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    initCodeWithHint,
+  );
+}
+
+function getServerInitCall(
+  functionName: 'Sentry.init' | 'Sentry.initCloudflareSentryHandle',
+  dsn: string,
+  selectedFeatures: {
+    performance: boolean;
+    logs: boolean;
+  },
+): string {
   const initArgs: {
     dsn: string;
     tracesSampleRate?: number;
@@ -524,26 +577,11 @@ function insertServerInitCall(
 
   // This assignment of any values is fine because we're just creating a function call in magicast
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const initCall = builders.functionCall('Sentry.init', initArgs);
+  const initCall = builders.functionCall(functionName, initArgs);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const generatedInitCode = generateCode(initCall).code;
-  const initCodeWithHint = generatedInitCode.replace(
-    /\n\}\)$/,
-    `,${DATA_COLLECTION_HINT}\n})`,
-  );
-
-  const originalModAST = originalMod.$ast as Program;
-
-  const initCallInsertionIndex = getInitCallInsertionIndex(originalModAST);
-
-  originalModAST.body.splice(
-    initCallInsertionIndex,
-    0,
-    // @ts-expect-error - string works here because the AST is proxified by magicast
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    initCodeWithHint,
-  );
+  return addDataCollectionHint(generatedInitCode);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -599,12 +637,28 @@ function wrapHandleError(mod: ProxifiedModule<any>): void {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function wrapHandle(mod: ProxifiedModule<any>): void {
+function wrapHandle(
+  mod: ProxifiedModule<Record<string, unknown>>,
+  cloudflareConfig?: {
+    dsn: string;
+    selectedFeatures: {
+      performance: boolean;
+      logs: boolean;
+    };
+  },
+): void {
   const modAst = mod.exports.$ast as Program;
   const namedExports = modAst.body.filter(
     (node) => node.type === 'ExportNamedDeclaration',
   ) as ExportNamedDeclaration[];
+
+  const sentryHandlers = cloudflareConfig
+    ? `${getServerInitCall(
+        'Sentry.initCloudflareSentryHandle',
+        cloudflareConfig.dsn,
+        cloudflareConfig.selectedFeatures,
+      )}, Sentry.sentryHandle()`
+    : 'Sentry.sentryHandle()';
 
   let foundHandle = false;
 
@@ -621,10 +675,7 @@ function wrapHandle(mod: ProxifiedModule<any>): void {
       const userCode = generateCode(declaration).code;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       mod.exports.handle = builders.raw(
-        `sequence(Sentry.sentryHandle(), ${userCode.replace(
-          'handle',
-          '_handle',
-        )})`,
+        `sequence(${sentryHandlers}, ${userCode.replace('handle', '_handle')})`,
       );
       // because of an issue with magicast, we need to remove the original export
       modAst.body = modAst.body.filter((node) => node !== modExport);
@@ -641,7 +692,7 @@ function wrapHandle(mod: ProxifiedModule<any>): void {
         const userCode = declaration.init;
         const stringifiedUserCode = userCode ? generateCode(userCode).code : '';
         // @ts-expect-error - we can just place a string here, magicast will convert it to a node
-        declaration.init = `sequence(Sentry.sentryHandle(), ${stringifiedUserCode})`;
+        declaration.init = `sequence(${sentryHandlers}, ${stringifiedUserCode})`;
         foundHandle = true;
       });
     }
@@ -651,7 +702,7 @@ function wrapHandle(mod: ProxifiedModule<any>): void {
     // can't use builders.functionCall here because it doesn't yet
     // support member expressions (Sentry.sentryHandle()) in args
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    mod.exports.handle = builders.raw('sequence(Sentry.sentryHandle())');
+    mod.exports.handle = builders.raw(`sequence(${sentryHandlers})`);
   }
 
   try {

--- a/src/sveltekit/sdk-setup/svelte-config.ts
+++ b/src/sveltekit/sdk-setup/svelte-config.ts
@@ -20,6 +20,9 @@ const b = recast.types.builders;
 
 export type PartialBackwardsForwardsCompatibleSvelteConfig = {
   kit?: {
+    adapter?: {
+      name?: string;
+    };
     files?: {
       hooks?: {
         client?: string;
@@ -37,6 +40,12 @@ export type PartialBackwardsForwardsCompatibleSvelteConfig = {
     };
   };
 };
+
+export function isCloudflareAdapter(
+  config: PartialBackwardsForwardsCompatibleSvelteConfig,
+): boolean {
+  return config.kit?.adapter?.name === '@sveltejs/adapter-cloudflare';
+}
 
 export async function loadSvelteConfig(): Promise<PartialBackwardsForwardsCompatibleSvelteConfig> {
   const configFilePath = path.join(process.cwd(), SVELTE_CONFIG_FILE);
@@ -353,8 +362,11 @@ export function _enableTracingAndInstrumentationInConfig(
   }
 
   try {
+    const lineEnding = config.includes('\r\n') ? '\r\n' : '\n';
+    const generatedCode = generateCode(svelteConfig).code;
+
     return {
-      result: generateCode(svelteConfig).code,
+      result: generatedCode.replace(/\r\n|\r|\n/g, lineEnding),
     };
   } catch (e) {
     debug(e);

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -61,11 +61,9 @@ export function getServerHooksTemplate(
     logs: boolean;
   },
   includeSentryInit: boolean,
+  isCloudflare = false,
 ) {
-  const sentryInit = includeSentryInit
-    ? `import * as Sentry from '@sentry/sveltekit';
-
-Sentry.init({
+  const sentryInitOptions = `{
   dsn: '${dsn}',
 ${
   selectedFeatures.performance
@@ -91,15 +89,30 @@ ${
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: import.meta.env.DEV,
-});`
-    : ``;
+}`;
+
+  const sentryInit =
+    includeSentryInit && !isCloudflare
+      ? `import * as Sentry from '@sentry/sveltekit';
+
+Sentry.init(${sentryInitOptions});`
+      : ``;
+
+  const sentryHandle = isCloudflare
+    ? `sequence(
+  initCloudflareSentryHandle(${sentryInitOptions}),
+  sentryHandle(),
+);`
+    : `sequence(sentryHandle());`;
+
+  const cloudflareImport = isCloudflare ? ', initCloudflareSentryHandle' : ``;
 
   return `import { sequence } from "@sveltejs/kit/hooks";
-import { handleErrorWithSentry, sentryHandle } from "@sentry/sveltekit";
+import { handleErrorWithSentry, sentryHandle${cloudflareImport} } from "@sentry/sveltekit";
 ${sentryInit}
 
 // If you have custom handlers, make sure to place them after \`sentryHandle()\` in the \`sequence\` function.
-export const handle = sequence(sentryHandle());
+export const handle = ${sentryHandle}
 
 // If you have a custom error handler, pass it to \`handleErrorWithSentry\`
 export const handleError = handleErrorWithSentry();

--- a/test/sveltekit/sdk-setup/setup.test.ts
+++ b/test/sveltekit/sdk-setup/setup.test.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { _mergeHooksFile } from '../../../src/sveltekit/sdk-setup/setup';
+
+vi.mock('@clack/prompts', () => ({
+  default: {
+    log: {
+      success: vi.fn(),
+    },
+  },
+}));
+
+describe('_mergeHooksFile', () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('prepends Cloudflare initialization when merging server hooks', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sentry-wizard-'));
+    const hooksFile = path.join(tempDir, 'hooks.server.ts');
+    fs.writeFileSync(
+      hooksFile,
+      'export const handle = ({ event, resolve }) => resolve(event);\n',
+    );
+
+    await _mergeHooksFile(
+      hooksFile,
+      'server',
+      'https://sentry.io/123',
+      {
+        performance: true,
+        replay: false,
+        logs: true,
+      },
+      false,
+      true,
+    );
+
+    const result = fs.readFileSync(hooksFile, 'utf8');
+    const cloudflareInitIndex = result.indexOf(
+      'Sentry.initCloudflareSentryHandle({',
+    );
+    const sentryHandleIndex = result.indexOf('Sentry.sentryHandle()');
+    const userHandleIndex = result.indexOf(
+      '({ event, resolve }) => resolve(event)',
+    );
+
+    expect(result).toMatch(
+      /import \* as Sentry from ["']@sentry\/sveltekit["'];/,
+    );
+    expect(result).toMatch(/dsn: ["']https:\/\/sentry\.io\/123["']/);
+    expect(result).toContain('tracesSampleRate: 1');
+    expect(result).toContain('enableLogs: true');
+    expect(result).toContain('dataCollection: {');
+    expect(cloudflareInitIndex).toBeGreaterThan(-1);
+    expect(sentryHandleIndex).toBeGreaterThan(cloudflareInitIndex);
+    expect(userHandleIndex).toBeGreaterThan(sentryHandleIndex);
+    expect(result).not.toContain('Sentry.init({');
+  });
+});

--- a/test/sveltekit/sdk-setup/svelte-config.test.ts
+++ b/test/sveltekit/sdk-setup/svelte-config.test.ts
@@ -1,5 +1,35 @@
 import { describe, it, expect } from 'vitest';
-import { _enableTracingAndInstrumentationInConfig } from '../../../src/sveltekit/sdk-setup/svelte-config';
+import {
+  _enableTracingAndInstrumentationInConfig,
+  isCloudflareAdapter,
+} from '../../../src/sveltekit/sdk-setup/svelte-config';
+
+describe('isCloudflareAdapter', () => {
+  it('detects the configured Cloudflare adapter', () => {
+    expect(
+      isCloudflareAdapter({
+        kit: {
+          adapter: {
+            name: '@sveltejs/adapter-cloudflare',
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat other adapters as Cloudflare', () => {
+    expect(
+      isCloudflareAdapter({
+        kit: {
+          adapter: {
+            name: '@sveltejs/adapter-node',
+          },
+        },
+      }),
+    ).toBe(false);
+    expect(isCloudflareAdapter({})).toBe(false);
+  });
+});
 
 describe('_enableTracingAndInstrumentationInConfig', () => {
   it('leaves already correct config unchanged', () => {

--- a/test/sveltekit/templates.test.ts
+++ b/test/sveltekit/templates.test.ts
@@ -320,6 +320,29 @@ describe('getServerHooksTemplate', () => {
       "
     `);
   });
+
+  it('generates worker-compatible server hooks for Cloudflare', () => {
+    const result = getServerHooksTemplate(
+      'https://sentry.io/123',
+      {
+        performance: true,
+        replay: false,
+        logs: true,
+      },
+      false,
+      true,
+    );
+
+    expect(result).toContain('initCloudflareSentryHandle({');
+    expect(result).toContain("dsn: 'https://sentry.io/123'");
+    expect(result).toContain('tracesSampleRate: 1.0');
+    expect(result).toContain('enableLogs: true');
+    expect(result).toContain('dataCollection: {');
+    expect(result).toMatch(
+      /sequence\(\s*initCloudflareSentryHandle\([\s\S]*\),\s*sentryHandle\(\),\s*\)/,
+    );
+    expect(result).not.toContain('Sentry.init(');
+  });
 });
 
 describe('getInstrumentationServerTemplate', () => {


### PR DESCRIPTION
## Summary
- detect `@sveltejs/adapter-cloudflare` in the loaded SvelteKit config
- initialize Cloudflare server hooks with `initCloudflareSentryHandle` before `sentryHandle`
- skip Node-only `instrumentation.server` setup for Cloudflare and preserve existing hooks
- preserve source line endings and cover new and merged hook configurations

Fixes #803

## Testing
- `corepack yarn fix`
- `corepack yarn tsc`
- `corepack yarn lint`
- `corepack yarn vitest run test/sveltekit/templates.test.ts test/sveltekit/sdk-setup/svelte-config.test.ts test/sveltekit/sdk-setup/setup.test.ts` (48 passed)
- `corepack yarn test` (909 passed; 54 unrelated Windows-only path and line-ending assertions failed, with the changed SvelteKit tests passing)