### PR TITLE
chore(deps): Bump nuxt from 3.21.7 to 3.21.10 in nuxt-4 e2e fixture

### DIFF
--- a/e2e-tests/test-applications/nuxt-4-test-app/package.json
+++ b/e2e-tests/test-applications/nuxt-4-test-app/package.json
@@ -11,7 +11,7 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "nuxt": "3.21.7",
+    "nuxt": "3.21.10",
     "vue": "latest",
     "vue-router": "latest"
   },


### PR DESCRIPTION
Same-minor patch bump, mirroring #1324 which did this for the `nuxt-3` fixture.

| Dependency | Change | Alerts |
| --- | --- | --- |
| `nuxt` | 3.21.7 → 3.21.10 | [459](https://github.com/getsentry/sentry-wizard/security/dependabot/459), [460](https://github.com/getsentry/sentry-wizard/security/dependabot/460), [461](https://github.com/getsentry/sentry-wizard/security/dependabot/461), [462](https://github.com/getsentry/sentry-wizard/security/dependabot/462), [463](https://github.com/getsentry/sentry-wizard/security/dependabot/463) |

The fixture's v4 behaviour comes from `future.compatibilityVersion: 4` in `nuxt.config.ts`, not from the package version, so the bump preserves what the fixture tests. Verified with a clean `npm run build`, which still reports "Running with compatibility version 4".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
