### PR TITLE
fix(pnpm): Surface package manager errors and provide pnpm 11 build approval guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(pnpm): Surface package manager errors and provide pnpm 11 build approval guidance ([#1317](https://github.com/getsentry/sentry-wizard/pull/1317))
 - fix(react-native): Add `use_modular_headers!` to the iOS `Podfile` so `pod install` succeeds with the Swift-based RNSentry pod
 - feat(react-native): Prompt for Logs first in the feature selection flow ([#1308](https://github.com/getsentry/sentry-wizard/pull/1308))
 - fix(react-native): Use User Feedback Widget terminology in the setup flow

--- a/README.md
+++ b/README.md
@@ -48,12 +48,30 @@ yarn sentry-wizard
 npx @sentry/wizard
 ```
 
+With pnpm:
+
+```bash
+pnpx @sentry/wizard@latest
+```
+
+### pnpm 11
+
+pnpm 11 requires explicit approval before dependencies can run build scripts. If  the Wizard's package installation 
+fails with `ERR_PNPM_IGNORED_BUILDS`, review  the packages listed by pnpm and run [approve-builds](https://pnpm.io/cli/approve-builds)
+before re-running the Wizard:
+
+```bash
+pnpm approve-builds [package-names-to-approve]
+```
+
+## Support
+
 At the current moment, the wizard can be used for Next.js, react-native, iOS,
 Flutter, Nuxt, Remix, Sveltekit, Android, Electron, Cordova, and for sourcemaps
 setup. If you have other platforms you would like the wizard to support, please
 open a [GitHub issue](https://github.com/getsentry/sentry-wizard/issues)!
 
-# Options
+## Options
 
 The following CLI arguments are available:
 

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -406,6 +406,16 @@ export async function installPackage({
 
     const pkgManager = packageManager || (await getPackageManager());
 
+    if (pkgManager.name === 'pnpm') {
+      clack.log.info(
+        `If you use pnpm 11, dependency build scripts require explicit approval. If installation fails with ${chalk.cyan(
+          'ERR_PNPM_IGNORED_BUILDS',
+        )}, review the pending packages, run ${chalk.cyan(
+          'pnpm approve-builds',
+        )}, and then rerun the wizard.`,
+      );
+    }
+
     sdkInstallSpinner.start(
       `${alreadyInstalled ? 'Updating' : 'Installing'} ${chalk.bold.cyan(
         packageNameDisplayLabel ?? packageName,
@@ -433,13 +443,14 @@ export async function installPackage({
           cause: Error | string,
           type: 'spawn_error' | 'process_error',
         ) {
+          const output = [stdout, stderr].filter(Boolean).join('\n');
           // Write a log file so we can better troubleshoot issues
           fs.writeFileSync(
             join(
               process.cwd(),
               `sentry-wizard-installation-error-${Date.now()}.log`,
             ),
-            stderr,
+            output,
             { encoding: 'utf8' },
           );
 
@@ -469,16 +480,26 @@ export async function installPackage({
           installArgs,
           {
             shell: true,
-            // Ignoring `stdout` to prevent certain node + yarn v4 (observed on ubuntu + snap)
+            // Ignoring Yarn `stdout` to prevent certain node + yarn v4 (observed on ubuntu + snap)
             // combinations from crashing here. See #851
-            stdio: ['pipe', 'ignore', 'pipe'],
+            stdio: [
+              'pipe',
+              pkgManager.name === 'yarn' ? 'ignore' : 'pipe',
+              'pipe',
+            ],
           },
         );
 
+        let stdout = '';
         let stderr = '';
 
         // Defining data as unknown to avoid TS and ESLint errors because of `any` type
-        installProcess.stderr.on('data', (data: unknown) => {
+        installProcess.stdout?.on('data', (data: unknown) => {
+          if (data && data.toString && typeof data.toString === 'function') {
+            stdout += data.toString();
+          }
+        });
+        installProcess.stderr?.on('data', (data: unknown) => {
           if (data && data.toString && typeof data.toString === 'function') {
             stderr += data.toString();
           }
@@ -503,7 +524,7 @@ export async function installPackage({
           'Encountered the following error during installation:',
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         )}\n\n${e}\n\n${chalk.dim(
-          "The wizard has created a `sentry-wizard-installation-error-*.log` file. If you think this issue is caused by the Sentry wizard, create an issue on GitHub and include the log file's content:\nhttps://github.com/getsentry/sentry-wizard/issues",
+          "The wizard has created a `sentry-wizard-installation-error-*.log` file. Review it for sensitive information before sharing it. If you think this issue is caused by the Sentry wizard, create an issue on GitHub and include the redacted log file's content:\nhttps://github.com/getsentry/sentry-wizard/issues",
         )}`,
       );
       await abort();

--- a/test/utils/clack/index.test.ts
+++ b/test/utils/clack/index.test.ts
@@ -44,6 +44,11 @@ vi.mock('node:child_process', async () => ({
   ...(await vi.importActual<typeof ChildProcess>('node:child_process')),
 }));
 
+vi.mock('node:fs', async () => ({
+  __esModule: true,
+  ...(await vi.importActual<typeof fs>('node:fs')),
+}));
+
 vi.mock('@clack/prompts', () => ({
   log: {
     info: vi.fn(),
@@ -225,6 +230,8 @@ describe('installPackage', () => {
       }
     }),
     // @ts-expect-error - this is fine
+    stdout: { on: vi.fn() },
+    // @ts-expect-error - this is fine
     stderr: { on: vi.fn() },
   }));
 
@@ -253,7 +260,7 @@ describe('installPackage', () => {
     expect(spawnSpy).toHaveBeenCalledWith(
       'npm',
       ['install', '@some/package', '--force'],
-      { shell: true, stdio: ['pipe', 'ignore', 'pipe'] },
+      { shell: true, stdio: ['pipe', 'pipe', 'pipe'] },
     );
   });
 
@@ -284,7 +291,7 @@ describe('installPackage', () => {
       expect(spawnSpy).toHaveBeenCalledWith(
         'npm',
         ['install', '@sentry/sveltekit'],
-        { shell: true, stdio: ['pipe', 'ignore', 'pipe'] },
+        { shell: true, stdio: ['pipe', 'pipe', 'pipe'] },
       );
     },
   );
@@ -315,8 +322,96 @@ describe('installPackage', () => {
       'npm',
 
       ['install', '@some/package', '--ignore-workspace-root-check', '--force'],
-      { shell: true, stdio: ['pipe', 'ignore', 'pipe'] },
+      { shell: true, stdio: ['pipe', 'pipe', 'pipe'] },
     );
+  });
+
+  it('irgnores stdout when installing with Yarn', async () => {
+    await installPackage({
+      alreadyInstalled: false,
+      packageName: '@sentry/nextjs',
+      askBeforeUpdating: false,
+      packageManager: YARN_V2,
+    });
+
+    expect(spawnSpy).toHaveBeenCalledWith('yarn', ['add', '@sentry/nextjs'], {
+      shell: true,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+  });
+
+  it('shows pnpm 11 build approval guidance before installation', async () => {
+    await installPackage({
+      alreadyInstalled: false,
+      packageName: '@sentry/nextjs',
+      askBeforeUpdating: false,
+      packageManager: PNPM,
+    });
+
+    expect(clack.log.info).toHaveBeenCalledWith(
+      expect.stringContaining('pnpm approve-builds'),
+    );
+  });
+
+  it('writes package manager stdout to the error log file', async () => {
+    const output = 'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: sharp';
+    const writeFileSpy = vi
+      .spyOn(fs, 'writeFileSync')
+      .mockImplementation(vi.fn());
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(123);
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/project');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as typeof process.exit);
+    spawnSpy.mockImplementationOnce(() => ({
+      stdout: {
+        on: vi.fn(
+          (
+            _event: string,
+            callback: ((data: string) => void) | (() => void),
+          ) => {
+            (callback as (data: string) => void)(output);
+          },
+        ),
+      } as unknown as ChildProcess.ChildProcess['stdout'],
+      // @ts-expect-error - not passing the full ChildProcess object
+      stderr: { on: vi.fn() },
+      // @ts-expect-error - not passing the full ChildProcess object
+      on: vi.fn(
+        (event: 'error' | 'close', callback: (code: number) => void) => {
+          if (event === 'close') {
+            callback(1);
+          }
+        },
+      ),
+    }));
+
+    await expect(
+      installPackage({
+        alreadyInstalled: false,
+        packageName: '@sentry/nextjs@^10',
+        askBeforeUpdating: false,
+        packageManager: PNPM,
+      }),
+    ).rejects.toThrow('exit');
+
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      '/project/sentry-wizard-installation-error-123.log',
+      output,
+      { encoding: 'utf8' },
+    );
+    expect(clack.log.error).toHaveBeenCalledWith(
+      expect.not.stringContaining(output),
+    );
+    expect(clack.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('sentry-wizard-installation-error-*.log'),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    writeFileSpy.mockRestore();
+    dateSpy.mockRestore();
+    cwdSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION


pnpm reports `ERR_PNPM_IGNORED_BUILDS` on `stdout`, but the Wizard previously discarded `stdout` for every package manager. This produced an empty `sentry-wizard-installation-error-*.log` file and left users with only a generic exit-code error.

The Wizard now preserves package-manager output in the generated diagnostic log and warns pnpm users about the `pnpm approve-builds` workflow before installation. Yarn continues to suppress `stdout`.

This intentionally does not automatically approve dependency build scripts. Approval remains an explicit user decision.



closes https://github.com/getsentry/sentry-wizard/issues/1294