### PR TITLE
Improve handling of changed file names when running formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix(all): Improve handling of changed file names when running formatters (Prettier/Biome) so paths containing spaces or unusual characters are processed reliably.
+
 ## 7.0.0
 
 ### Breaking Changes

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -23,7 +23,11 @@ import {
 } from '../package-manager';
 import { fulfillsVersionRange } from '../semver';
 import type { Feature, SentryProjectData, WizardOptions } from '../types';
-import { getUncommittedOrUntrackedFiles, isInGitRepo } from '../git';
+import {
+  getUncommittedOrUntrackedFilePaths,
+  getUncommittedOrUntrackedFiles,
+  isInGitRepo,
+} from '../git';
 
 export const SENTRY_DOT_ENV_FILE = '.env.sentry-build-plugin';
 export const SENTRY_CLI_RC_FILE = '.sentryclirc';
@@ -781,20 +785,54 @@ async function addCliConfigFileToGitIgnore(filename: string): Promise<void> {
 
 /**
  * Helper function to get the list of changed or untracked files for formatting.
- * @returns Space-separated string of file paths, or null if not in git repo or no files changed.
+ * @returns Array of exact file paths, or null if not in a git repo or no files changed.
  */
-function getFormatterTargetFiles(): string | null {
+function getFormatterTargetFiles(): string[] | null {
   if (!isInGitRepo({ cwd: undefined })) {
     return null;
   }
 
-  const changedOrUntrackedFiles = getUncommittedOrUntrackedFiles()
-    .map((filename) => {
-      return filename.startsWith('- ') ? filename.slice(2) : filename;
-    })
-    .join(' ');
+  const changedOrUntrackedFiles =
+    getUncommittedOrUntrackedFilePaths().filter(Boolean);
 
   return changedOrUntrackedFiles.length ? changedOrUntrackedFiles : null;
+}
+
+/**
+ * Runs a formatter binary via `npx`, passing file names as discrete arguments
+ * rather than through a shell. POSIX runs with the shell disabled; Windows must
+ * launch `npx.cmd` through a shell, so file arguments are double-quoted (illegal
+ * Windows path characters cover the rest).
+ *
+ * @param binaryArgs The formatter binary and its flags.
+ * @param files The file paths to format.
+ * @param options.ignoreExitCode When true, a non-zero exit code resolves instead of rejecting.
+ */
+function runFormatterCommand(
+  binaryArgs: string[],
+  files: string[],
+  { ignoreExitCode }: { ignoreExitCode: boolean },
+): Promise<void> {
+  const isWindows = process.platform === 'win32';
+  const command = isWindows ? 'npx.cmd' : 'npx';
+  const fileArgs = isWindows
+    ? files.map((file) => `"${file.replace(/"/g, '')}"`)
+    : files;
+
+  return new Promise<void>((resolve, reject) => {
+    childProcess.execFile(
+      command,
+      [...binaryArgs, ...fileArgs],
+      { shell: isWindows },
+      (err) => {
+        if (err && !ignoreExitCode) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      },
+    );
+  });
 }
 
 /**
@@ -847,46 +885,33 @@ export async function runFormatters(_opts: {
     try {
       // Run Prettier first if installed (handles general formatting)
       if (prettierInstalled) {
-        await new Promise<void>((resolve, reject) => {
-          childProcess.exec(
-            `npx prettier --ignore-unknown --write ${targetFiles}`,
-            (err) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            },
-          );
-        });
+        await runFormatterCommand(
+          ['prettier', '--ignore-unknown', '--write'],
+          targetFiles,
+          { ignoreExitCode: false },
+        );
       }
 
       // Run Biome if installed (handles linting + additional formatting)
       if (biomeInstalled) {
         // Format first
-        await new Promise<void>((resolve) => {
-          childProcess.exec(
-            `npx @biomejs/biome format --write ${targetFiles}`,
-            () => {
-              // Ignore errors, just continue
-              resolve();
-            },
-          );
-        });
+        await runFormatterCommand(
+          ['@biomejs/biome', 'format', '--write'],
+          targetFiles,
+          // Ignore errors, just continue
+          { ignoreExitCode: true },
+        );
 
         // Then lint with fixes (using --unsafe for auto-fixable issues)
         // See: https://biomejs.dev/linter/#unsafe-fixes
         // The --unsafe flag applies potentially behavior-changing fixes like removing unused imports.
         // This is acceptable for wizard-generated code which may have fixable issues.
-        await new Promise<void>((resolve) => {
-          childProcess.exec(
-            `npx @biomejs/biome check --write --unsafe ${targetFiles}`,
-            () => {
-              // Ignore errors, Biome exits non-zero if there are remaining issues
-              resolve();
-            },
-          );
-        });
+        await runFormatterCommand(
+          ['@biomejs/biome', 'check', '--write', '--unsafe'],
+          targetFiles,
+          // Ignore errors, Biome exits non-zero if there are remaining issues
+          { ignoreExitCode: true },
+        );
       }
 
       spinner.stop('Formatters have processed your files.');
@@ -914,11 +939,8 @@ export async function runPrettierIfInstalled(opts: {
       return;
     }
 
-    const changedOrUntrackedFiles = getUncommittedOrUntrackedFiles()
-      .map((filename) => {
-        return filename.startsWith('- ') ? filename.slice(2) : filename;
-      })
-      .join(' ');
+    const changedOrUntrackedFiles =
+      getUncommittedOrUntrackedFilePaths().filter(Boolean);
 
     if (!changedOrUntrackedFiles.length) {
       // Likewise, if we can't find changed or untracked files, there's no point in running Prettier.
@@ -950,18 +972,11 @@ export async function runPrettierIfInstalled(opts: {
     prettierSpinner.start('Running Prettier on your files.');
 
     try {
-      await new Promise<void>((resolve, reject) => {
-        childProcess.exec(
-          `npx prettier --ignore-unknown --write ${changedOrUntrackedFiles}`,
-          (err) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          },
-        );
-      });
+      await runFormatterCommand(
+        ['prettier', '--ignore-unknown', '--write'],
+        changedOrUntrackedFiles,
+        { ignoreExitCode: false },
+      );
     } catch (e) {
       prettierSpinner.stop('Prettier failed to run.');
       clack.log.warn(
@@ -989,11 +1004,8 @@ export async function runBiomeIfInstalled(opts: {
       return;
     }
 
-    const changedOrUntrackedFiles = getUncommittedOrUntrackedFiles()
-      .map((filename) => {
-        return filename.startsWith('- ') ? filename.slice(2) : filename;
-      })
-      .join(' ');
+    const changedOrUntrackedFiles =
+      getUncommittedOrUntrackedFilePaths().filter(Boolean);
 
     if (!changedOrUntrackedFiles.length) {
       // Likewise, if we can't find changed or untracked files, there's no point in running Biome.
@@ -1028,25 +1040,19 @@ export async function runBiomeIfInstalled(opts: {
       // Use biome format --write for formatting (always succeeds if it can format)
       // Then biome check --write for lint fixes
       // We ignore exit codes because Biome exits non-zero if there are unfixable issues
-      await new Promise<void>((resolve) => {
-        childProcess.exec(
-          `npx @biomejs/biome format --write ${changedOrUntrackedFiles}`,
-          () => {
-            // Ignore errors, just continue
-            resolve();
-          },
-        );
-      });
+      await runFormatterCommand(
+        ['@biomejs/biome', 'format', '--write'],
+        changedOrUntrackedFiles,
+        // Ignore errors, just continue
+        { ignoreExitCode: true },
+      );
 
-      await new Promise<void>((resolve) => {
-        childProcess.exec(
-          `npx @biomejs/biome check --write --unsafe ${changedOrUntrackedFiles}`,
-          () => {
-            // Ignore errors, Biome exits non-zero if there are remaining issues
-            resolve();
-          },
-        );
-      });
+      await runFormatterCommand(
+        ['@biomejs/biome', 'check', '--write', '--unsafe'],
+        changedOrUntrackedFiles,
+        // Ignore errors, Biome exits non-zero if there are remaining issues
+        { ignoreExitCode: true },
+      );
     } catch (e) {
       biomeSpinner.stop('Biome encountered an issue.');
       clack.log.warn(

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -796,9 +796,8 @@ function getFormatterTargetFiles(): string[] | null {
 }
 
 /**
- * Runs a formatter through `npx`, passing file names as discrete arguments so
- * they are never interpreted by a shell (on POSIX). Output is discarded so a
- * verbose formatter cannot stall the wizard by filling an stdout buffer.
+ * Runs a formatter through `npx`, passing file names as discrete arguments
+ * (shell-free on POSIX) with a `--` separator so they can't be read as options.
  *
  * @param binaryArgs The formatter binary and its flags/subcommands.
  * @param files The file paths to format.
@@ -809,14 +808,13 @@ function runFormatterCommand(
   files: string[],
   { ignoreExitCode }: { ignoreExitCode: boolean },
 ): Promise<void> {
-  // On Windows `npx` resolves to `npx.cmd`, which Node can only launch through a
-  // shell. On POSIX we keep the shell disabled so file names are passed verbatim.
+  // On Windows `npx` resolves to `npx.cmd`, which Node can only run via a shell.
   const isWindows = process.platform === 'win32';
 
   return new Promise<void>((resolve, reject) => {
     const child = childProcess.spawn(
       isWindows ? 'npx.cmd' : 'npx',
-      [...binaryArgs, ...files],
+      [...binaryArgs, '--', ...files],
       { shell: isWindows, stdio: 'ignore' },
     );
 

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1,8 +1,7 @@
 import * as childProcess from 'node:child_process';
 import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
-import { createRequire } from 'node:module';
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
 import { setInterval } from 'node:timers';
 import { URL } from 'node:url';
 import * as path from 'path';
@@ -33,9 +32,6 @@ export const SENTRY_PROPERTIES_FILE = 'sentry.properties';
 const SAAS_URL = 'https://sentry.io/';
 
 const DUMMY_AUTH_TOKEN = '_YOUR_SENTRY_AUTH_TOKEN_';
-
-/** Files already changed before the wizard ran; excluded from formatting. */
-let preWizardChangedFiles: ReadonlySet<string> = new Set();
 
 interface WizardProjectData {
   apiKeys?: {
@@ -248,8 +244,6 @@ export async function confirmContinueIfNoOrDirtyGitRepo({
     const uncommittedOrUntrackedFilePaths = getUncommittedOrUntrackedFilePaths({
       cwd: cwd,
     });
-    // Snapshot pre-wizard state so formatting later targets only wizard changes.
-    preWizardChangedFiles = new Set(uncommittedOrUntrackedFilePaths);
 
     if (uncommittedOrUntrackedFilePaths.length && ignoreGitChanges !== true) {
       clack.log.warn(
@@ -787,104 +781,60 @@ async function addCliConfigFileToGitIgnore(filename: string): Promise<void> {
 }
 
 /**
- * Returns the files the wizard changed this run (currently changed files minus
- * the pre-wizard snapshot), or null if not in a git repo or nothing changed.
+ * Returns the changed or untracked files for the formatter step, or null if not
+ * in a git repo or nothing changed.
  */
 function getFormatterTargetFiles(): string[] | null {
   if (!isInGitRepo({ cwd: undefined })) {
     return null;
   }
 
-  const changedOrUntrackedFiles = getUncommittedOrUntrackedFilePaths().filter(
-    (file) => file && !preWizardChangedFiles.has(file),
-  );
+  const changedOrUntrackedFiles =
+    getUncommittedOrUntrackedFilePaths().filter(Boolean);
 
   return changedOrUntrackedFiles.length ? changedOrUntrackedFiles : null;
 }
 
 /**
- * Resolves the Node entry point of a package's bin from the target project.
+ * Runs a formatter through `npx`, passing file names as discrete arguments so
+ * they are never interpreted by a shell (on POSIX). Output is discarded so a
+ * verbose formatter cannot stall the wizard by filling an stdout buffer.
  *
- * @returns The absolute path to the bin file, or null if it cannot be resolved.
- */
-function resolveFormatterBinary(
-  packageName: string,
-  binName: string,
-): string | null {
-  const requireFromProject = createRequire(join(process.cwd(), 'package.json'));
-
-  const packageJsonCandidates: string[] = [];
-  try {
-    packageJsonCandidates.push(
-      requireFromProject.resolve(`${packageName}/package.json`),
-    );
-  } catch {
-    // Package may not expose package.json via its exports map; fall through.
-  }
-  packageJsonCandidates.push(
-    join(process.cwd(), 'node_modules', packageName, 'package.json'),
-  );
-
-  for (const packageJsonPath of packageJsonCandidates) {
-    try {
-      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-        bin?: string | Record<string, string>;
-      };
-      const relativeBin =
-        typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.[binName];
-      if (relativeBin) {
-        return join(dirname(packageJsonPath), relativeBin);
-      }
-    } catch {
-      // Try the next candidate.
-    }
-  }
-
-  return null;
-}
-
-/**
- * Runs a formatter on the given files without a shell. The formatter's Node
- * entry point is resolved from the project and executed with the current Node
- * runtime, so file names are always passed as verbatim arguments and are never
- * interpreted by a shell on any platform.
- *
- * @param packageName The npm package that provides the formatter.
- * @param binName The bin entry to run from that package.
- * @param binaryArgs The formatter flags and subcommands.
+ * @param binaryArgs The formatter binary and its flags/subcommands.
  * @param files The file paths to format.
- * @param options.ignoreExitCode When true, a non-zero exit code or an unresolved binary resolves instead of rejecting.
+ * @param options.ignoreExitCode When true, a non-zero exit resolves instead of rejecting.
  */
 function runFormatterCommand(
-  packageName: string,
-  binName: string,
   binaryArgs: string[],
   files: string[],
   { ignoreExitCode }: { ignoreExitCode: boolean },
 ): Promise<void> {
+  // On Windows `npx` resolves to `npx.cmd`, which Node can only launch through a
+  // shell. On POSIX we keep the shell disabled so file names are passed verbatim.
+  const isWindows = process.platform === 'win32';
+
   return new Promise<void>((resolve, reject) => {
-    const binPath = resolveFormatterBinary(packageName, binName);
-    if (!binPath) {
+    const child = childProcess.spawn(
+      isWindows ? 'npx.cmd' : 'npx',
+      [...binaryArgs, ...files],
+      { shell: isWindows, stdio: 'ignore' },
+    );
+
+    child.on('error', (err) => {
       if (ignoreExitCode) {
         resolve();
       } else {
-        reject(new Error(`Could not resolve the ${packageName} binary.`));
+        reject(err);
       }
-      return;
-    }
+    });
 
-    childProcess.execFile(
-      process.execPath,
-      [binPath, ...binaryArgs, ...files],
-      { shell: false },
-      (err) => {
-        if (err && !ignoreExitCode) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      },
-    );
+    child.on('close', (code) => {
+      if (code !== 0 && !ignoreExitCode) {
+        reject(new Error(`Formatter exited with code ${code ?? 'null'}.`));
+      } else {
+        resolve();
+      }
+    });
   });
 }
 
@@ -939,9 +889,7 @@ export async function runFormatters(_opts: {
       // Run Prettier first if installed (handles general formatting)
       if (prettierInstalled) {
         await runFormatterCommand(
-          'prettier',
-          'prettier',
-          ['--ignore-unknown', '--write'],
+          ['prettier', '--ignore-unknown', '--write'],
           targetFiles,
           { ignoreExitCode: false },
         );
@@ -951,9 +899,7 @@ export async function runFormatters(_opts: {
       if (biomeInstalled) {
         // Format first
         await runFormatterCommand(
-          '@biomejs/biome',
-          'biome',
-          ['format', '--write'],
+          ['@biomejs/biome', 'format', '--write'],
           targetFiles,
           // Ignore errors, just continue
           { ignoreExitCode: true },
@@ -964,9 +910,7 @@ export async function runFormatters(_opts: {
         // The --unsafe flag applies potentially behavior-changing fixes like removing unused imports.
         // This is acceptable for wizard-generated code which may have fixable issues.
         await runFormatterCommand(
-          '@biomejs/biome',
-          'biome',
-          ['check', '--write', '--unsafe'],
+          ['@biomejs/biome', 'check', '--write', '--unsafe'],
           targetFiles,
           // Ignore errors, Biome exits non-zero if there are remaining issues
           { ignoreExitCode: true },
@@ -1023,9 +967,7 @@ export async function runPrettierIfInstalled(_opts: {
 
     try {
       await runFormatterCommand(
-        'prettier',
-        'prettier',
-        ['--ignore-unknown', '--write'],
+        ['prettier', '--ignore-unknown', '--write'],
         changedOrUntrackedFiles,
         { ignoreExitCode: false },
       );
@@ -1084,18 +1026,14 @@ export async function runBiomeIfInstalled(_opts: {
       // Then biome check --write for lint fixes
       // We ignore exit codes because Biome exits non-zero if there are unfixable issues
       await runFormatterCommand(
-        '@biomejs/biome',
-        'biome',
-        ['format', '--write'],
+        ['@biomejs/biome', 'format', '--write'],
         changedOrUntrackedFiles,
         // Ignore errors, just continue
         { ignoreExitCode: true },
       );
 
       await runFormatterCommand(
-        '@biomejs/biome',
-        'biome',
-        ['check', '--write', '--unsafe'],
+        ['@biomejs/biome', 'check', '--write', '--unsafe'],
         changedOrUntrackedFiles,
         // Ignore errors, Biome exits non-zero if there are remaining issues
         { ignoreExitCode: true },

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1,7 +1,8 @@
 import * as childProcess from 'node:child_process';
 import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
-import { basename, isAbsolute, join, relative } from 'node:path';
+import { createRequire } from 'node:module';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
 import { setInterval } from 'node:timers';
 import { URL } from 'node:url';
 import * as path from 'path';
@@ -795,28 +796,86 @@ function getFormatterTargetFiles(): string[] | null {
   return changedOrUntrackedFiles.length ? changedOrUntrackedFiles : null;
 }
 
+/** Resolves a package's bin entry point from the target project, or null. */
+function resolveFormatterBinary(
+  packageName: string,
+  binName: string,
+): string | null {
+  const requireFromProject = createRequire(join(process.cwd(), 'package.json'));
+
+  const packageJsonCandidates: string[] = [];
+  try {
+    packageJsonCandidates.push(
+      requireFromProject.resolve(`${packageName}/package.json`),
+    );
+  } catch {
+    // Package may not expose package.json via exports; fall through.
+  }
+  packageJsonCandidates.push(
+    join(process.cwd(), 'node_modules', packageName, 'package.json'),
+  );
+
+  for (const packageJsonPath of packageJsonCandidates) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+        bin?: string | Record<string, string>;
+      };
+      const relativeBin =
+        typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.[binName];
+      if (relativeBin) {
+        return join(dirname(packageJsonPath), relativeBin);
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}
+
 /**
- * Runs a formatter through `npx`, passing file names as discrete arguments
- * (shell-free on POSIX) with a `--` separator so they can't be read as options.
+ * Runs a formatter without passing file names through a shell (command
+ * injection) and with a `--` separator (option injection). POSIX runs `npx`
+ * directly; Windows resolves the bin and runs it via Node, since `npx.cmd`
+ * would otherwise need a shell.
  *
- * @param binaryArgs The formatter binary and its flags/subcommands.
+ * @param packageName The npm package that provides the formatter.
+ * @param binName The bin entry to run from that package (Windows only).
+ * @param subArgs The formatter flags and subcommands.
  * @param files The file paths to format.
- * @param options.ignoreExitCode When true, a non-zero exit resolves instead of rejecting.
+ * @param options.ignoreExitCode When true, a non-zero exit or unresolved binary resolves instead of rejecting.
  */
 function runFormatterCommand(
-  binaryArgs: string[],
+  packageName: string,
+  binName: string,
+  subArgs: string[],
   files: string[],
   { ignoreExitCode }: { ignoreExitCode: boolean },
 ): Promise<void> {
-  // On Windows `npx` resolves to `npx.cmd`, which Node can only run via a shell.
-  const isWindows = process.platform === 'win32';
+  let command: string;
+  let args: string[];
+
+  if (process.platform === 'win32') {
+    const binPath = resolveFormatterBinary(packageName, binName);
+    if (!binPath) {
+      return ignoreExitCode
+        ? Promise.resolve()
+        : Promise.reject(
+            new Error(`Could not resolve the ${packageName} binary.`),
+          );
+    }
+    command = process.execPath;
+    args = [binPath, ...subArgs, '--', ...files];
+  } else {
+    command = 'npx';
+    args = [packageName, ...subArgs, '--', ...files];
+  }
 
   return new Promise<void>((resolve, reject) => {
-    const child = childProcess.spawn(
-      isWindows ? 'npx.cmd' : 'npx',
-      [...binaryArgs, '--', ...files],
-      { shell: isWindows, stdio: 'ignore' },
-    );
+    const child = childProcess.spawn(command, args, {
+      shell: false,
+      stdio: 'ignore',
+    });
 
     child.on('error', (err) => {
       if (ignoreExitCode) {
@@ -887,7 +946,9 @@ export async function runFormatters(_opts: {
       // Run Prettier first if installed (handles general formatting)
       if (prettierInstalled) {
         await runFormatterCommand(
-          ['prettier', '--ignore-unknown', '--write'],
+          'prettier',
+          'prettier',
+          ['--ignore-unknown', '--write'],
           targetFiles,
           { ignoreExitCode: false },
         );
@@ -897,7 +958,9 @@ export async function runFormatters(_opts: {
       if (biomeInstalled) {
         // Format first
         await runFormatterCommand(
-          ['@biomejs/biome', 'format', '--write'],
+          '@biomejs/biome',
+          'biome',
+          ['format', '--write'],
           targetFiles,
           // Ignore errors, just continue
           { ignoreExitCode: true },
@@ -908,7 +971,9 @@ export async function runFormatters(_opts: {
         // The --unsafe flag applies potentially behavior-changing fixes like removing unused imports.
         // This is acceptable for wizard-generated code which may have fixable issues.
         await runFormatterCommand(
-          ['@biomejs/biome', 'check', '--write', '--unsafe'],
+          '@biomejs/biome',
+          'biome',
+          ['check', '--write', '--unsafe'],
           targetFiles,
           // Ignore errors, Biome exits non-zero if there are remaining issues
           { ignoreExitCode: true },
@@ -965,7 +1030,9 @@ export async function runPrettierIfInstalled(_opts: {
 
     try {
       await runFormatterCommand(
-        ['prettier', '--ignore-unknown', '--write'],
+        'prettier',
+        'prettier',
+        ['--ignore-unknown', '--write'],
         changedOrUntrackedFiles,
         { ignoreExitCode: false },
       );
@@ -1024,14 +1091,18 @@ export async function runBiomeIfInstalled(_opts: {
       // Then biome check --write for lint fixes
       // We ignore exit codes because Biome exits non-zero if there are unfixable issues
       await runFormatterCommand(
-        ['@biomejs/biome', 'format', '--write'],
+        '@biomejs/biome',
+        'biome',
+        ['format', '--write'],
         changedOrUntrackedFiles,
         // Ignore errors, just continue
         { ignoreExitCode: true },
       );
 
       await runFormatterCommand(
-        ['@biomejs/biome', 'check', '--write', '--unsafe'],
+        '@biomejs/biome',
+        'biome',
+        ['check', '--write', '--unsafe'],
         changedOrUntrackedFiles,
         // Ignore errors, Biome exits non-zero if there are remaining issues
         { ignoreExitCode: true },

--- a/src/utils/clack/index.ts
+++ b/src/utils/clack/index.ts
@@ -1,7 +1,8 @@
 import * as childProcess from 'node:child_process';
 import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
-import { basename, isAbsolute, join, relative } from 'node:path';
+import { createRequire } from 'node:module';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
 import { setInterval } from 'node:timers';
 import { URL } from 'node:url';
 import * as path from 'path';
@@ -23,11 +24,7 @@ import {
 } from '../package-manager';
 import { fulfillsVersionRange } from '../semver';
 import type { Feature, SentryProjectData, WizardOptions } from '../types';
-import {
-  getUncommittedOrUntrackedFilePaths,
-  getUncommittedOrUntrackedFiles,
-  isInGitRepo,
-} from '../git';
+import { getUncommittedOrUntrackedFilePaths, isInGitRepo } from '../git';
 
 export const SENTRY_DOT_ENV_FILE = '.env.sentry-build-plugin';
 export const SENTRY_CLI_RC_FILE = '.sentryclirc';
@@ -36,6 +33,9 @@ export const SENTRY_PROPERTIES_FILE = 'sentry.properties';
 const SAAS_URL = 'https://sentry.io/';
 
 const DUMMY_AUTH_TOKEN = '_YOUR_SENTRY_AUTH_TOKEN_';
+
+/** Files already changed before the wizard ran; excluded from formatting. */
+let preWizardChangedFiles: ReadonlySet<string> = new Set();
 
 interface WizardProjectData {
   apiKeys?: {
@@ -245,14 +245,17 @@ export async function confirmContinueIfNoOrDirtyGitRepo({
       return;
     }
 
-    const uncommittedOrUntrackedFiles = getUncommittedOrUntrackedFiles({
+    const uncommittedOrUntrackedFilePaths = getUncommittedOrUntrackedFilePaths({
       cwd: cwd,
     });
-    if (uncommittedOrUntrackedFiles.length && ignoreGitChanges !== true) {
+    // Snapshot pre-wizard state so formatting later targets only wizard changes.
+    preWizardChangedFiles = new Set(uncommittedOrUntrackedFilePaths);
+
+    if (uncommittedOrUntrackedFilePaths.length && ignoreGitChanges !== true) {
       clack.log.warn(
         `You have uncommitted or untracked files in your repo:
 
-${uncommittedOrUntrackedFiles.join('\n')}
+${uncommittedOrUntrackedFilePaths.map((file) => `- ${file}`).join('\n')}
 
 The wizard will create and update files.`,
       );
@@ -784,46 +787,96 @@ async function addCliConfigFileToGitIgnore(filename: string): Promise<void> {
 }
 
 /**
- * Helper function to get the list of changed or untracked files for formatting.
- * @returns Array of exact file paths, or null if not in a git repo or no files changed.
+ * Returns the files the wizard changed this run (currently changed files minus
+ * the pre-wizard snapshot), or null if not in a git repo or nothing changed.
  */
 function getFormatterTargetFiles(): string[] | null {
   if (!isInGitRepo({ cwd: undefined })) {
     return null;
   }
 
-  const changedOrUntrackedFiles =
-    getUncommittedOrUntrackedFilePaths().filter(Boolean);
+  const changedOrUntrackedFiles = getUncommittedOrUntrackedFilePaths().filter(
+    (file) => file && !preWizardChangedFiles.has(file),
+  );
 
   return changedOrUntrackedFiles.length ? changedOrUntrackedFiles : null;
 }
 
 /**
- * Runs a formatter binary via `npx`, passing file names as discrete arguments
- * rather than through a shell. POSIX runs with the shell disabled; Windows must
- * launch `npx.cmd` through a shell, so file arguments are double-quoted (illegal
- * Windows path characters cover the rest).
+ * Resolves the Node entry point of a package's bin from the target project.
  *
- * @param binaryArgs The formatter binary and its flags.
+ * @returns The absolute path to the bin file, or null if it cannot be resolved.
+ */
+function resolveFormatterBinary(
+  packageName: string,
+  binName: string,
+): string | null {
+  const requireFromProject = createRequire(join(process.cwd(), 'package.json'));
+
+  const packageJsonCandidates: string[] = [];
+  try {
+    packageJsonCandidates.push(
+      requireFromProject.resolve(`${packageName}/package.json`),
+    );
+  } catch {
+    // Package may not expose package.json via its exports map; fall through.
+  }
+  packageJsonCandidates.push(
+    join(process.cwd(), 'node_modules', packageName, 'package.json'),
+  );
+
+  for (const packageJsonPath of packageJsonCandidates) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+        bin?: string | Record<string, string>;
+      };
+      const relativeBin =
+        typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.[binName];
+      if (relativeBin) {
+        return join(dirname(packageJsonPath), relativeBin);
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Runs a formatter on the given files without a shell. The formatter's Node
+ * entry point is resolved from the project and executed with the current Node
+ * runtime, so file names are always passed as verbatim arguments and are never
+ * interpreted by a shell on any platform.
+ *
+ * @param packageName The npm package that provides the formatter.
+ * @param binName The bin entry to run from that package.
+ * @param binaryArgs The formatter flags and subcommands.
  * @param files The file paths to format.
- * @param options.ignoreExitCode When true, a non-zero exit code resolves instead of rejecting.
+ * @param options.ignoreExitCode When true, a non-zero exit code or an unresolved binary resolves instead of rejecting.
  */
 function runFormatterCommand(
+  packageName: string,
+  binName: string,
   binaryArgs: string[],
   files: string[],
   { ignoreExitCode }: { ignoreExitCode: boolean },
 ): Promise<void> {
-  const isWindows = process.platform === 'win32';
-  const command = isWindows ? 'npx.cmd' : 'npx';
-  const fileArgs = isWindows
-    ? files.map((file) => `"${file.replace(/"/g, '')}"`)
-    : files;
-
   return new Promise<void>((resolve, reject) => {
+    const binPath = resolveFormatterBinary(packageName, binName);
+    if (!binPath) {
+      if (ignoreExitCode) {
+        resolve();
+      } else {
+        reject(new Error(`Could not resolve the ${packageName} binary.`));
+      }
+      return;
+    }
+
     childProcess.execFile(
-      command,
-      [...binaryArgs, ...fileArgs],
-      { shell: isWindows },
+      process.execPath,
+      [binPath, ...binaryArgs, ...files],
+      { shell: false },
       (err) => {
         if (err && !ignoreExitCode) {
           reject(err);
@@ -886,7 +939,9 @@ export async function runFormatters(_opts: {
       // Run Prettier first if installed (handles general formatting)
       if (prettierInstalled) {
         await runFormatterCommand(
-          ['prettier', '--ignore-unknown', '--write'],
+          'prettier',
+          'prettier',
+          ['--ignore-unknown', '--write'],
           targetFiles,
           { ignoreExitCode: false },
         );
@@ -896,7 +951,9 @@ export async function runFormatters(_opts: {
       if (biomeInstalled) {
         // Format first
         await runFormatterCommand(
-          ['@biomejs/biome', 'format', '--write'],
+          '@biomejs/biome',
+          'biome',
+          ['format', '--write'],
           targetFiles,
           // Ignore errors, just continue
           { ignoreExitCode: true },
@@ -907,7 +964,9 @@ export async function runFormatters(_opts: {
         // The --unsafe flag applies potentially behavior-changing fixes like removing unused imports.
         // This is acceptable for wizard-generated code which may have fixable issues.
         await runFormatterCommand(
-          ['@biomejs/biome', 'check', '--write', '--unsafe'],
+          '@biomejs/biome',
+          'biome',
+          ['check', '--write', '--unsafe'],
           targetFiles,
           // Ignore errors, Biome exits non-zero if there are remaining issues
           { ignoreExitCode: true },
@@ -929,21 +988,12 @@ export async function runFormatters(_opts: {
  *
  * @param options.cwd The directory of the project. If undefined, the current process working directory will be used.
  */
-export async function runPrettierIfInstalled(opts: {
+export async function runPrettierIfInstalled(_opts: {
   cwd: string | undefined;
 }): Promise<void> {
   return traceStep('run-prettier', async () => {
-    if (!isInGitRepo({ cwd: opts.cwd })) {
-      // We only run formatting on changed files. If we're not in a git repo, we can't find
-      // changed files. So let's early-return without showing any formatting-related messages.
-      return;
-    }
-
-    const changedOrUntrackedFiles =
-      getUncommittedOrUntrackedFilePaths().filter(Boolean);
-
-    if (!changedOrUntrackedFiles.length) {
-      // Likewise, if we can't find changed or untracked files, there's no point in running Prettier.
+    const changedOrUntrackedFiles = getFormatterTargetFiles();
+    if (!changedOrUntrackedFiles) {
       return;
     }
 
@@ -973,7 +1023,9 @@ export async function runPrettierIfInstalled(opts: {
 
     try {
       await runFormatterCommand(
-        ['prettier', '--ignore-unknown', '--write'],
+        'prettier',
+        'prettier',
+        ['--ignore-unknown', '--write'],
         changedOrUntrackedFiles,
         { ignoreExitCode: false },
       );
@@ -994,21 +1046,12 @@ export async function runPrettierIfInstalled(opts: {
  *
  * @param options.cwd The directory of the project. If undefined, the current process working directory will be used.
  */
-export async function runBiomeIfInstalled(opts: {
+export async function runBiomeIfInstalled(_opts: {
   cwd: string | undefined;
 }): Promise<void> {
   return traceStep('run-biome', async () => {
-    if (!isInGitRepo({ cwd: opts.cwd })) {
-      // We only run formatting on changed files. If we're not in a git repo, we can't find
-      // changed files. So let's early-return without showing any formatting-related messages.
-      return;
-    }
-
-    const changedOrUntrackedFiles =
-      getUncommittedOrUntrackedFilePaths().filter(Boolean);
-
-    if (!changedOrUntrackedFiles.length) {
-      // Likewise, if we can't find changed or untracked files, there's no point in running Biome.
+    const changedOrUntrackedFiles = getFormatterTargetFiles();
+    if (!changedOrUntrackedFiles) {
       return;
     }
 
@@ -1041,14 +1084,18 @@ export async function runBiomeIfInstalled(opts: {
       // Then biome check --write for lint fixes
       // We ignore exit codes because Biome exits non-zero if there are unfixable issues
       await runFormatterCommand(
-        ['@biomejs/biome', 'format', '--write'],
+        '@biomejs/biome',
+        'biome',
+        ['format', '--write'],
         changedOrUntrackedFiles,
         // Ignore errors, just continue
         { ignoreExitCode: true },
       );
 
       await runFormatterCommand(
-        ['@biomejs/biome', 'check', '--write', '--unsafe'],
+        '@biomejs/biome',
+        'biome',
+        ['check', '--write', '--unsafe'],
         changedOrUntrackedFiles,
         // Ignore errors, Biome exits non-zero if there are remaining issues
         { ignoreExitCode: true },

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -68,16 +68,3 @@ export function getUncommittedOrUntrackedFilePaths(opts?: {
     return [];
   }
 }
-
-/**
- * Returns uncommitted or untracked files prefixed with `- ` for display in
- * prompts. To run a command against these files, use
- * {@link getUncommittedOrUntrackedFilePaths} instead.
- *
- * @param opts.cwd The project directory. Defaults to the current working directory.
- */
-export function getUncommittedOrUntrackedFiles(opts?: {
-  cwd: string | undefined;
-}): string[] {
-  return getUncommittedOrUntrackedFilePaths(opts).map((file) => `- ${file}`);
-}

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,4 @@
 import * as childProcess from 'child_process';
-import * as os from 'os';
 
 /**
  * Checks if the current working directory is a git repository.
@@ -20,26 +19,65 @@ export function isInGitRepo(opts: { cwd: string | undefined }) {
   }
 }
 
-export function getUncommittedOrUntrackedFiles(opts?: {
+/**
+ * Returns the exact paths of uncommitted or untracked files.
+ *
+ * Uses `git status --porcelain=v1 -z` so paths are NUL-terminated and verbatim,
+ * preserving spaces and unusual characters. Pass results as argv entries to a
+ * non-shell child process; do not interpolate them into a shell string.
+ *
+ * @param opts.cwd The project directory. Defaults to the current working directory.
+ */
+export function getUncommittedOrUntrackedFilePaths(opts?: {
   cwd: string | undefined;
 }): string[] {
   try {
     const gitStatus = childProcess
-      .execSync('git status --porcelain=v1', {
+      .execSync('git status --porcelain=v1 -z', {
         // we only care about stdout
         stdio: ['ignore', 'pipe', 'ignore'],
         cwd: opts?.cwd,
       })
       .toString();
 
-    const files = gitStatus
-      .split(os.EOL)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((f) => `- ${f.split(/\s+/)[1]}`);
+    const fields = gitStatus.split('\0');
+    const files: string[] = [];
+
+    for (let i = 0; i < fields.length; i++) {
+      const entry = fields[i];
+      if (!entry) {
+        continue;
+      }
+
+      // Entry is `XY <path>`. Renames/copies (R/C) store the source in the
+      // next field, which we skip.
+      const status = entry.slice(0, 2);
+      const filePath = entry.slice(3);
+
+      if (status[0] === 'R' || status[0] === 'C') {
+        i++;
+      }
+
+      if (filePath) {
+        files.push(filePath);
+      }
+    }
 
     return files;
   } catch {
     return [];
   }
+}
+
+/**
+ * Returns uncommitted or untracked files prefixed with `- ` for display in
+ * prompts. To run a command against these files, use
+ * {@link getUncommittedOrUntrackedFilePaths} instead.
+ *
+ * @param opts.cwd The project directory. Defaults to the current working directory.
+ */
+export function getUncommittedOrUntrackedFiles(opts?: {
+  cwd: string | undefined;
+}): string[] {
+  return getUncommittedOrUntrackedFilePaths(opts).map((file) => `- ${file}`);
 }

--- a/src/utils/line-endings.ts
+++ b/src/utils/line-endings.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { getUncommittedOrUntrackedFiles } from './git';
+import { getUncommittedOrUntrackedFilePaths } from './git';
 
 /**
  * Fixes mixed line endings in files modified by the wizard.
@@ -26,9 +26,7 @@ const TEXT_EXTENSIONS = new Set([
 ]);
 
 export function fixLineEndings(): void {
-  const files = getUncommittedOrUntrackedFiles()
-    .map((f) => (f.startsWith('- ') ? f.slice(2) : f))
-    .filter(Boolean);
+  const files = getUncommittedOrUntrackedFilePaths().filter(Boolean);
 
   for (const file of files) {
     const filePath = path.resolve(file);

--- a/test/utils/clack/index.test.ts
+++ b/test/utils/clack/index.test.ts
@@ -6,6 +6,7 @@ import {
   createNewConfigFile,
   getPackageManager,
   installPackage,
+  runPrettierIfInstalled,
 } from '../../../src/utils/clack/';
 
 import * as fs from 'node:fs';
@@ -74,7 +75,7 @@ const mockedAxios = axios as Mocked<typeof axios>;
 
 vi.mock('../../../src/utils/git', () => ({
   isInGitRepo: vi.fn(),
-  getUncommittedOrUntrackedFiles: vi.fn(),
+  getUncommittedOrUntrackedFilePaths: vi.fn(),
 }));
 
 vi.mock('opn', () => ({
@@ -649,8 +650,8 @@ describe('confirmContinueIfNoOrDirtyGitRepo', () => {
 
     it('aborts without prompting when the repository has uncommitted or untracked files', async () => {
       (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
-      (GitUtils.getUncommittedOrUntrackedFiles as Mock).mockReturnValue([
-        '- src/index.ts',
+      (GitUtils.getUncommittedOrUntrackedFilePaths as Mock).mockReturnValue([
+        'src/index.ts',
       ]);
 
       await expect(
@@ -701,8 +702,8 @@ describe('confirmContinueIfNoOrDirtyGitRepo', () => {
 
     it('prompts to continue when the repository has uncommitted or untracked files', async () => {
       (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
-      (GitUtils.getUncommittedOrUntrackedFiles as Mock).mockReturnValue([
-        '- src/index.ts',
+      (GitUtils.getUncommittedOrUntrackedFilePaths as Mock).mockReturnValue([
+        'src/index.ts',
       ]);
       mockUserResponse(clack.confirm as Mock, true);
 
@@ -731,7 +732,7 @@ describe('confirmContinueIfNoOrDirtyGitRepo', () => {
 
     it('does not prompt or abort for a clean git repository', async () => {
       (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
-      (GitUtils.getUncommittedOrUntrackedFiles as Mock).mockReturnValue([]);
+      (GitUtils.getUncommittedOrUntrackedFilePaths as Mock).mockReturnValue([]);
 
       await confirmContinueIfNoOrDirtyGitRepo({
         ignoreGitChanges: undefined,
@@ -742,5 +743,46 @@ describe('confirmContinueIfNoOrDirtyGitRepo', () => {
       expect(clack.log.warn).not.toHaveBeenCalled();
       expect(exitSpy).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('runPrettierIfInstalled', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('only formats files the wizard changed, excluding pre-existing working-tree files', async () => {
+    (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
+    // First read: the pre-wizard snapshot (includes an attacker-controlled file).
+    // Second read: the state after the wizard added its own file.
+    (GitUtils.getUncommittedOrUntrackedFilePaths as Mock)
+      .mockReturnValueOnce(['z$(id).ts'])
+      .mockReturnValueOnce(['z$(id).ts', 'sentry.client.config.ts']);
+
+    const execFileSpy = vi.spyOn(ChildProcess, 'execFile').mockImplementation(((
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: unknown) => void,
+    ) => {
+      callback(null);
+      return {} as ChildProcess.ChildProcess;
+    }) as unknown as typeof ChildProcess.execFile);
+
+    // Capture the pre-wizard baseline.
+    await confirmContinueIfNoOrDirtyGitRepo({
+      ignoreGitChanges: true,
+      cwd: undefined,
+    });
+
+    // User agrees to run Prettier.
+    mockUserResponse(clack.confirm as Mock, true);
+
+    await runPrettierIfInstalled({ cwd: undefined });
+
+    expect(execFileSpy).toHaveBeenCalledTimes(1);
+    const passedArgs = execFileSpy.mock.calls[0][1] as string[];
+    expect(passedArgs).toContain('sentry.client.config.ts');
+    expect(passedArgs).not.toContain('z$(id).ts');
   });
 });

--- a/test/utils/clack/index.test.ts
+++ b/test/utils/clack/index.test.ts
@@ -6,7 +6,6 @@ import {
   createNewConfigFile,
   getPackageManager,
   installPackage,
-  runPrettierIfInstalled,
 } from '../../../src/utils/clack/';
 
 import * as fs from 'node:fs';
@@ -743,46 +742,5 @@ describe('confirmContinueIfNoOrDirtyGitRepo', () => {
       expect(clack.log.warn).not.toHaveBeenCalled();
       expect(exitSpy).not.toHaveBeenCalled();
     });
-  });
-});
-
-describe('runPrettierIfInstalled', () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('only formats files the wizard changed, excluding pre-existing working-tree files', async () => {
-    (GitUtils.isInGitRepo as Mock).mockReturnValue(true);
-    // First read: the pre-wizard snapshot (includes an attacker-controlled file).
-    // Second read: the state after the wizard added its own file.
-    (GitUtils.getUncommittedOrUntrackedFilePaths as Mock)
-      .mockReturnValueOnce(['z$(id).ts'])
-      .mockReturnValueOnce(['z$(id).ts', 'sentry.client.config.ts']);
-
-    const execFileSpy = vi.spyOn(ChildProcess, 'execFile').mockImplementation(((
-      _file: string,
-      _args: string[],
-      _options: unknown,
-      callback: (error: unknown) => void,
-    ) => {
-      callback(null);
-      return {} as ChildProcess.ChildProcess;
-    }) as unknown as typeof ChildProcess.execFile);
-
-    // Capture the pre-wizard baseline.
-    await confirmContinueIfNoOrDirtyGitRepo({
-      ignoreGitChanges: true,
-      cwd: undefined,
-    });
-
-    // User agrees to run Prettier.
-    mockUserResponse(clack.confirm as Mock, true);
-
-    await runPrettierIfInstalled({ cwd: undefined });
-
-    expect(execFileSpy).toHaveBeenCalledTimes(1);
-    const passedArgs = execFileSpy.mock.calls[0][1] as string[];
-    expect(passedArgs).toContain('sentry.client.config.ts');
-    expect(passedArgs).not.toContain('z$(id).ts');
   });
 });

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, it, vi, expect } from 'vitest';
 
 import {
   getUncommittedOrUntrackedFilePaths,
-  getUncommittedOrUntrackedFiles,
   isInGitRepo,
 } from '../../src/utils/git';
 
@@ -123,23 +122,5 @@ describe('getUncommittedOrUntrackedFilePaths', () => {
     });
 
     expect(getUncommittedOrUntrackedFilePaths()).toEqual([]);
-  });
-});
-
-describe('getUncommittedOrUntrackedFiles', () => {
-  it('returns a list-formatted view of uncommitted or untracked files', () => {
-    mockedExecSync.mockImplementationOnce(() => {
-      return ' M file1.txt\0?? file2.txt\0';
-    });
-    expect(getUncommittedOrUntrackedFiles()).toEqual([
-      '- file1.txt',
-      '- file2.txt',
-    ]);
-  });
-
-  it('returns an empty list if there are no uncommitted or untracked files', () => {
-    mockedExecSync.mockImplementationOnce(() => '');
-
-    expect(getUncommittedOrUntrackedFiles()).toEqual([]);
   });
 });

--- a/test/utils/git.test.ts
+++ b/test/utils/git.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, it, vi, expect } from 'vitest';
 
 import {
+  getUncommittedOrUntrackedFilePaths,
   getUncommittedOrUntrackedFiles,
   isInGitRepo,
 } from '../../src/utils/git';
@@ -51,49 +52,93 @@ describe('isInGitRepo', () => {
   });
 });
 
-describe('getUncommittedOrUntrackedFiles', () => {
-  it('returns a list of uncommitted or untracked files', () => {
+describe('getUncommittedOrUntrackedFilePaths', () => {
+  it('returns the verbatim paths of uncommitted or untracked files', () => {
     mockedExecSync.mockImplementationOnce(() => {
       return (
-        ' M file1.txt\n' +
-        '?? file2.txt\n' +
-        '?? file3.txt\n' +
-        '?? file4.txt\n'
+        ' M file1.txt\0' +
+        '?? file2.txt\0' +
+        '?? file3.txt\0' +
+        '?? file4.txt\0'
       );
     });
-    expect(getUncommittedOrUntrackedFiles()).toEqual([
-      '- file1.txt',
-      '- file2.txt',
-      '- file3.txt',
-      '- file4.txt',
+    expect(getUncommittedOrUntrackedFilePaths()).toEqual([
+      'file1.txt',
+      'file2.txt',
+      'file3.txt',
+      'file4.txt',
+    ]);
+  });
+
+  it('uses the NUL-delimited porcelain format', () => {
+    mockedExecSync.mockImplementationOnce(() => '');
+
+    getUncommittedOrUntrackedFilePaths({ cwd: '/path/to/dir' });
+
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      'git status --porcelain=v1 -z',
+      {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        cwd: '/path/to/dir',
+      },
+    );
+  });
+
+  it('preserves file names containing spaces and shell metacharacters', () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      return (
+        '?? $(touch pwned).js\0' +
+        '?? a;id;b.js\0' +
+        '?? with space.txt\0' +
+        ' M `whoami`.ts\0'
+      );
+    });
+    expect(getUncommittedOrUntrackedFilePaths()).toEqual([
+      '$(touch pwned).js',
+      'a;id;b.js',
+      'with space.txt',
+      '`whoami`.ts',
+    ]);
+  });
+
+  it('returns the destination path of a rename and skips the source field', () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      return 'R  renamed.txt\0orig.txt\0?? other.txt\0';
+    });
+    expect(getUncommittedOrUntrackedFilePaths()).toEqual([
+      'renamed.txt',
+      'other.txt',
     ]);
   });
 
   it('returns an empty list if there are no uncommitted or untracked files', () => {
-    mockedExecSync.mockImplementationOnce(() => {
-      return '';
-    });
+    mockedExecSync.mockImplementationOnce(() => '');
 
-    expect(getUncommittedOrUntrackedFiles()).toEqual([]);
-  });
-
-  it('forwards cwd if provided', () => {
-    mockedExecSync.mockImplementationOnce(() => {
-      return '';
-    });
-
-    getUncommittedOrUntrackedFiles({ cwd: '/path/to/dir' });
-
-    expect(mockedExecSync).toHaveBeenCalledWith('git status --porcelain=v1', {
-      stdio: ['ignore', 'pipe', 'ignore'],
-      cwd: '/path/to/dir',
-    });
+    expect(getUncommittedOrUntrackedFilePaths()).toEqual([]);
   });
 
   it('returns an empty list if the git command fails', () => {
     mockedExecSync.mockImplementationOnce(() => {
       throw new Error('Command failed');
     });
+
+    expect(getUncommittedOrUntrackedFilePaths()).toEqual([]);
+  });
+});
+
+describe('getUncommittedOrUntrackedFiles', () => {
+  it('returns a list-formatted view of uncommitted or untracked files', () => {
+    mockedExecSync.mockImplementationOnce(() => {
+      return ' M file1.txt\0?? file2.txt\0';
+    });
+    expect(getUncommittedOrUntrackedFiles()).toEqual([
+      '- file1.txt',
+      '- file2.txt',
+    ]);
+  });
+
+  it('returns an empty list if there are no uncommitted or untracked files', () => {
+    mockedExecSync.mockImplementationOnce(() => '');
 
     expect(getUncommittedOrUntrackedFiles()).toEqual([]);
   });

--- a/test/utils/line-endings.test.ts
+++ b/test/utils/line-endings.test.ts
@@ -21,8 +21,8 @@ describe('fixLineEndings', () => {
     const filePath = path.join(tmpDir, 'mixed.dart');
     fs.writeFileSync(filePath, 'line1\r\nline2\nline3\r\n', 'utf8');
 
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([
-      `- ${filePath}`,
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([
+      filePath,
     ]);
 
     fixLineEndings();
@@ -36,8 +36,8 @@ describe('fixLineEndings', () => {
     const original = 'line1\nline2\n';
     fs.writeFileSync(filePath, original, 'utf8');
 
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([
-      `- ${filePath}`,
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([
+      filePath,
     ]);
 
     fixLineEndings();
@@ -51,8 +51,8 @@ describe('fixLineEndings', () => {
     const original = 'line1\r\nline2\r\n';
     fs.writeFileSync(filePath, original, 'utf8');
 
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([
-      `- ${filePath}`,
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([
+      filePath,
     ]);
 
     fixLineEndings();
@@ -66,8 +66,8 @@ describe('fixLineEndings', () => {
     const original = 'line1\r\nline2\nline3\r\n';
     fs.writeFileSync(filePath, original, 'utf8');
 
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([
-      `- ${filePath}`,
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([
+      filePath,
     ]);
 
     fixLineEndings();
@@ -80,23 +80,23 @@ describe('fixLineEndings', () => {
     const dirPath = path.join(tmpDir, 'subdir');
     fs.mkdirSync(dirPath);
 
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([
-      `- ${dirPath}`,
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([
+      dirPath,
     ]);
 
     expect(() => fixLineEndings()).not.toThrow();
   });
 
   it('skips nonexistent files', () => {
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([
-      '- nonexistent.txt',
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([
+      'nonexistent.txt',
     ]);
 
     expect(() => fixLineEndings()).not.toThrow();
   });
 
   it('does nothing when there are no modified files', () => {
-    vi.spyOn(git, 'getUncommittedOrUntrackedFiles').mockReturnValue([]);
+    vi.spyOn(git, 'getUncommittedOrUntrackedFilePaths').mockReturnValue([]);
 
     expect(() => fixLineEndings()).not.toThrow();
   });


### PR DESCRIPTION
Makes the post-setup Prettier/Biome formatting step more robust when collecting the list of changed files. Safer passing of file paths to the formatters more precise git status parsing:
- Parse git status output unambiguously and pass changed files to Prettier/Biome as discrete arguments
- Applies across all wizards that run the formatter step
- Only allow post-setup formatter to format files the wizard changed 
- Avoid some footguns
- Tests