### PR TITLE
ref(js): Remove Logs opt-in step from JS wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- ref(js): Remove Logs opt-in step from JS wizards and rely on the SDK's default `enableLogs` ([#1329](https://github.com/getsentry/sentry-wizard/pull/1329))
+- ref(js): Remove Logs opt-in from JS wizards ([#1329](https://github.com/getsentry/sentry-wizard/pull/1329))
 
 ## 7.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref(js): Remove Logs opt-in step from JS wizards and rely on the SDK's default `enableLogs` ([#1329](https://github.com/getsentry/sentry-wizard/pull/1329))
+
 ## 7.0.2
 
 ### Fixes

--- a/e2e-tests/tests/angular-17.test.ts
+++ b/e2e-tests/tests/angular-17.test.ts
@@ -111,8 +111,6 @@ async function runWizardOnAngularProject(
       .respondWith(KEYS.ENTER) // yes
       .whenAsked('Do you want to enable Session Replay')
       .respondWith(KEYS.ENTER) // yes
-      .whenAsked('Do you want to enable Logs')
-      .respondWith(KEYS.ENTER) // yes
       .expectOutput('initialized Sentry in main.ts', {
         timeout: 10_000,
       })
@@ -194,7 +192,6 @@ function checkAngularProject(
       'tracesSampleRate: 1',
       'replaysSessionSampleRate: 0.1',
       'replaysOnErrorSampleRate: 1',
-      'enableLogs: true',
     ]);
   });
 

--- a/e2e-tests/tests/angular-19.test.ts
+++ b/e2e-tests/tests/angular-19.test.ts
@@ -110,8 +110,6 @@ async function runWizardOnAngularProject(
       .respondWith(KEYS.ENTER) // yes
       .whenAsked('Do you want to enable Session Replay')
       .respondWith(KEYS.ENTER) // yes
-      .whenAsked('Do you want to enable Logs')
-      .respondWith(KEYS.ENTER) // yes
       .expectOutput('initialized Sentry in main.ts', {
         timeout: 10_000,
       })
@@ -193,7 +191,6 @@ function checkAngularProject(
       'tracesSampleRate: 1',
       'replaysSessionSampleRate: 0.1',
       'replaysOnErrorSampleRate: 1',
-      'enableLogs: true',
     ]);
   });
 

--- a/e2e-tests/tests/cloudflare-worker.test.ts
+++ b/e2e-tests/tests/cloudflare-worker.test.ts
@@ -40,9 +40,6 @@ describe('cloudflare-worker', () => {
         whenAsked('Do you want to enable Tracing', {
           timeout: 90_000, // package installation can take a while in CI
         }).respondWith(KEYS.ENTER);
-        whenAsked('Do you want to enable Logs', {
-          timeout: 90_000, // package installation can take a while in CI
-        }).respondWith(KEYS.ENTER);
       })
       .whenAsked(
         'Optionally add a project-scoped MCP server configuration for the Sentry MCP?',
@@ -86,7 +83,6 @@ describe('cloudflare-worker', () => {
       'export default Sentry.withSentry(env => ({',
       'dsn: "https://public@dsn.ingest.sentry.io/1337",',
       'tracesSampleRate: 1',
-      'enableLogs: true',
     ]);
   });
 });

--- a/e2e-tests/tests/nextjs-14.test.ts
+++ b/e2e-tests/tests/nextjs-14.test.ts
@@ -42,8 +42,6 @@ describe('NextJS-14', () => {
         'to get a video-like reproduction of errors during a user session?',
       )
       .respondWith(KEYS.ENTER)
-      .whenAsked('to send your application logs to Sentry?')
-      .respondWith(KEYS.ENTER)
       .whenAsked('Do you want to create an example page')
       .respondWith(KEYS.ENTER)
       .whenAsked('Are you using a CI/CD tool')

--- a/e2e-tests/tests/nextjs-15.test.ts
+++ b/e2e-tests/tests/nextjs-15.test.ts
@@ -46,8 +46,6 @@ describe('NextJS-15', () => {
         'to get a video-like reproduction of errors during a user session?',
       )
       .respondWith(KEYS.ENTER)
-      .whenAsked('to send your application logs to Sentry?')
-      .respondWith(KEYS.ENTER)
       .whenAsked('Do you want to create an example page')
       .respondWith(KEYS.ENTER)
       .whenAsked('Are you using a CI/CD tool')
@@ -170,8 +168,6 @@ describe('NextJS-15 Spotlight', () => {
       .whenAsked(
         'to get a video-like reproduction of errors during a user session?',
       )
-      .respondWith(KEYS.ENTER)
-      .whenAsked('to send your application logs to Sentry?')
       .respondWith(KEYS.ENTER)
       .whenAsked('Do you want to create an example page')
       .respondWith(KEYS.DOWN, KEYS.ENTER) // Skip example page

--- a/e2e-tests/tests/nextjs-16.test.ts
+++ b/e2e-tests/tests/nextjs-16.test.ts
@@ -43,8 +43,6 @@ describe('NextJS-16 with Prettier, Biome, and ESLint', () => {
         'to get a video-like reproduction of errors during a user session?',
       )
       .respondWith(KEYS.ENTER)
-      .whenAsked('to send your application logs to Sentry?')
-      .respondWith(KEYS.ENTER)
       .whenAsked('Do you want to create an example page')
       .respondWith(KEYS.DOWN, KEYS.ENTER) // Skip example page
       .whenAsked('Are you using a CI/CD tool')

--- a/e2e-tests/tests/nuxt-3.test.ts
+++ b/e2e-tests/tests/nuxt-3.test.ts
@@ -44,8 +44,6 @@ describe('Nuxt-3', () => {
       .respondWith(KEYS.ENTER)
       .whenAsked('Do you want to enable Session Replay')
       .respondWith(KEYS.ENTER)
-      .whenAsked('Do you want to enable Logs')
-      .respondWith(KEYS.ENTER)
       .expectOutput('Created new sentry.server.config.ts')
       .expectOutput('Created new sentry.client.config.ts')
       .whenAsked('Do you want to create an example page')
@@ -121,8 +119,6 @@ describe('Nuxt-3', () => {
       '  replaysOnErrorSampleRate: 1.0,',
       "  // If you don't want to use Session Replay, just remove the line below:",
       '  integrations: [Sentry.replayIntegration()],',
-      '  // Enable logs to be sent to Sentry',
-      '  enableLogs: true,',
       '  dataCollection: {',
       '    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:',
       '    // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection',
@@ -143,8 +139,6 @@ describe('Nuxt-3', () => {
       '  // We recommend adjusting this value in production, or using tracesSampler',
       '  // for finer control',
       '  tracesSampleRate: 1.0,',
-      '  // Enable logs to be sent to Sentry',
-      '  enableLogs: true,',
       '  dataCollection: {',
       '    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:',
       '    // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection',

--- a/e2e-tests/tests/nuxt-4.test.ts
+++ b/e2e-tests/tests/nuxt-4.test.ts
@@ -44,8 +44,6 @@ describe('Nuxt-4', () => {
       .respondWith(KEYS.ENTER)
       .whenAsked('Do you want to enable Session Replay')
       .respondWith(KEYS.ENTER)
-      .whenAsked('Do you want to enable Logs')
-      .respondWith(KEYS.ENTER)
       .expectOutput('Created new sentry.server.config.ts')
       .expectOutput('Created new sentry.client.config.ts')
       .whenAsked('Do you want to create an example page')
@@ -121,8 +119,6 @@ describe('Nuxt-4', () => {
       '  replaysOnErrorSampleRate: 1.0,',
       "  // If you don't want to use Session Replay, just remove the line below:",
       '  integrations: [Sentry.replayIntegration()],',
-      '  // Enable logs to be sent to Sentry',
-      '  enableLogs: true,',
       '  dataCollection: {',
       '    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:',
       '    // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection',
@@ -143,8 +139,6 @@ describe('Nuxt-4', () => {
       '  // We recommend adjusting this value in production, or using tracesSampler',
       '  // for finer control',
       '  tracesSampleRate: 1.0,',
-      '  // Enable logs to be sent to Sentry',
-      '  enableLogs: true,',
       '  dataCollection: {',
       '    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:',
       '    // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection',

--- a/e2e-tests/tests/pnpm-workspace.test.ts
+++ b/e2e-tests/tests/pnpm-workspace.test.ts
@@ -50,7 +50,6 @@ describe('pnpm workspace', () => {
         whenAsked('Do you want to enable Session Replay').respondWith(
           KEYS.ENTER,
         );
-        whenAsked('Do you want to enable Logs').respondWith(KEYS.ENTER);
       })
       .whenAsked('Do you want to create an example page')
       .respondWith(KEYS.ENTER)
@@ -123,9 +122,6 @@ describe('pnpm workspace', () => {
 
           tracesSampleRate: 1.0,
 
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
-
           // This sets the sample rate to be 10%. You may want this to be 100% while
           // in development and sample at a lower rate in production
           replaysSessionSampleRate: 0.1,
@@ -173,10 +169,6 @@ describe('pnpm workspace', () => {
           dsn: '${TEST_ARGS.PROJECT_DSN}',
 
           tracesSampleRate: 1.0,
-
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
-
           // uncomment the line below to enable Spotlight (https://spotlightjs.com)
           // spotlight: import.meta.env.DEV,
         });"

--- a/e2e-tests/tests/react-router-instrumentation-api.test.ts
+++ b/e2e-tests/tests/react-router-instrumentation-api.test.ts
@@ -35,8 +35,6 @@ async function runWizardWithInstrumentationAPI(
     .respondWith(KEYS.ENTER) // Yes
     .whenAsked('Do you want to enable Session Replay')
     .respondWith(KEYS.ENTER) // Yes
-    .whenAsked('Do you want to enable Logs')
-    .respondWith(KEYS.ENTER) // Yes
     .whenAsked('Do you want to enable Profiling')
     .respondWith(KEYS.ENTER) // Yes
     .whenAsked('Do you want to use the Instrumentation API')

--- a/e2e-tests/tests/react-router.test.ts
+++ b/e2e-tests/tests/react-router.test.ts
@@ -48,8 +48,6 @@ async function runWizardOnReactRouterProject(
     .respondWith(KEYS.ENTER)
     .whenAsked('Do you want to enable Session Replay')
     .respondWith(KEYS.ENTER)
-    .whenAsked('Do you want to enable Logs')
-    .respondWith(KEYS.ENTER)
     .whenAsked('Do you want to enable Profiling')
     .respondWith(KEYS.ENTER)
     .whenAsked('Do you want to use the Instrumentation API')
@@ -131,7 +129,6 @@ describe('React Router', () => {
         `Sentry.init({
   dsn: "${TEST_ARGS.PROJECT_DSN}",`,
         'integrations: [Sentry.reactRouterTracingIntegration(), Sentry.replayIntegration()]',
-        'enableLogs: true,',
         'tracesSampleRate: 1.0,',
       ]);
     });
@@ -157,7 +154,6 @@ describe('React Router', () => {
         "import * as Sentry from '@sentry/react-router';",
         `Sentry.init({
   dsn: "${TEST_ARGS.PROJECT_DSN}",`,
-        'enableLogs: true,',
       ]);
     });
 

--- a/e2e-tests/tests/remix.test.ts
+++ b/e2e-tests/tests/remix.test.ts
@@ -92,8 +92,6 @@ async function runWizardOnRemixProject(
       'to get a video-like reproduction of errors during a user session?',
     )
     .respondWith(KEYS.ENTER)
-    .whenAsked('to send your application logs to Sentry?')
-    .respondWith(KEYS.ENTER)
     .whenAsked('Do you want to create an example page')
     .respondWith(KEYS.ENTER)
     .whenAsked(
@@ -147,7 +145,6 @@ describe('Remix', () => {
         `init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
-    enableLogs: true,
 
     integrations: [browserTracingIntegration({
       useEffect,
@@ -178,8 +175,7 @@ describe('Remix', () => {
         'import * as Sentry from "@sentry/remix";',
         `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
-    tracesSampleRate: 1,
-    enableLogs: true
+    tracesSampleRate: 1
 })`,
       ]);
     });
@@ -261,7 +257,6 @@ describe('Remix', () => {
         `init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
-    enableLogs: true,
 
     integrations: [browserTracingIntegration({
       useEffect,
@@ -292,8 +287,7 @@ describe('Remix', () => {
         'import * as Sentry from "@sentry/remix";',
         `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
-    tracesSampleRate: 1,
-    enableLogs: true
+    tracesSampleRate: 1
 })`,
       ]);
     });

--- a/e2e-tests/tests/sveltekit-hooks.test.ts
+++ b/e2e-tests/tests/sveltekit-hooks.test.ts
@@ -97,9 +97,6 @@ describe.sequential('Sveltekit', () => {
 
   tracesSampleRate: 1.0,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
   replaysSessionSampleRate: 0.1,
@@ -129,10 +126,6 @@ describe.sequential('Sveltekit', () => {
   dsn: '${TEST_ARGS.PROJECT_DSN}',
 
   tracesSampleRate: 1.0,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
 
   dataCollection: {
     // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -235,7 +228,6 @@ describe.sequential('Sveltekit', () => {
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1,
     integrations: [Sentry.replayIntegration()],
-    enableLogs: true,
     dataCollection: {
       // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
@@ -253,7 +245,6 @@ describe.sequential('Sveltekit', () => {
         `Sentry.init({
     dsn: "${TEST_ARGS.PROJECT_DSN}",
     tracesSampleRate: 1,
-    enableLogs: true,
     dataCollection: {
       // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
@@ -297,8 +288,6 @@ async function runWizardOnSvelteKitProject(
     })
     .respondWith(KEYS.ENTER)
     .whenAsked('Do you want to enable Session Replay')
-    .respondWith(KEYS.ENTER)
-    .whenAsked('Do you want to enable Logs')
     .respondWith(KEYS.ENTER)
     .whenAsked('Do you want to create an example page')
     .respondWith(KEYS.ENTER)

--- a/e2e-tests/tests/sveltekit-tracing.test.ts
+++ b/e2e-tests/tests/sveltekit-tracing.test.ts
@@ -49,7 +49,6 @@ describe('Sveltekit with instrumentation and tracing', () => {
           whenAsked('Do you want to enable Session Replay').respondWith(
             KEYS.ENTER,
           );
-          whenAsked('Do you want to enable Logs').respondWith(KEYS.ENTER);
         })
         .whenAsked('Do you want to create an example page')
         .respondWith(KEYS.ENTER)
@@ -127,9 +126,6 @@ describe('Sveltekit with instrumentation and tracing', () => {
 
           tracesSampleRate: 1.0,
 
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
-
           // This sets the sample rate to be 10%. You may want this to be 100% while
           // in development and sample at a lower rate in production
           replaysSessionSampleRate: 0.1,
@@ -177,10 +173,6 @@ describe('Sveltekit with instrumentation and tracing', () => {
           dsn: '${TEST_ARGS.PROJECT_DSN}',
 
           tracesSampleRate: 1.0,
-
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
-
           // uncomment the line below to enable Spotlight (https://spotlightjs.com)
           // spotlight: import.meta.env.DEV,
         });"

--- a/src/angular/angular-wizard.ts
+++ b/src/angular/angular-wizard.ts
@@ -182,13 +182,6 @@ Apologies for the inconvenience!`,
       )} to get a video-like reproduction of errors during a user session?`,
       enabledHint: 'recommended, but increases bundle size',
     },
-    {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    },
   ] as const);
 
   await traceStep(

--- a/src/angular/codemods/main.ts
+++ b/src/angular/codemods/main.ts
@@ -15,7 +15,6 @@ export function updateAppEntryMod(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): ProxifiedModule<any> {
@@ -37,7 +36,6 @@ export function insertInitCall(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): void {
   const initCallArgs = getInitCallArgs(dsn, selectedFeatures);
@@ -68,7 +66,6 @@ export function getInitCallArgs(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): InitCallArgs {
   const initCallArgs: InitCallArgs = {
@@ -93,10 +90,6 @@ export function getInitCallArgs(
       initCallArgs.replaysSessionSampleRate = 0.1;
       initCallArgs.replaysOnErrorSampleRate = 1.0;
     }
-  }
-
-  if (selectedFeatures.logs) {
-    initCallArgs.enableLogs = true;
   }
 
   return initCallArgs;

--- a/src/angular/sdk-setup.ts
+++ b/src/angular/sdk-setup.ts
@@ -22,7 +22,6 @@ export async function initializeSentryOnApplicationEntry(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): Promise<void> {
   const appEntryFilename = 'main.ts';

--- a/src/cloudflare/cloudflare-wizard.ts
+++ b/src/cloudflare/cloudflare-wizard.ts
@@ -89,13 +89,6 @@ async function runCloudflareWizardWithTelemetry(
       )} to track the performance of your application?`,
       enabledHint: 'recommended',
     },
-    {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    },
   ] as const);
 
   await traceStep('Create Sentry initialization', async () => {

--- a/src/cloudflare/sdk-setup.ts
+++ b/src/cloudflare/sdk-setup.ts
@@ -21,7 +21,6 @@ export async function createSentryInitFile(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ): Promise<void> {
   const entryPointFromConfig = getEntryPointFromWranglerConfig();

--- a/src/cloudflare/templates.ts
+++ b/src/cloudflare/templates.ts
@@ -2,7 +2,6 @@ export function getCloudflareWorkerTemplate(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ): string {
   let performanceOptions = '';
@@ -12,18 +11,11 @@ export function getCloudflareWorkerTemplate(
 		tracesSampleRate: 1,`;
   }
 
-  let logsOptions = '';
-  if (selectedFeatures.logs) {
-    logsOptions = `
-		// Enable logs to be sent to Sentry
-		enableLogs: true,`;
-  }
-
   return `import * as Sentry from '@sentry/cloudflare';
 
 export default Sentry.withSentry(
 	(env) => ({
-		dsn: '${dsn}',${performanceOptions}${logsOptions}
+		dsn: '${dsn}',${performanceOptions}
 	}),
 	{
 		async fetch(request, env, ctx): Promise<Response> {

--- a/src/cloudflare/wrap-worker.ts
+++ b/src/cloudflare/wrap-worker.ts
@@ -44,7 +44,6 @@ export async function wrapWorkerWithSentry(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ): Promise<void> {
   const workerAst = await loadFile(workerFilePath);
@@ -91,7 +90,6 @@ function createSentryConfigFunction(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ): t.ArrowFunctionExpression {
   const configProperties: t.ObjectProperty[] = [
@@ -113,19 +111,6 @@ function createSentryConfigFunction(
     ];
 
     configProperties.push(tracesSampleRateProperty);
-  }
-
-  if (selectedFeatures.logs) {
-    const enableLogsProperty = b.objectProperty(
-      b.identifier('enableLogs'),
-      b.booleanLiteral(true),
-    );
-
-    enableLogsProperty.comments = [
-      b.commentLine(' Enable logs to be sent to Sentry', true, false),
-    ];
-
-    configProperties.push(enableLogsProperty);
   }
 
   const configObject = b.objectExpression(configProperties);

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -142,7 +142,7 @@ export async function runNextjsWizardWithTelemetry(
     ({ selectedProject, authToken, selfHosted, sentryUrl } = projectData);
   }
 
-  const { logsEnabled } = await traceStep('configure-sdk', async () => {
+  await traceStep('configure-sdk', async () => {
     const tunnelRoute = await askShouldSetTunnelRoute();
 
     return await createOrMergeNextJsFiles(
@@ -385,7 +385,6 @@ export async function runNextjsWizardWithTelemetry(
         selectedProject,
         sentryUrl,
         typeScriptDetected,
-        logsEnabled,
       ),
     );
   }
@@ -461,7 +460,7 @@ async function createOrMergeNextJsFiles(
   sentryUrl: string,
   sdkConfigOptions: SDKConfigOptions,
   spotlight = false,
-): Promise<{ logsEnabled: boolean }> {
+): Promise<void> {
   const dsn = selectedProject.keys[0].dsn.public;
   const selectedFeatures = await featureSelectionPrompt([
     {
@@ -477,13 +476,6 @@ async function createOrMergeNextJsFiles(
         'Session Replay',
       )} to get a video-like reproduction of errors during a user session?`,
       enabledHint: 'recommended, but increases bundle size',
-    },
-    {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
     },
   ] as const);
 
@@ -1007,8 +999,6 @@ async function createOrMergeNextJsFiles(
       }
     }
   });
-
-  return { logsEnabled: selectedFeatures.logs };
 }
 
 function hasDirectoryPathFromRoot(dirnameOrDirs: string | string[]): boolean {
@@ -1024,7 +1014,6 @@ async function createExamplePage(
   selectedProject: SentryProjectData,
   sentryUrl: string,
   typeScriptDetected: boolean,
-  logsEnabled: boolean,
 ): Promise<void> {
   const hasSrcDirectory = hasDirectoryPathFromRoot('src');
   const hasRootAppDirectory = hasDirectoryPathFromRoot('app');
@@ -1094,7 +1083,6 @@ async function createExamplePage(
       sentryUrl,
       useClient: true,
       isTypeScript: typeScriptDetected,
-      logsEnabled,
     });
 
     fs.mkdirSync(path.join(appFolderPath, 'sentry-example-page'), {
@@ -1125,7 +1113,6 @@ async function createExamplePage(
       path.join(appFolderPath, 'api', 'sentry-example-api', newRouteFileName),
       getSentryExampleAppDirApiRoute({
         isTypeScript: typeScriptDetected,
-        logsEnabled,
       }),
       { encoding: 'utf8', flag: 'w' },
     );
@@ -1148,7 +1135,6 @@ async function createExamplePage(
       sentryUrl,
       useClient: false,
       isTypeScript: typeScriptDetected,
-      logsEnabled,
     });
 
     const examplePageFileName = `sentry-example-page.${
@@ -1179,7 +1165,6 @@ async function createExamplePage(
       path.join(process.cwd(), ...pagesFolderLocation, 'api', apiRouteFileName),
       getSentryExamplePagesDirApiRoute({
         isTypeScript: typeScriptDetected,
-        logsEnabled,
       }),
       { encoding: 'utf8', flag: 'w' },
     );

--- a/src/nextjs/templates.ts
+++ b/src/nextjs/templates.ts
@@ -135,7 +135,6 @@ export function getSentryServersideConfigContents(
   selectedFeaturesMap: {
     replay: boolean;
     performance: boolean;
-    logs: boolean;
   },
   spotlight = false,
 ): string {
@@ -159,14 +158,6 @@ export function getSentryServersideConfigContents(
   tracesSampleRate: 1,`;
   }
 
-  let logsOptions = '';
-  if (selectedFeaturesMap.logs) {
-    logsOptions += `
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`;
-  }
-
   const spotlightOptions = getSpotlightOption(spotlight);
 
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -175,7 +166,7 @@ export function getSentryServersideConfigContents(
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "${dsn}",${performanceOptions}${logsOptions}
+  dsn: "${dsn}",${performanceOptions}
 
   dataCollection: {
     // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -192,7 +183,6 @@ export function getInstrumentationClientFileContents(
   selectedFeaturesMap: {
     replay: boolean;
     performance: boolean;
-    logs: boolean;
   },
   spotlight = false,
 ): string {
@@ -222,13 +212,6 @@ export function getInstrumentationClientFileContents(
   tracesSampleRate: 1,`;
   }
 
-  let logsOptions = '';
-  if (selectedFeaturesMap.logs) {
-    logsOptions += `
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`;
-  }
-
   const spotlightOptions = getSpotlightOption(spotlight);
 
   return `// This file configures the initialization of Sentry on the client.
@@ -238,7 +221,7 @@ export function getInstrumentationClientFileContents(
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "${dsn}",${integrationsOptions}${performanceOptions}${logsOptions}${replayOptions}
+  dsn: "${dsn}",${integrationsOptions}${performanceOptions}${replayOptions}
 
   dataCollection: {
     // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -259,21 +242,16 @@ export function getSentryExamplePageContents(options: {
   projectId: string;
   useClient: boolean;
   isTypeScript?: boolean;
-  logsEnabled?: boolean;
 }): string {
   const issuesPageLink = options.selfHosted
     ? `${options.sentryUrl}organizations/${options.orgSlug}/issues/?project=${options.projectId}`
     : `https://${options.orgSlug}.sentry.io/issues/?project=${options.projectId}`;
 
-  const loggerPageLoad = options.logsEnabled
-    ? `
-    Sentry.logger.info("Sentry example page loaded");`
-    : '';
+  const loggerPageLoad = `
+    Sentry.logger.info("Sentry example page loaded");`;
 
-  const loggerUserAction = options.logsEnabled
-    ? `
-            Sentry.logger.info("User clicked the button, throwing a sample error");`
-    : '';
+  const loggerUserAction = `
+            Sentry.logger.info("User clicked the button, throwing a sample error");`;
 
   return `${
     options.useClient ? '"use client";\n\n' : ''
@@ -515,21 +493,15 @@ export default function Page() {
 
 export function getSentryExamplePagesDirApiRoute({
   isTypeScript,
-  logsEnabled,
 }: {
   isTypeScript: boolean;
-  logsEnabled?: boolean;
 }) {
-  const sentryImport = logsEnabled
-    ? `import * as Sentry from "@sentry/nextjs";
+  const sentryImport = `import * as Sentry from "@sentry/nextjs";
 
-`
-    : '';
+`;
 
-  const loggerCall = logsEnabled
-    ? `  Sentry.logger.info("Sentry example API called");
-`
-    : '';
+  const loggerCall = `  Sentry.logger.info("Sentry example API called");
+`;
 
   return `${sentryImport}// Custom error class for Sentry testing
 class SentryExampleAPIError extends Error {
@@ -548,20 +520,14 @@ res.status(200).json({ name: "John Doe" });
 
 export function getSentryExampleAppDirApiRoute({
   isTypeScript,
-  logsEnabled,
 }: {
   isTypeScript: boolean;
-  logsEnabled?: boolean;
 }) {
-  const sentryImport = logsEnabled
-    ? `import * as Sentry from "@sentry/nextjs";
-`
-    : '';
+  const sentryImport = `import * as Sentry from "@sentry/nextjs";
+`;
 
-  const loggerCall = logsEnabled
-    ? `
-  Sentry.logger.info("Sentry example API called");`
-    : '';
+  const loggerCall = `
+  Sentry.logger.info("Sentry example API called");`;
 
   // Note: We intentionally don't have a return statement after throw - it would be unreachable code
   // We also don't import NextResponse since we don't use it (Biome noUnusedImports rule)
@@ -718,7 +684,6 @@ export function getInstrumentationClientHookCopyPasteSnippet(
   selectedFeaturesMap: {
     replay: boolean;
     performance: boolean;
-    logs: boolean;
   },
   spotlight = false,
 ) {

--- a/src/nuxt/sdk-setup.ts
+++ b/src/nuxt/sdk-setup.ts
@@ -236,13 +236,6 @@ export async function createConfigFiles(dsn: string) {
       )} to get a video-like reproduction of errors during a user session?`,
       enabledHint: 'recommended, but increases bundle size',
     },
-    {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    },
   ] as const);
 
   const typeScriptDetected = isUsingTypeScript();

--- a/src/nuxt/templates.ts
+++ b/src/nuxt/templates.ts
@@ -3,7 +3,6 @@ import { getIssueStreamUrl } from '../utils/url';
 type SelectedSentryFeatures = {
   performance: boolean;
   replay: boolean;
-  logs: boolean;
 };
 
 export function getDefaultNuxtConfig(): string {
@@ -73,17 +72,14 @@ const featuresConfigMap: Record<keyof SelectedSentryFeatures, string> = {
     "  // If you don't want to use Session Replay, just remove the line below:",
     '  integrations: [Sentry.replayIntegration()],',
   ].join('\n'),
-  logs: ['  // Enable logs to be sent to Sentry', '  enableLogs: true,'].join(
-    '\n',
-  ),
 };
 
 const featuresMap: Record<
   'client' | 'server',
   Array<keyof SelectedSentryFeatures>
 > = {
-  client: ['performance', 'replay', 'logs'],
-  server: ['performance', 'logs'],
+  client: ['performance', 'replay'],
+  server: ['performance'],
 };
 
 export function getConfigBody(

--- a/src/react-router/codemods/client.entry.ts
+++ b/src/react-router/codemods/client.entry.ts
@@ -19,7 +19,6 @@ export async function instrumentClientEntry(
   dsn: string,
   enableTracing: boolean,
   enableReplay: boolean,
-  enableLogs: boolean,
   useInstrumentationAPI = false,
   useOnError = false,
 ): Promise<void> {
@@ -54,7 +53,6 @@ Sentry.init({
     // httpBodies: [],
   },
   integrations: [${integrations.join(', ')}],
-  ${enableLogs ? 'enableLogs: true,' : ''}
   tracesSampleRate: 1.0,
   tracePropagationTargets: [/^\\//, /^https:\\/\\/yourserver\\.io\\/api/],${
     enableReplay
@@ -81,7 +79,6 @@ Sentry.init({
     // httpBodies: [],
   },
   integrations: [${integrations.join(', ')}],
-  ${enableLogs ? 'enableLogs: true,' : ''}
   tracesSampleRate: ${enableTracing ? '1.0' : '0'},${
         enableTracing
           ? '\n  tracePropagationTargets: [/^\\//, /^https:\\/\\/yourserver\\.io\\/api/],'

--- a/src/react-router/react-router-wizard.ts
+++ b/src/react-router/react-router-wizard.ts
@@ -127,13 +127,6 @@ async function runReactRouterWizardWithTelemetry(
       enabledHint: 'recommended, but increases bundle size',
     },
     {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    },
-    {
       id: 'profiling',
       prompt: `Do you want to enable ${chalk.bold(
         'Profiling',
@@ -233,7 +226,6 @@ Please create your entry files manually using React Router v7 commands.`);
         selectedProject.keys[0].dsn.public,
         featureSelection.performance,
         featureSelection.replay,
-        featureSelection.logs,
         typeScriptDetected,
         useInstrumentationAPI,
         useOnError,
@@ -251,7 +243,6 @@ Please create your entry files manually using React Router v7 commands.`);
         selectedProject.keys[0].dsn.public,
         featureSelection.performance,
         featureSelection.replay,
-        featureSelection.logs,
         useInstrumentationAPI,
         useOnError,
       );
@@ -299,7 +290,6 @@ Please create your entry files manually using React Router v7 commands.`);
       createServerInstrumentationFile(selectedProject.keys[0].dsn.public, {
         performance: featureSelection.performance,
         replay: featureSelection.replay,
-        logs: featureSelection.logs,
         profiling: featureSelection.profiling,
       });
     } catch (e) {
@@ -311,7 +301,6 @@ Please create your entry files manually using React Router v7 commands.`);
         selectedProject.keys[0].dsn.public,
         featureSelection.performance,
         featureSelection.profiling,
-        featureSelection.logs,
       );
 
       await showCopyPasteInstructions({

--- a/src/react-router/sdk-setup.ts
+++ b/src/react-router/sdk-setup.ts
@@ -209,7 +209,6 @@ export async function initializeSentryOnEntryClient(
   dsn: string,
   enableTracing: boolean,
   enableReplay: boolean,
-  enableLogs: boolean,
   isTS: boolean,
   useInstrumentationAPI = false,
   useOnError = false,
@@ -224,7 +223,6 @@ export async function initializeSentryOnEntryClient(
     dsn,
     enableTracing,
     enableReplay,
-    enableLogs,
     useInstrumentationAPI,
     useOnError,
   );
@@ -239,7 +237,6 @@ export function createServerInstrumentationFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
     profiling: boolean;
   },
 ): string {
@@ -249,7 +246,6 @@ export function createServerInstrumentationFile(
     dsn,
     selectedFeatures.performance,
     selectedFeatures.profiling,
-    selectedFeatures.logs,
   );
 
   fs.writeFileSync(instrumentationPath, content);

--- a/src/react-router/templates.ts
+++ b/src/react-router/templates.ts
@@ -22,7 +22,6 @@ function generateServerInstrumentationCode(
   dsn: string,
   enableTracing: boolean,
   enableProfiling: boolean,
-  enableLogs: boolean,
 ): string {
   return `import * as Sentry from '@sentry/react-router';${
     enableProfiling
@@ -39,10 +38,8 @@ Sentry.init({
     // userInfo: false,
     // httpBodies: [],
   },${
-    enableLogs
-      ? '\n\n  // Enable logs to be sent to Sentry\n  enableLogs: true,'
-      : ''
-  }${enableProfiling ? '\n\n  integrations: [nodeProfilingIntegration()],' : ''}
+    enableProfiling ? '\n\n  integrations: [nodeProfilingIntegration()],' : ''
+  }
   tracesSampleRate: ${enableTracing ? '1.0' : '0'}, ${
     enableTracing ? '// Capture 100% of the transactions' : ''
   }${
@@ -73,21 +70,14 @@ export const getSentryInstrumentationServerContent = (
   dsn: string,
   enableTracing: boolean,
   enableProfiling = false,
-  enableLogs = false,
 ) => {
-  return generateServerInstrumentationCode(
-    dsn,
-    enableTracing,
-    enableProfiling,
-    enableLogs,
-  );
+  return generateServerInstrumentationCode(dsn, enableTracing, enableProfiling);
 };
 
 export const getManualClientEntryContent = (
   dsn: string,
   enableTracing: boolean,
   enableReplay: boolean,
-  enableLogs: boolean,
   useInstrumentationAPI = false,
   useOnError = false,
 ) => {
@@ -121,11 +111,7 @@ ${plus(`Sentry.init({
     ${integrationsStr}
   ],
 
-  ${
-    enableLogs
-      ? '// Enable logs to be sent to Sentry\n  enableLogs: true,\n\n  '
-      : ''
-  }tracesSampleRate: 1.0, //  Capture 100% of the transactions
+  tracesSampleRate: 1.0, //  Capture 100% of the transactions
 
   // Set \`tracePropagationTargets\` to declare which URL(s) should have trace propagation enabled
   // In production, replace "yourserver.io" with your actual backend domain
@@ -184,11 +170,7 @@ ${plus(`Sentry.init({
     ${integrationsStr}
   ],
 
-  ${
-    enableLogs
-      ? '// Enable logs to be sent to Sentry\n  enableLogs: true,\n\n  '
-      : ''
-  }tracesSampleRate: ${enableTracing ? '1.0' : '0'},${
+  tracesSampleRate: ${enableTracing ? '1.0' : '0'},${
   enableTracing ? ' //  Capture 100% of the transactions' : ''
 }${
   enableTracing
@@ -290,16 +272,10 @@ export const getManualServerInstrumentContent = (
   dsn: string,
   enableTracing: boolean,
   enableProfiling: boolean,
-  enableLogs = false,
 ) => {
   return makeCodeSnippet(true, (unchanged, plus) =>
     plus(
-      generateServerInstrumentationCode(
-        dsn,
-        enableTracing,
-        enableProfiling,
-        enableLogs,
-      ),
+      generateServerInstrumentationCode(dsn, enableTracing, enableProfiling),
     ),
   );
 };

--- a/src/remix/remix-wizard.ts
+++ b/src/remix/remix-wizard.ts
@@ -112,13 +112,6 @@ async function runRemixWizardWithTelemetry(
       )} to get a video-like reproduction of errors during a user session?`,
       enabledHint: 'recommended, but increases bundle size',
     },
-    {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    },
   ] as const);
 
   if (viteConfig) {

--- a/src/remix/sdk-setup.ts
+++ b/src/remix/sdk-setup.ts
@@ -73,7 +73,6 @@ interface SdkAstOptions {
   replaysSessionSampleRate?: number;
   replaysOnErrorSampleRate?: number;
   integrations?: Array<Proxified>;
-  enableLogs?: boolean;
 }
 
 function getInitCallArgs(
@@ -82,7 +81,6 @@ function getInitCallArgs(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ) {
   const initCallArgs: SdkAstOptions = {
@@ -92,11 +90,6 @@ function getInitCallArgs(
   // Adding tracing sample rate for both client and server
   if (selectedFeatures.performance) {
     initCallArgs.tracesSampleRate = 1.0;
-  }
-
-  // Adding logs for both client and server
-  if (selectedFeatures.logs) {
-    initCallArgs.enableLogs = true;
   }
 
   // Adding integrations and replay options only for client
@@ -139,7 +132,6 @@ function insertClientInitCall(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): void {
   const initCallArgs = getInitCallArgs(dsn, 'client', selectedFeatures);
@@ -163,7 +155,6 @@ export function generateServerInstrumentationFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ) {
   // create an empty file named `instrument.server.mjs`
@@ -201,7 +192,6 @@ export async function createServerInstrumentationFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ) {
   const { instrumentationFile, instrumentationFileMod } =
@@ -217,7 +207,6 @@ export async function insertServerInstrumentationFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ) {
   const instrumentationFile = await createServerInstrumentationFile(
@@ -372,7 +361,6 @@ export function updateEntryClientMod(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): ProxifiedModule<any> {
@@ -419,7 +407,6 @@ export async function initializeSentryOnEntryClient(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): Promise<void> {
   const clientEntryFilename = `entry.client.${isTS ? 'tsx' : 'jsx'}`;

--- a/src/sveltekit/sdk-setup/setup.ts
+++ b/src/sveltekit/sdk-setup/setup.ts
@@ -55,13 +55,6 @@ export async function createOrMergeSvelteKitFiles(
       )} to get a video-like reproduction of errors during a user session?`,
       enabledHint: 'recommended, but increases bundle size',
     },
-    {
-      id: 'logs',
-      prompt: `Do you want to enable ${chalk.bold(
-        'Logs',
-      )} to send your application logs to Sentry?`,
-      enabledHint: 'recommended',
-    },
   ] as const);
 
   const { clientHooksPath, serverHooksPath } = getHooksConfigDirs(svelteConfig);
@@ -205,7 +198,6 @@ async function createNewHooksFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
   setupForSvelteKitTracing: boolean,
 ): Promise<void> {
@@ -225,7 +217,6 @@ async function createNewInstrumentationServerFile(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ): Promise<void> {
   const filledTemplate = getInstrumentationServerTemplate(
@@ -271,7 +262,6 @@ async function mergeHooksFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
   includeSentryInit: boolean,
 ): Promise<void> {
@@ -362,7 +352,6 @@ async function mergeInstrumentationServerFile(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): Promise<void> {
   const originalInstrumentationServerMod = await loadFile(
@@ -435,7 +424,6 @@ export function insertClientInitCall(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ): void {
   const initCallComment = `
@@ -448,7 +436,6 @@ export function insertClientInitCall(
     replaysSessionSampleRate?: number;
     replaysOnErrorSampleRate?: number;
     integrations?: string[];
-    enableLogs?: boolean;
   } = {
     dsn,
   };
@@ -461,10 +448,6 @@ export function insertClientInitCall(
     initArgs.replaysSessionSampleRate = 0.1;
     initArgs.replaysOnErrorSampleRate = 1.0;
     initArgs.integrations = [builders.functionCall('Sentry.replayIntegration')];
-  }
-
-  if (selectedFeatures.logs) {
-    initArgs.enableLogs = true;
   }
 
   // This assignment of any values is fine because we're just creating a function call in magicast
@@ -503,23 +486,17 @@ function insertServerInitCall(
   originalMod: ProxifiedModule<any>,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ): void {
   const initArgs: {
     dsn: string;
     tracesSampleRate?: number;
-    enableLogs?: boolean;
   } = {
     dsn,
   };
 
   if (selectedFeatures.performance) {
     initArgs.tracesSampleRate = 1.0;
-  }
-
-  if (selectedFeatures.logs) {
-    initArgs.enableLogs = true;
   }
 
   // This assignment of any values is fine because we're just creating a function call in magicast

--- a/src/sveltekit/templates.ts
+++ b/src/sveltekit/templates.ts
@@ -3,7 +3,6 @@ export function getClientHooksTemplate(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
 ) {
   return `import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
@@ -15,13 +14,6 @@ ${
   selectedFeatures.performance
     ? `
   tracesSampleRate: 1.0,
-`
-    : ''
-}
-${
-  selectedFeatures.logs
-    ? `  // Enable logs to be sent to Sentry
-  enableLogs: true,
 `
     : ''
 }
@@ -58,7 +50,6 @@ export function getServerHooksTemplate(
   selectedFeatures: {
     performance: boolean;
     replay: boolean;
-    logs: boolean;
   },
   includeSentryInit: boolean,
 ) {
@@ -74,14 +65,6 @@ ${
 `
     : ''
 }
-${
-  selectedFeatures.logs
-    ? `  // Enable logs to be sent to Sentry
-  enableLogs: true,
-`
-    : ''
-}
-
   dataCollection: {
     // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
     // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
@@ -110,7 +93,6 @@ export function getInstrumentationServerTemplate(
   dsn: string,
   selectedFeatures: {
     performance: boolean;
-    logs: boolean;
   },
 ) {
   return `import * as Sentry from '@sentry/sveltekit';
@@ -123,15 +105,7 @@ ${
   tracesSampleRate: 1.0,
 `
     : ''
-}
-${
-  selectedFeatures.logs
-    ? `  // Enable logs to be sent to Sentry
-  enableLogs: true,
-`
-    : ''
-}
-  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+}  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: import.meta.env.DEV,
 });`;
 }

--- a/test/angular/angular-wizard.test.ts
+++ b/test/angular/angular-wizard.test.ts
@@ -34,12 +34,10 @@ describe('angular-wizard', () => {
       const args = getInitCallArgs('https://example.com', {
         performance: true,
         replay: true,
-        logs: true,
       });
       expect(args).toMatchInlineSnapshot(`
         {
           "dsn": "https://example.com",
-          "enableLogs": true,
           "integrations": [
             {},
             {},
@@ -55,13 +53,11 @@ describe('angular-wizard', () => {
       const args = getInitCallArgs('https://example.com', {
         performance: false,
         replay: true,
-        logs: true,
       });
 
       expect(args).toMatchInlineSnapshot(`
         {
           "dsn": "https://example.com",
-          "enableLogs": true,
           "integrations": [
             {},
           ],
@@ -75,26 +71,6 @@ describe('angular-wizard', () => {
       const args = getInitCallArgs('https://example.com', {
         performance: true,
         replay: false,
-        logs: true,
-      });
-
-      expect(args).toMatchInlineSnapshot(`
-        {
-          "dsn": "https://example.com",
-          "enableLogs": true,
-          "integrations": [
-            {},
-          ],
-          "tracesSampleRate": 1,
-        }
-      `);
-    });
-
-    it('returns the correct init call arguments when logs are disabled', () => {
-      const args = getInitCallArgs('https://example.com', {
-        performance: true,
-        replay: true,
-        logs: false,
       });
 
       expect(args).toMatchInlineSnapshot(`
@@ -102,10 +78,7 @@ describe('angular-wizard', () => {
           "dsn": "https://example.com",
           "integrations": [
             {},
-            {},
           ],
-          "replaysOnErrorSampleRate": 1,
-          "replaysSessionSampleRate": 0.1,
           "tracesSampleRate": 1,
         }
       `);
@@ -115,7 +88,6 @@ describe('angular-wizard', () => {
       const args = getInitCallArgs('https://example.com', {
         performance: false,
         replay: false,
-        logs: false,
       });
 
       expect(args).toMatchInlineSnapshot(`

--- a/test/cloudflare/__snapshots__/wrap-worker.test.ts.snap
+++ b/test/cloudflare/__snapshots__/wrap-worker.test.ts.snap
@@ -92,37 +92,6 @@ export default Sentry.withSentry(env => ({
 });"
 `;
 
-exports[`wrapWorkerWithSentry > logs > includes both tracesSampleRate and enableLogs when both are enabled 1`] = `
-"import * as Sentry from "@sentry/cloudflare";
-export default Sentry.withSentry(env => ({
-  dsn: "my-dsn",
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true
-}), {
-  async fetch(request, env, ctx): Promise<Response> {
-    return new Response('Hello');
-  }
-});"
-`;
-
-exports[`wrapWorkerWithSentry > logs > includes enableLogs when logs is enabled 1`] = `
-"import * as Sentry from "@sentry/cloudflare";
-export default Sentry.withSentry(env => ({
-  dsn: "my-dsn",
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true
-}), {
-  async fetch(request, env, ctx): Promise<Response> {
-    return new Response('Hello');
-  }
-});"
-`;
-
 exports[`wrapWorkerWithSentry > performance monitoring > includes tracesSampleRate when performance is enabled 1`] = `
 "import * as Sentry from "@sentry/cloudflare";
 export default Sentry.withSentry(env => ({

--- a/test/cloudflare/sdk-setup.test.ts
+++ b/test/cloudflare/sdk-setup.test.ts
@@ -55,7 +55,6 @@ describe('createSentryInitFile', () => {
   const testDsn = 'https://example@sentry.io/123';
   const testFeatures = {
     performance: true,
-    logs: false,
   };
 
   beforeEach(() => {
@@ -158,41 +157,26 @@ describe('createSentryInitFile', () => {
 
         await createSentryInitFile(testDsn, {
           performance: false,
-          logs: false,
         });
 
         expect(wrapWorkerWithSentrySpy).toHaveBeenCalledWith(
           path.join(tmpDir, defaultEntryPoint),
           testDsn,
-          { performance: false, logs: false },
+          { performance: false },
         );
       });
 
-      it('passes logs feature flag correctly', async () => {
+      it('passes performance feature flag when enabled', async () => {
         const wrapWorkerWithSentrySpy = vi
           .spyOn(wrapWorker, 'wrapWorkerWithSentry')
           .mockResolvedValue(undefined);
 
-        await createSentryInitFile(testDsn, { performance: false, logs: true });
+        await createSentryInitFile(testDsn, { performance: true });
 
         expect(wrapWorkerWithSentrySpy).toHaveBeenCalledWith(
           path.join(tmpDir, defaultEntryPoint),
           testDsn,
-          { performance: false, logs: true },
-        );
-      });
-
-      it('passes both feature flags correctly', async () => {
-        const wrapWorkerWithSentrySpy = vi
-          .spyOn(wrapWorker, 'wrapWorkerWithSentry')
-          .mockResolvedValue(undefined);
-
-        await createSentryInitFile(testDsn, { performance: true, logs: true });
-
-        expect(wrapWorkerWithSentrySpy).toHaveBeenCalledWith(
-          path.join(tmpDir, defaultEntryPoint),
-          testDsn,
-          { performance: true, logs: true },
+          { performance: true },
         );
       });
     });

--- a/test/cloudflare/templates.test.ts
+++ b/test/cloudflare/templates.test.ts
@@ -6,7 +6,6 @@ describe('Cloudflare code templates', () => {
     it('generates worker template with performance monitoring enabled', () => {
       const template = getCloudflareWorkerTemplate('my-dsn', {
         performance: true,
-        logs: false,
       });
 
       expect(template).toMatchInlineSnapshot(`
@@ -32,7 +31,6 @@ describe('Cloudflare code templates', () => {
     it('generates worker template with performance monitoring disabled', () => {
       const template = getCloudflareWorkerTemplate('my-dsn', {
         performance: false,
-        logs: false,
       });
 
       expect(template).toMatchInlineSnapshot(`
@@ -41,60 +39,6 @@ describe('Cloudflare code templates', () => {
         export default Sentry.withSentry(
         	(env) => ({
         		dsn: 'my-dsn',
-        	}),
-        	{
-        		async fetch(request, env, ctx): Promise<Response> {
-        			// Your worker logic here
-        			return new Response('Hello World!');
-        		},
-        	} satisfies ExportedHandler<Env>,
-        );
-        "
-      `);
-    });
-
-    it('generates worker template with logs enabled', () => {
-      const template = getCloudflareWorkerTemplate('my-dsn', {
-        performance: false,
-        logs: true,
-      });
-
-      expect(template).toMatchInlineSnapshot(`
-        "import * as Sentry from '@sentry/cloudflare';
-
-        export default Sentry.withSentry(
-        	(env) => ({
-        		dsn: 'my-dsn',
-        		// Enable logs to be sent to Sentry
-        		enableLogs: true,
-        	}),
-        	{
-        		async fetch(request, env, ctx): Promise<Response> {
-        			// Your worker logic here
-        			return new Response('Hello World!');
-        		},
-        	} satisfies ExportedHandler<Env>,
-        );
-        "
-      `);
-    });
-
-    it('generates worker template with both performance and logs enabled', () => {
-      const template = getCloudflareWorkerTemplate('my-dsn', {
-        performance: true,
-        logs: true,
-      });
-
-      expect(template).toMatchInlineSnapshot(`
-        "import * as Sentry from '@sentry/cloudflare';
-
-        export default Sentry.withSentry(
-        	(env) => ({
-        		dsn: 'my-dsn',
-        		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-        		tracesSampleRate: 1,
-        		// Enable logs to be sent to Sentry
-        		enableLogs: true,
         	}),
         	{
         		async fetch(request, env, ctx): Promise<Response> {
@@ -111,7 +55,6 @@ describe('Cloudflare code templates', () => {
       const dsn = 'https://example@sentry.io/123';
       const template = getCloudflareWorkerTemplate(dsn, {
         performance: true,
-        logs: false,
       });
 
       expect(template).toContain(`dsn: '${dsn}'`);
@@ -120,7 +63,6 @@ describe('Cloudflare code templates', () => {
     it('wraps handler with Sentry.withSentry', () => {
       const template = getCloudflareWorkerTemplate('my-dsn', {
         performance: false,
-        logs: false,
       });
 
       expect(template).toContain('Sentry.withSentry');

--- a/test/cloudflare/wrap-worker.test.ts
+++ b/test/cloudflare/wrap-worker.test.ts
@@ -42,7 +42,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-test-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -55,7 +54,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -70,7 +68,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: true,
-        logs: false,
       });
 
       const result = readResult();
@@ -83,48 +80,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
-      });
-
-      const result = readResult();
-
-      expect(result).toMatchSnapshot();
-    });
-  });
-
-  describe('logs', () => {
-    it('includes enableLogs when logs is enabled', async () => {
-      const filePath = copyFixture('simple.ts');
-
-      await wrapWorkerWithSentry(filePath, 'my-dsn', {
-        performance: false,
-        logs: true,
-      });
-
-      const result = readResult();
-
-      expect(result).toMatchSnapshot();
-    });
-
-    it('omits enableLogs when logs is disabled', async () => {
-      const filePath = copyFixture('simple.ts');
-
-      await wrapWorkerWithSentry(filePath, 'my-dsn', {
-        performance: false,
-        logs: false,
-      });
-
-      const result = readResult();
-
-      expect(result).not.toContain('enableLogs');
-    });
-
-    it('includes both tracesSampleRate and enableLogs when both are enabled', async () => {
-      const filePath = copyFixture('simple.ts');
-
-      await wrapWorkerWithSentry(filePath, 'my-dsn', {
-        performance: true,
-        logs: true,
       });
 
       const result = readResult();
@@ -139,7 +94,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -152,7 +106,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -165,7 +118,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -184,7 +136,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'new-dsn', {
         performance: true,
-        logs: false,
       });
 
       const result = readResult();
@@ -201,7 +152,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -219,7 +169,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, testDsn, {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -234,7 +183,6 @@ describe('wrapWorkerWithSentry', () => {
 
       await wrapWorkerWithSentry(filePath, 'my-dsn', {
         performance: false,
-        logs: false,
       });
 
       const result = readResult();
@@ -248,7 +196,6 @@ describe('wrapWorkerWithSentry', () => {
       await expect(
         wrapWorkerWithSentry(filePath, 'my-dsn', {
           performance: false,
-          logs: false,
         }),
       ).resolves.not.toThrow();
 

--- a/test/nextjs/templates.test.ts
+++ b/test/nextjs/templates.test.ts
@@ -17,7 +17,6 @@ describe('Next.js code templates', () => {
       const template = getInstrumentationClientFileContents('my-dsn', {
         performance: true,
         replay: true,
-        logs: true,
       });
 
       expect(template).toMatchInlineSnapshot(`
@@ -35,8 +34,6 @@ describe('Next.js code templates', () => {
 
           // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
           tracesSampleRate: 1,
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
 
           // Define how likely Replay events are sampled.
           // This sets the sample rate to be 10%. You may want this to be 100% while
@@ -63,7 +60,6 @@ describe('Next.js code templates', () => {
       const template = getInstrumentationClientFileContents('my-dsn', {
         performance: false,
         replay: true,
-        logs: true,
       });
 
       expect(template).toMatchInlineSnapshot(`
@@ -78,8 +74,6 @@ describe('Next.js code templates', () => {
 
           // Add optional integrations for additional features
           integrations: [Sentry.replayIntegration()],
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
 
           // Define how likely Replay events are sampled.
           // This sets the sample rate to be 10%. You may want this to be 100% while
@@ -106,7 +100,6 @@ describe('Next.js code templates', () => {
       const template = getInstrumentationClientFileContents('my-dsn', {
         performance: true,
         replay: false,
-        logs: true,
       });
 
       expect(template).toMatchInlineSnapshot(`
@@ -121,52 +114,6 @@ describe('Next.js code templates', () => {
 
           // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
           tracesSampleRate: 1,
-          // Enable logs to be sent to Sentry
-          enableLogs: true,
-
-          dataCollection: {
-            // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-            // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-            // userInfo: false,
-            // httpBodies: [],
-          },
-        });
-
-        export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
-        "
-      `);
-    });
-
-    it('generates client-side Sentry config with logs disabled', () => {
-      const template = getInstrumentationClientFileContents('my-dsn', {
-        performance: true,
-        replay: true,
-        logs: false,
-      });
-
-      expect(template).toMatchInlineSnapshot(`
-        "// This file configures the initialization of Sentry on the client.
-        // The added config here will be used whenever a users loads a page in their browser.
-        // https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-        import * as Sentry from "@sentry/nextjs";
-
-        Sentry.init({
-          dsn: "my-dsn",
-
-          // Add optional integrations for additional features
-          integrations: [Sentry.replayIntegration()],
-
-          // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-          tracesSampleRate: 1,
-
-          // Define how likely Replay events are sampled.
-          // This sets the sample rate to be 10%. You may want this to be 100% while
-          // in development and sample at a lower rate in production
-          replaysSessionSampleRate: 0.1,
-
-          // Define how likely Replay events are sampled when an error occurs.
-          replaysOnErrorSampleRate: 1.0,
 
           dataCollection: {
             // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -186,7 +133,6 @@ describe('Next.js code templates', () => {
         {
           performance: true,
           replay: false,
-          logs: false,
         },
         true, // spotlight
       );
@@ -203,7 +149,6 @@ describe('Next.js code templates', () => {
         const template = getSentryServersideConfigContents('my-dsn', 'server', {
           performance: true,
           replay: true,
-          logs: true,
         });
 
         expect(template).toMatchInlineSnapshot(`
@@ -218,9 +163,6 @@ describe('Next.js code templates', () => {
 
             // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
             tracesSampleRate: 1,
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -237,7 +179,6 @@ describe('Next.js code templates', () => {
         const template = getSentryServersideConfigContents('my-dsn', 'server', {
           performance: false,
           replay: true,
-          logs: true,
         });
 
         expect(template).toMatchInlineSnapshot(`
@@ -249,9 +190,6 @@ describe('Next.js code templates', () => {
 
           Sentry.init({
             dsn: "my-dsn",
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -268,41 +206,6 @@ describe('Next.js code templates', () => {
         const template = getSentryServersideConfigContents('my-dsn', 'server', {
           performance: true,
           replay: true,
-          logs: true,
-        });
-
-        expect(template).toMatchInlineSnapshot(`
-          "// This file configures the initialization of Sentry on the server.
-          // The config you add here will be used whenever the server handles a request.
-          // https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-          import * as Sentry from "@sentry/nextjs";
-
-          Sentry.init({
-            dsn: "my-dsn",
-
-            // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-            tracesSampleRate: 1,
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
-
-            dataCollection: {
-              // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-              // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-              // userInfo: false,
-              // httpBodies: [],
-            },
-          });
-          "
-        `);
-      });
-
-      it('generates server-side Sentry config with logs disabled', () => {
-        const template = getSentryServersideConfigContents('my-dsn', 'server', {
-          performance: true,
-          replay: true,
-          logs: false,
         });
 
         expect(template).toMatchInlineSnapshot(`
@@ -336,7 +239,6 @@ describe('Next.js code templates', () => {
           {
             performance: true,
             replay: false,
-            logs: false,
           },
           true, // spotlight
         );
@@ -352,7 +254,6 @@ describe('Next.js code templates', () => {
         const template = getSentryServersideConfigContents('my-dsn', 'edge', {
           performance: true,
           replay: true,
-          logs: true,
         });
 
         expect(template).toMatchInlineSnapshot(`
@@ -368,9 +269,6 @@ describe('Next.js code templates', () => {
 
             // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
             tracesSampleRate: 1,
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -387,7 +285,6 @@ describe('Next.js code templates', () => {
         const template = getSentryServersideConfigContents('my-dsn', 'edge', {
           performance: false,
           replay: true,
-          logs: true,
         });
 
         expect(template).toMatchInlineSnapshot(`
@@ -400,41 +297,6 @@ describe('Next.js code templates', () => {
 
           Sentry.init({
             dsn: "my-dsn",
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
-
-            dataCollection: {
-              // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-              // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
-              // userInfo: false,
-              // httpBodies: [],
-            },
-          });
-          "
-        `);
-      });
-
-      it('generates edge Sentry config with logs disabled', () => {
-        const template = getSentryServersideConfigContents('my-dsn', 'edge', {
-          performance: true,
-          replay: true,
-          logs: false,
-        });
-
-        expect(template).toMatchInlineSnapshot(`
-          "// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
-          // The config you add here will be used whenever one of the edge features is loaded.
-          // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
-          // https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-          import * as Sentry from "@sentry/nextjs";
-
-          Sentry.init({
-            dsn: "my-dsn",
-
-            // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-            tracesSampleRate: 1,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -805,7 +667,7 @@ describe('Next.js code templates', () => {
       );
     });
 
-    it('generates example page with logger calls when logsEnabled is true', () => {
+    it('generates example page with logger calls', () => {
       const template = getSentryExamplePageContents({
         selfHosted: false,
         sentryUrl: 'https://sentry.io',
@@ -813,7 +675,6 @@ describe('Next.js code templates', () => {
         projectId: '123',
         useClient: true,
         isTypeScript: true,
-        logsEnabled: true,
       });
 
       expect(template).toContain(
@@ -822,20 +683,6 @@ describe('Next.js code templates', () => {
       expect(template).toContain(
         'Sentry.logger.info("User clicked the button, throwing a sample error")',
       );
-    });
-
-    it('generates example page without logger calls when logsEnabled is false', () => {
-      const template = getSentryExamplePageContents({
-        selfHosted: false,
-        sentryUrl: 'https://sentry.io',
-        orgSlug: 'my-org',
-        projectId: '123',
-        useClient: true,
-        isTypeScript: true,
-        logsEnabled: false,
-      });
-
-      expect(template).not.toContain('Sentry.logger.info');
     });
   });
 
@@ -860,28 +707,15 @@ describe('Next.js code templates', () => {
       expect(template).toContain('export default function handler(_req, res)');
     });
 
-    it('generates Pages Router API route with logger calls when logsEnabled is true', () => {
+    it('generates Pages Router API route with logger calls', () => {
       const template = getSentryExamplePagesDirApiRoute({
         isTypeScript: true,
-        logsEnabled: true,
       });
 
       expect(template).toContain('import * as Sentry from "@sentry/nextjs";');
       expect(template).toContain(
         'Sentry.logger.info("Sentry example API called")',
       );
-    });
-
-    it('generates Pages Router API route without logger calls when logsEnabled is false', () => {
-      const template = getSentryExamplePagesDirApiRoute({
-        isTypeScript: true,
-        logsEnabled: false,
-      });
-
-      expect(template).not.toContain(
-        'import * as Sentry from "@sentry/nextjs"',
-      );
-      expect(template).not.toContain('Sentry.logger.info');
     });
   });
 
@@ -908,25 +742,15 @@ describe('Next.js code templates', () => {
       expect(template).toContain('export const dynamic = "force-dynamic";');
     });
 
-    it('generates App Router API route with logger calls when logsEnabled is true', () => {
+    it('generates App Router API route with logger calls', () => {
       const template = getSentryExampleAppDirApiRoute({
         isTypeScript: true,
-        logsEnabled: true,
       });
 
       expect(template).toContain('import * as Sentry from "@sentry/nextjs";');
       expect(template).toContain(
         'Sentry.logger.info("Sentry example API called")',
       );
-    });
-
-    it('generates App Router API route without logger calls when logsEnabled is false', () => {
-      const template = getSentryExampleAppDirApiRoute({
-        isTypeScript: true,
-        logsEnabled: false,
-      });
-
-      expect(template).not.toContain('Sentry.logger.info');
     });
   });
 });

--- a/test/nuxt/templates.test.ts
+++ b/test/nuxt/templates.test.ts
@@ -32,7 +32,6 @@ describe('Nuxt code templates', () => {
           {
             performance: true,
             replay: true,
-            logs: true,
           },
         );
 
@@ -58,9 +57,6 @@ describe('Nuxt code templates', () => {
             
             // If you don't want to use Session Replay, just remove the line below:
             integrations: [Sentry.replayIntegration()],
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -83,7 +79,6 @@ describe('Nuxt code templates', () => {
           {
             performance: false,
             replay: true,
-            logs: true,
           },
         );
 
@@ -105,9 +100,6 @@ describe('Nuxt code templates', () => {
             
             // If you don't want to use Session Replay, just remove the line below:
             integrations: [Sentry.replayIntegration()],
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -130,7 +122,6 @@ describe('Nuxt code templates', () => {
           {
             performance: true,
             replay: false,
-            logs: true,
           },
         );
 
@@ -145,57 +136,6 @@ describe('Nuxt code templates', () => {
             // We recommend adjusting this value in production, or using tracesSampler
             // for finer control
             tracesSampleRate: 1.0,
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
-
-            dataCollection: {
-              // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-              // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection
-              // userInfo: false,
-              // httpBodies: [],
-            },
-
-            // Setting this option to true will print useful information to the console while you're setting up Sentry.
-            debug: false,
-          });
-          "
-        `);
-      });
-
-      it('generates Sentry config with logs disabled', () => {
-        const template = getSentryConfigContents(
-          'https://sentry.io/123',
-          'client',
-          {
-            performance: true,
-            replay: true,
-            logs: false,
-          },
-        );
-
-        expect(template).toMatchInlineSnapshot(`
-          "import * as Sentry from "@sentry/nuxt";
-
-          Sentry.init({
-            // If set up, you can use your runtime config here
-            // dsn: useRuntimeConfig().public.sentry.dsn,
-            dsn: "https://sentry.io/123",
-
-            // We recommend adjusting this value in production, or using tracesSampler
-            // for finer control
-            tracesSampleRate: 1.0,
-
-            // This sets the sample rate to be 10%. You may want this to be 100% while
-            // in development and sample at a lower rate in production
-            replaysSessionSampleRate: 0.1,
-            
-            // If the entire session is not sampled, use the below sample rate to sample
-            // sessions when an error occurs.
-            replaysOnErrorSampleRate: 1.0,
-            
-            // If you don't want to use Session Replay, just remove the line below:
-            integrations: [Sentry.replayIntegration()],
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -218,7 +158,6 @@ describe('Nuxt code templates', () => {
           {
             performance: false,
             replay: false,
-            logs: true,
           },
         );
 
@@ -229,9 +168,6 @@ describe('Nuxt code templates', () => {
             // If set up, you can use your runtime config here
             // dsn: useRuntimeConfig().public.sentry.dsn,
             dsn: "https://sentry.io/123",
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -254,7 +190,6 @@ describe('Nuxt code templates', () => {
           {
             performance: false,
             replay: false,
-            logs: false,
           },
         );
 
@@ -289,7 +224,6 @@ describe('Nuxt code templates', () => {
           {
             performance: true,
             replay: true,
-            logs: true,
           },
         );
 
@@ -302,9 +236,6 @@ describe('Nuxt code templates', () => {
             // We recommend adjusting this value in production, or using tracesSampler
             // for finer control
             tracesSampleRate: 1.0,
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -327,7 +258,6 @@ describe('Nuxt code templates', () => {
           {
             performance: false,
             replay: true,
-            logs: true,
           },
         );
 
@@ -336,44 +266,6 @@ describe('Nuxt code templates', () => {
            
           Sentry.init({
             dsn: "https://sentry.io/123",
-
-            // Enable logs to be sent to Sentry
-            enableLogs: true,
-
-            dataCollection: {
-              // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-              // https://docs.sentry.io/platforms/javascript/guides/nuxt/configuration/options/#dataCollection
-              // userInfo: false,
-              // httpBodies: [],
-            },
-
-            // Setting this option to true will print useful information to the console while you're setting up Sentry.
-            debug: false,
-          });
-          "
-        `);
-      });
-
-      it('generates Sentry config with logs disabled', () => {
-        const template = getSentryConfigContents(
-          'https://sentry.io/123',
-          'server',
-          {
-            performance: true,
-            replay: true,
-            logs: false,
-          },
-        );
-
-        expect(template).toMatchInlineSnapshot(`
-          "import * as Sentry from "@sentry/nuxt";
-           
-          Sentry.init({
-            dsn: "https://sentry.io/123",
-
-            // We recommend adjusting this value in production, or using tracesSampler
-            // for finer control
-            tracesSampleRate: 1.0,
 
             dataCollection: {
               // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -396,7 +288,6 @@ describe('Nuxt code templates', () => {
           {
             performance: false,
             replay: false,
-            logs: false,
           },
         );
 

--- a/test/react-router/codemods/client-entry.test.ts
+++ b/test/react-router/codemods/client-entry.test.ts
@@ -52,15 +52,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, basicContent);
 
-    await instrumentClientEntry(
-      tmpFile,
-      'test-dsn',
-      true,
-      true,
-      true,
-      false,
-      true,
-    );
+    await instrumentClientEntry(tmpFile, 'test-dsn', true, true, false, true);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -72,7 +64,6 @@ describe('instrumentClientEntry', () => {
     expect(modifiedContent).toContain('integrations: [');
     expect(modifiedContent).toContain('Sentry.reactRouterTracingIntegration()');
     expect(modifiedContent).toContain('Sentry.replayIntegration(');
-    expect(modifiedContent).toContain('enableLogs: true');
     expect(modifiedContent).toContain('onError={Sentry.sentryOnError}');
   });
 
@@ -84,7 +75,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, basicContent);
 
-    await instrumentClientEntry(tmpFile, 'test-dsn', true, false, false);
+    await instrumentClientEntry(tmpFile, 'test-dsn', true, false);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -96,7 +87,6 @@ describe('instrumentClientEntry', () => {
     expect(modifiedContent).toContain('integrations: [');
     expect(modifiedContent).toContain('Sentry.reactRouterTracingIntegration()');
     expect(modifiedContent).not.toContain('Sentry.replayIntegration()');
-    expect(modifiedContent).not.toContain('enableLogs: true');
   });
 
   it('should add Sentry initialization with only replay enabled', async () => {
@@ -107,7 +97,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, basicContent);
 
-    await instrumentClientEntry(tmpFile, 'test-dsn', false, true, false);
+    await instrumentClientEntry(tmpFile, 'test-dsn', false, true);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -121,32 +111,6 @@ describe('instrumentClientEntry', () => {
       'Sentry.reactRouterTracingIntegration()',
     );
     expect(modifiedContent).toContain('Sentry.replayIntegration(');
-    expect(modifiedContent).not.toContain('enableLogs: true');
-  });
-
-  it('should add Sentry initialization with only logs enabled', async () => {
-    const basicContent = fs.readFileSync(
-      path.join(fixturesDir, 'basic.tsx'),
-      'utf8',
-    );
-
-    fs.writeFileSync(tmpFile, basicContent);
-
-    await instrumentClientEntry(tmpFile, 'test-dsn', false, false, true);
-
-    const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
-
-    expect(modifiedContent).toContain(
-      'import * as Sentry from "@sentry/react-router";',
-    );
-    expect(modifiedContent).toContain('Sentry.init({');
-    expect(modifiedContent).toContain('dsn: "test-dsn"');
-    expect(modifiedContent).toContain('integrations: [');
-    expect(modifiedContent).not.toContain(
-      'Sentry.reactRouterTracingIntegration()',
-    );
-    expect(modifiedContent).not.toContain('Sentry.replayIntegration()');
-    expect(modifiedContent).toContain('enableLogs: true');
   });
 
   it('should add minimal Sentry initialization when all features are disabled', async () => {
@@ -157,7 +121,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, basicContent);
 
-    await instrumentClientEntry(tmpFile, 'test-dsn', false, false, false);
+    await instrumentClientEntry(tmpFile, 'test-dsn', false, false);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -171,7 +135,6 @@ describe('instrumentClientEntry', () => {
       'Sentry.reactRouterTracingIntegration()',
     );
     expect(modifiedContent).not.toContain('Sentry.replayIntegration()');
-    expect(modifiedContent).not.toContain('enableLogs: true');
   });
 
   it('should not add Sentry.init when Sentry content already exists but still add onError', async () => {
@@ -182,15 +145,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, withSentryContent);
 
-    await instrumentClientEntry(
-      tmpFile,
-      'test-dsn',
-      true,
-      true,
-      true,
-      false,
-      true,
-    );
+    await instrumentClientEntry(tmpFile, 'test-dsn', true, true, false, true);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -210,7 +165,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, withImportsContent);
 
-    await instrumentClientEntry(tmpFile, 'test-dsn', true, false, false);
+    await instrumentClientEntry(tmpFile, 'test-dsn', true, false);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -235,7 +190,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, noImportsContent);
 
-    await instrumentClientEntry(tmpFile, 'test-dsn', false, true, false);
+    await instrumentClientEntry(tmpFile, 'test-dsn', false, true);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -254,7 +209,7 @@ describe('instrumentClientEntry', () => {
 
     fs.writeFileSync(tmpFile, complexContent);
 
-    await instrumentClientEntry(tmpFile, 'test-dsn', true, true, false);
+    await instrumentClientEntry(tmpFile, 'test-dsn', true, true);
 
     const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -278,14 +233,7 @@ describe('instrumentClientEntry', () => {
 
       fs.writeFileSync(tmpFile, basicContent);
 
-      await instrumentClientEntry(
-        tmpFile,
-        'test-dsn',
-        true,
-        false,
-        false,
-        true,
-      );
+      await instrumentClientEntry(tmpFile, 'test-dsn', true, false, true);
 
       const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -306,7 +254,7 @@ describe('instrumentClientEntry', () => {
 
       fs.writeFileSync(tmpFile, basicContent);
 
-      await instrumentClientEntry(tmpFile, 'test-dsn', true, true, false, true);
+      await instrumentClientEntry(tmpFile, 'test-dsn', true, true, true);
 
       const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 
@@ -329,14 +277,7 @@ describe('instrumentClientEntry', () => {
 
       fs.writeFileSync(tmpFile, basicContent);
 
-      await instrumentClientEntry(
-        tmpFile,
-        'test-dsn',
-        true,
-        false,
-        false,
-        false,
-      );
+      await instrumentClientEntry(tmpFile, 'test-dsn', true, false, false);
 
       const modifiedContent = fs.readFileSync(tmpFile, 'utf8');
 

--- a/test/react-router/sdk-setup.test.ts
+++ b/test/react-router/sdk-setup.test.ts
@@ -312,36 +312,30 @@ describe('React Router SDK Setup', () => {
       const dsn = 'https://sentry.io/123';
       const enableTracing = true;
       const enableProfiling = false;
-      const enableLogs = true;
 
       const result = getSentryInstrumentationServerContent(
         dsn,
         enableTracing,
         enableProfiling,
-        enableLogs,
       );
 
       expect(result).toContain('dsn: "https://sentry.io/123"');
       expect(result).toContain('tracesSampleRate: 1');
-      expect(result).toContain('enableLogs: true');
     });
 
     it('should generate server instrumentation file when performance is disabled', () => {
       const dsn = 'https://sentry.io/123';
       const enableTracing = false;
       const enableProfiling = false;
-      const enableLogs = false;
 
       const result = getSentryInstrumentationServerContent(
         dsn,
         enableTracing,
         enableProfiling,
-        enableLogs,
       );
 
       expect(result).toContain('dsn: "https://sentry.io/123"');
       expect(result).toContain('tracesSampleRate: 0');
-      expect(result).not.toContain('enableLogs: true');
     });
   });
 });
@@ -391,7 +385,6 @@ describe('server instrumentation helpers', () => {
     const path = createServerInstrumentationFile('https://sentry.io/123', {
       performance: true,
       replay: false,
-      logs: true,
       profiling: false,
     });
 

--- a/test/react-router/templates.test.ts
+++ b/test/react-router/templates.test.ts
@@ -75,14 +75,7 @@ describe('React Router Templates', () => {
     it('should generate manual client entry with all features enabled and onError', () => {
       const dsn = 'https://test.sentry.io/123';
 
-      const result = getManualClientEntryContent(
-        dsn,
-        true,
-        true,
-        true,
-        false,
-        true,
-      );
+      const result = getManualClientEntryContent(dsn, true, true, false, true);
 
       expect(result).toContain(
         "+ import * as Sentry from '@sentry/react-router'",
@@ -91,7 +84,6 @@ describe('React Router Templates', () => {
       expect(result).toContain('// httpBodies: [],');
       expect(result).toContain('Sentry.reactRouterTracingIntegration()');
       expect(result).toContain('Sentry.replayIntegration()');
-      expect(result).toContain('enableLogs: true');
       expect(result).toContain('tracesSampleRate: 1.0');
       expect(result).toContain('replaysSessionSampleRate: 0.1');
       expect(result).toContain('replaysOnErrorSampleRate: 1.0');
@@ -102,7 +94,7 @@ describe('React Router Templates', () => {
     it('should not include onError when useOnError is false', () => {
       const dsn = 'https://test.sentry.io/123';
 
-      const result = getManualClientEntryContent(dsn, true, true, true);
+      const result = getManualClientEntryContent(dsn, true, true);
 
       expect(result).not.toContain('onError={Sentry.sentryOnError}');
     });
@@ -111,20 +103,17 @@ describe('React Router Templates', () => {
       const dsn = 'https://test.sentry.io/123';
       const enableTracing = false;
       const enableReplay = true;
-      const enableLogs = false;
 
       const result = getManualClientEntryContent(
         dsn,
         enableTracing,
         enableReplay,
-        enableLogs,
       );
 
       expect(result).toContain(`dsn: "${dsn}"`);
       expect(result).toContain('tracesSampleRate: 0');
       expect(result).not.toContain('Sentry.reactRouterTracingIntegration()');
       expect(result).toContain('Sentry.replayIntegration()');
-      expect(result).not.toContain('enableLogs: true');
       expect(result).not.toContain('tracePropagationTargets');
     });
 
@@ -132,20 +121,17 @@ describe('React Router Templates', () => {
       const dsn = 'https://test.sentry.io/123';
       const enableTracing = true;
       const enableReplay = false;
-      const enableLogs = true;
 
       const result = getManualClientEntryContent(
         dsn,
         enableTracing,
         enableReplay,
-        enableLogs,
       );
 
       expect(result).toContain(`dsn: "${dsn}"`);
       expect(result).toContain('tracesSampleRate: 1.0');
       expect(result).toContain('Sentry.reactRouterTracingIntegration()');
       expect(result).not.toContain('Sentry.replayIntegration()');
-      expect(result).toContain('enableLogs: true');
       expect(result).not.toContain('replaysSessionSampleRate');
       expect(result).not.toContain('replaysOnErrorSampleRate');
     });
@@ -154,20 +140,17 @@ describe('React Router Templates', () => {
       const dsn = 'https://test.sentry.io/123';
       const enableTracing = false;
       const enableReplay = false;
-      const enableLogs = false;
 
       const result = getManualClientEntryContent(
         dsn,
         enableTracing,
         enableReplay,
-        enableLogs,
       );
 
       expect(result).toContain(`dsn: "${dsn}"`);
       expect(result).toContain('tracesSampleRate: 0');
       expect(result).not.toContain('Sentry.reactRouterTracingIntegration()');
       expect(result).not.toContain('Sentry.replayIntegration()');
-      expect(result).not.toContain('enableLogs: true');
       expect(result).toContain('integrations: [');
     });
 
@@ -178,7 +161,6 @@ describe('React Router Templates', () => {
         const result = getManualClientEntryContent(
           dsn,
           true,
-          false,
           false,
           true,
           true,
@@ -198,14 +180,7 @@ describe('React Router Templates', () => {
       it('should generate client entry with instrumentation API and replay enabled', () => {
         const dsn = 'https://test.sentry.io/123';
 
-        const result = getManualClientEntryContent(
-          dsn,
-          true,
-          true,
-          false,
-          true,
-          true,
-        );
+        const result = getManualClientEntryContent(dsn, true, true, true, true);
 
         expect(result).toContain(
           'const tracing = Sentry.reactRouterTracingIntegration();',
@@ -224,7 +199,6 @@ describe('React Router Templates', () => {
         const result = getManualClientEntryContent(
           dsn,
           true,
-          false,
           false,
           false,
           true,
@@ -288,13 +262,11 @@ describe('React Router Templates', () => {
       const dsn = 'https://test.sentry.io/123';
       const enableTracing = true;
       const enableProfiling = true;
-      const enableLogs = true;
 
       const result = getManualServerInstrumentContent(
         dsn,
         enableTracing,
         enableProfiling,
-        enableLogs,
       );
 
       expect(result).toContain(
@@ -305,7 +277,6 @@ describe('React Router Templates', () => {
       );
       expect(result).toContain(`dsn: "${dsn}"`);
       expect(result).toContain('// httpBodies: [],');
-      expect(result).toContain('enableLogs: true');
       expect(result).toContain('integrations: [nodeProfilingIntegration()]');
       expect(result).toContain('tracesSampleRate: 1.0');
       expect(result).toContain('profilesSampleRate: 1.0');
@@ -331,21 +302,17 @@ describe('React Router Templates', () => {
       expect(result).not.toContain(
         'integrations: [nodeProfilingIntegration()]',
       );
-      // When logs are not enabled, enableLogs should not appear
-      expect(result).not.toContain('enableLogs: true');
     });
 
     it('should generate server instrumentation with profiling disabled but tracing enabled', () => {
       const dsn = 'https://test.sentry.io/123';
       const enableTracing = true;
       const enableProfiling = false;
-      const enableLogs = false;
 
       const result = getManualServerInstrumentContent(
         dsn,
         enableTracing,
         enableProfiling,
-        enableLogs,
       );
 
       expect(result).toContain(`dsn: "${dsn}"`);

--- a/test/remix/client-entry.test.ts
+++ b/test/remix/client-entry.test.ts
@@ -12,7 +12,6 @@ describe('initializeSentryOnEntryClient', () => {
     const selectedFeatures = {
       performance: true,
       replay: true,
-      logs: true,
     };
 
     const result = updateEntryClientMod(
@@ -34,7 +33,6 @@ describe('initializeSentryOnEntryClient', () => {
       init({
           dsn: "https://sentry.io/123",
           tracesSampleRate: 1,
-          enableLogs: true,
 
           integrations: [browserTracingIntegration({
             useEffect,
@@ -59,7 +57,6 @@ describe('initializeSentryOnEntryClient', () => {
     const selectedFeatures = {
       performance: false,
       replay: true,
-      logs: false,
     };
 
     const result = updateEntryClientMod(
@@ -93,7 +90,6 @@ describe('initializeSentryOnEntryClient', () => {
     const selectedFeatures = {
       performance: true,
       replay: false,
-      logs: false,
     };
 
     const result = updateEntryClientMod(
@@ -115,74 +111,6 @@ describe('initializeSentryOnEntryClient', () => {
       init({
           dsn: "https://sentry.io/123",
           tracesSampleRate: 1,
-
-          integrations: [browserTracingIntegration({
-            useEffect,
-            useLocation,
-            useMatches
-          })]
-      })"
-    `);
-  });
-
-  it('should initialize Sentry on client entry with only logs enabled', () => {
-    // Empty entry.client.tsx file for testing
-    const originalEntryClientMod = parseModule('');
-
-    const dsn = 'https://sentry.io/123';
-    const selectedFeatures = {
-      performance: false,
-      replay: false,
-      logs: true,
-    };
-
-    const result = updateEntryClientMod(
-      originalEntryClientMod,
-      dsn,
-      selectedFeatures,
-    );
-
-    expect(result.generate().code).toMatchInlineSnapshot(`
-      "import {  init,} from "@sentry/remix";
-
-      init({
-          dsn: "https://sentry.io/123",
-          enableLogs: true
-      })"
-    `);
-  });
-
-  it('should initialize Sentry on client entry with performance and logs enabled', () => {
-    // Empty entry.client.tsx file for testing
-    const originalEntryClientMod = parseModule('');
-
-    const dsn = 'https://sentry.io/123';
-    const selectedFeatures = {
-      performance: true,
-      replay: false,
-      logs: true,
-    };
-
-    const result = updateEntryClientMod(
-      originalEntryClientMod,
-      dsn,
-      selectedFeatures,
-    );
-
-    expect(result.generate().code).toMatchInlineSnapshot(`
-      "import {  useEffect,} from "react";
-
-      import {
-        useLocation,
-        useMatches,
-      } from "@remix-run/react";
-
-      import {  init, browserTracingIntegration,} from "@sentry/remix";
-
-      init({
-          dsn: "https://sentry.io/123",
-          tracesSampleRate: 1,
-          enableLogs: true,
 
           integrations: [browserTracingIntegration({
             useEffect,

--- a/test/remix/server-instrumentation.test.ts
+++ b/test/remix/server-instrumentation.test.ts
@@ -6,7 +6,6 @@ describe('generateServerInstrumentationFile', () => {
     const result = generateServerInstrumentationFile('https://sentry.io/123', {
       performance: true,
       replay: true,
-      logs: true,
     });
 
     expect(result.instrumentationFileMod.generate().code)
@@ -15,8 +14,7 @@ describe('generateServerInstrumentationFile', () => {
 
       Sentry.init({
           dsn: "https://sentry.io/123",
-          tracesSampleRate: 1,
-          enableLogs: true
+          tracesSampleRate: 1
       })"
     `);
   });
@@ -25,7 +23,6 @@ describe('generateServerInstrumentationFile', () => {
     const result = generateServerInstrumentationFile('https://sentry.io/123', {
       performance: false,
       replay: true,
-      logs: false,
     });
 
     expect(result.instrumentationFileMod.generate().code)
@@ -34,43 +31,6 @@ describe('generateServerInstrumentationFile', () => {
 
       Sentry.init({
           dsn: "https://sentry.io/123"
-      })"
-    `);
-  });
-
-  it('should generate server instrumentation file with only logs enabled', () => {
-    const result = generateServerInstrumentationFile('https://sentry.io/123', {
-      performance: false,
-      replay: false,
-      logs: true,
-    });
-
-    expect(result.instrumentationFileMod.generate().code)
-      .toMatchInlineSnapshot(`
-      "import * as Sentry from "@sentry/remix";
-
-      Sentry.init({
-          dsn: "https://sentry.io/123",
-          enableLogs: true
-      })"
-    `);
-  });
-
-  it('should generate server instrumentation file with performance and logs enabled', () => {
-    const result = generateServerInstrumentationFile('https://sentry.io/123', {
-      performance: true,
-      replay: false,
-      logs: true,
-    });
-
-    expect(result.instrumentationFileMod.generate().code)
-      .toMatchInlineSnapshot(`
-      "import * as Sentry from "@sentry/remix";
-
-      Sentry.init({
-          dsn: "https://sentry.io/123",
-          tracesSampleRate: 1,
-          enableLogs: true
       })"
     `);
   });

--- a/test/sveltekit/templates.test.ts
+++ b/test/sveltekit/templates.test.ts
@@ -19,7 +19,6 @@ describe('getClientHooksTemplate', () => {
     const result = getClientHooksTemplate('https://sentry.io/123', {
       performance: true,
       replay: true,
-      logs: true,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -30,9 +29,6 @@ describe('getClientHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
-
-        // Enable logs to be sent to Sentry
-        enableLogs: true,
 
         // This sets the sample rate to be 10%. You may want this to be 100% while
         // in development and sample at a lower rate in production
@@ -63,7 +59,6 @@ describe('getClientHooksTemplate', () => {
     const result = getClientHooksTemplate('https://sentry.io/123', {
       performance: false,
       replay: true,
-      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -72,7 +67,6 @@ describe('getClientHooksTemplate', () => {
 
       Sentry.init({
         dsn: 'https://sentry.io/123',
-
 
         // This sets the sample rate to be 10%. You may want this to be 100% while
         // in development and sample at a lower rate in production
@@ -103,7 +97,6 @@ describe('getClientHooksTemplate', () => {
     const result = getClientHooksTemplate('https://sentry.io/123', {
       performance: true,
       replay: false,
-      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -114,40 +107,6 @@ describe('getClientHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
-
-
-
-
-        dataCollection: {
-          // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-          // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-          // userInfo: false,
-          // httpBodies: [],
-        },
-      });
-
-      // If you have a custom error handler, pass it to \`handleErrorWithSentry\`
-      export const handleError = handleErrorWithSentry();
-      "
-    `);
-  });
-
-  it('generates client hooks template with only logs enabled', () => {
-    const result = getClientHooksTemplate('https://sentry.io/123', {
-      performance: false,
-      replay: false,
-      logs: true,
-    });
-
-    expect(result).toMatchInlineSnapshot(`
-      "import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
-      import * as Sentry from '@sentry/sveltekit';
-
-      Sentry.init({
-        dsn: 'https://sentry.io/123',
-
-        // Enable logs to be sent to Sentry
-        enableLogs: true,
 
 
 
@@ -173,7 +132,6 @@ describe('getServerHooksTemplate', () => {
       {
         performance: true,
         replay: true,
-        logs: true,
       },
       true,
     );
@@ -187,10 +145,6 @@ describe('getServerHooksTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
-
-        // Enable logs to be sent to Sentry
-        enableLogs: true,
-
 
         dataCollection: {
           // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -218,7 +172,6 @@ describe('getServerHooksTemplate', () => {
       {
         performance: false,
         replay: true,
-        logs: false,
       },
       true,
     );
@@ -230,51 +183,6 @@ describe('getServerHooksTemplate', () => {
 
       Sentry.init({
         dsn: 'https://sentry.io/123',
-
-
-
-        dataCollection: {
-          // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-          // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-          // userInfo: false,
-          // httpBodies: [],
-        },
-
-        // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-        // spotlight: import.meta.env.DEV,
-      });
-
-      // If you have custom handlers, make sure to place them after \`sentryHandle()\` in the \`sequence\` function.
-      export const handle = sequence(sentryHandle());
-
-      // If you have a custom error handler, pass it to \`handleErrorWithSentry\`
-      export const handleError = handleErrorWithSentry();
-      "
-    `);
-  });
-
-  it('generates server hooks template with only logs enabled', () => {
-    const result = getServerHooksTemplate(
-      'https://sentry.io/123',
-      {
-        performance: false,
-        replay: false,
-        logs: true,
-      },
-      true,
-    );
-
-    expect(result).toMatchInlineSnapshot(`
-      "import { sequence } from "@sveltejs/kit/hooks";
-      import { handleErrorWithSentry, sentryHandle } from "@sentry/sveltekit";
-      import * as Sentry from '@sentry/sveltekit';
-
-      Sentry.init({
-        dsn: 'https://sentry.io/123',
-
-        // Enable logs to be sent to Sentry
-        enableLogs: true,
-
 
         dataCollection: {
           // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -302,7 +210,6 @@ describe('getServerHooksTemplate', () => {
       {
         performance: false,
         replay: false,
-        logs: true,
       },
       false,
     );
@@ -326,7 +233,6 @@ describe('getInstrumentationServerTemplate', () => {
   it('generates instrumentation.server template with all features enabled', () => {
     const result = getInstrumentationServerTemplate('https://sentry.io/123', {
       performance: true,
-      logs: true,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -336,31 +242,6 @@ describe('getInstrumentationServerTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
-
-        // Enable logs to be sent to Sentry
-        enableLogs: true,
-
-        // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-        // spotlight: import.meta.env.DEV,
-      });"
-    `);
-  });
-
-  it('generates instrumentation.server template with only logs enabled', () => {
-    const result = getInstrumentationServerTemplate('https://sentry.io/123', {
-      performance: false,
-      logs: true,
-    });
-
-    expect(result).toMatchInlineSnapshot(`
-      "import * as Sentry from '@sentry/sveltekit';
-
-      Sentry.init({
-        dsn: 'https://sentry.io/123',
-
-        // Enable logs to be sent to Sentry
-        enableLogs: true,
-
         // uncomment the line below to enable Spotlight (https://spotlightjs.com)
         // spotlight: import.meta.env.DEV,
       });"
@@ -370,7 +251,6 @@ describe('getInstrumentationServerTemplate', () => {
   it('generates instrumentation.server template with only tracesSampleRate enabled', () => {
     const result = getInstrumentationServerTemplate('https://sentry.io/123', {
       performance: true,
-      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -380,8 +260,6 @@ describe('getInstrumentationServerTemplate', () => {
         dsn: 'https://sentry.io/123',
 
         tracesSampleRate: 1.0,
-
-
         // uncomment the line below to enable Spotlight (https://spotlightjs.com)
         // spotlight: import.meta.env.DEV,
       });"
@@ -391,7 +269,6 @@ describe('getInstrumentationServerTemplate', () => {
   it('generates instrumentation.server template without any extra features enabled', () => {
     const result = getInstrumentationServerTemplate('https://sentry.io/123', {
       performance: false,
-      logs: false,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -399,8 +276,6 @@ describe('getInstrumentationServerTemplate', () => {
 
       Sentry.init({
         dsn: 'https://sentry.io/123',
-
-
         // uncomment the line below to enable Spotlight (https://spotlightjs.com)
         // spotlight: import.meta.env.DEV,
       });"
@@ -420,7 +295,6 @@ describe('insertClientInitCall', () => {
     insertClientInitCall('https://sentry.io/123', originalHooksMod, {
       performance: true,
       replay: true,
-      logs: true,
     });
 
     const result = originalHooksMod.generate().code;
@@ -437,7 +311,6 @@ describe('insertClientInitCall', () => {
           replaysSessionSampleRate: 0.1,
           replaysOnErrorSampleRate: 1,
           integrations: [Sentry.replayIntegration()],
-          enableLogs: true,
           dataCollection: {
             // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
             // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
@@ -461,7 +334,6 @@ describe('insertClientInitCall', () => {
     insertClientInitCall('https://sentry.io/456', originalHooksMod, {
       performance: false,
       replay: true,
-      logs: false,
     });
 
     const result = originalHooksMod.generate().code;
@@ -500,7 +372,6 @@ describe('insertClientInitCall', () => {
     insertClientInitCall('https://sentry.io/789', originalHooksMod, {
       performance: true,
       replay: false,
-      logs: true,
     });
 
     const result = originalHooksMod.generate().code;
@@ -514,44 +385,6 @@ describe('insertClientInitCall', () => {
       Sentry.init({
           dsn: "https://sentry.io/789",
           tracesSampleRate: 1,
-          enableLogs: true,
-          dataCollection: {
-            // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
-            // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
-            // userInfo: false,
-            // httpBodies: [],
-          },
-      })
-
-      export const handleError = handleErrorWithSentry();"
-    `);
-  });
-
-  it('should insert client init call with only logs enabled', () => {
-    const originalHooksMod = parseModule(`
-      import { handleErrorWithSentry } from "@sentry/sveltekit";
-      import * as Sentry from "@sentry/sveltekit";
-
-      export const handleError = handleErrorWithSentry();
-    `);
-
-    insertClientInitCall('https://sentry.io/xyz', originalHooksMod, {
-      performance: false,
-      replay: false,
-      logs: true,
-    });
-
-    const result = originalHooksMod.generate().code;
-
-    expect(result).toMatchInlineSnapshot(`
-      "import { handleErrorWithSentry } from "@sentry/sveltekit";
-      import * as Sentry from "@sentry/sveltekit";
-
-      // If you don't want to use Session Replay, remove the \`Replay\` integration,
-      // \`replaysSessionSampleRate\` and \`replaysOnErrorSampleRate\` options.
-      Sentry.init({
-          dsn: "https://sentry.io/xyz",
-          enableLogs: true,
           dataCollection: {
             // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
             // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#dataCollection
@@ -575,7 +408,6 @@ describe('insertClientInitCall', () => {
     insertClientInitCall('https://sentry.io/minimal', originalHooksMod, {
       performance: false,
       replay: false,
-      logs: false,
     });
 
     const result = originalHooksMod.generate().code;
@@ -613,7 +445,6 @@ describe('insertClientInitCall', () => {
     insertClientInitCall('https://sentry.io/order-test', originalHooksMod, {
       performance: true,
       replay: false,
-      logs: false,
     });
 
     const result = originalHooksMod.generate().code;


### PR DESCRIPTION
The Sentry JS SDKs now default `enableLogs` to `true`, so the wizard no longer needs to prompt for logs or write `enableLogs: true` explicitly.